### PR TITLE
Set proper displayName for HOC wrappers

### DIFF
--- a/samples/advanced-sample-react/src/enhancers/commonComponent.js
+++ b/samples/advanced-sample-react/src/enhancers/commonComponent.js
@@ -1,7 +1,15 @@
 import { withExperienceEditorChromes } from '@sitecore-jss/sitecore-jss-react';
 import extendStyles from './extendStyles';
 
-const commonComponent = (WrappedComponent) =>
-  withExperienceEditorChromes(extendStyles(WrappedComponent, WrappedComponent.styles));
+const commonComponent = WrappedComponent => {
+  const ExperienceEditorComponent = withExperienceEditorChromes(
+    extendStyles(WrappedComponent, WrappedComponent.styles)
+  );
+
+  ExperienceEditorComponent.displayName =
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
+
+  return ExperienceEditorComponent;
+};
 
 export default commonComponent;


### PR DESCRIPTION
The `commonComponent` component blinds the `wrappedComponent` displayName. This PR should fix this.

**Before**
<img width="616" alt="capture d ecran 2018-04-19 a 19 56 32" src="https://user-images.githubusercontent.com/5003380/39009512-26810122-440c-11e8-96b4-8b5c2d16ef65.png">

**After**
<img width="642" alt="capture d ecran 2018-04-19 a 19 56 56" src="https://user-images.githubusercontent.com/5003380/39009524-2c4c83f6-440c-11e8-9d26-d29e65bcdb24.png">

_**EDIT:** this is just a quick fix at the moment, since according to [React documentation best practices](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging) a HOC shouldn't have the same name as the wrapped component. Let me know if you'd like this PR to fix this as well._ 