### PR TITLE
Make the embedded example work again

### DIFF
--- a/samples/sitecore-embedded-jss-app/sitecore/definitions/components/components.sitecore.js
+++ b/samples/sitecore-embedded-jss-app/sitecore/definitions/components/components.sitecore.js
@@ -1,5 +1,10 @@
 import { addComponent, CommonFieldTypes, SitecoreIcon } from '@sitecore-jss/sitecore-jss-manifest';
-import WizardQuery from './Wizard.sitecore.graphql';
+import fs from 'fs';
+
+const WizardQuery = fs.readFileSync(
+  'sitecore/definitions/components/Wizard.sitecore.graphql',
+  'utf8'
+);
 
 export default (manifest) => {
   addComponent(manifest, {

--- a/samples/sitecore-embedded-jss-app/sitecore/definitions/config.js
+++ b/samples/sitecore-embedded-jss-app/sitecore/definitions/config.js
@@ -1,0 +1,19 @@
+// this file is imported by default prior to executing the jss manifest command
+// use this to enable transpilation or any other pre-manifest configurations that are needed.
+
+console.log('Enabling Babel transpilation for the manifest...');
+
+require('babel-core/register')({
+  presets: [
+    [
+      // eslint-disable-next-line global-require
+      require('babel-preset-env'),
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+  babelrc: false,
+});

--- a/samples/sitecore-embedded-jss-app/src/app/components/Step.js
+++ b/samples/sitecore-embedded-jss-app/src/app/components/Step.js
@@ -30,7 +30,7 @@ export default class Step extends React.Component {
     return routeData.placeholders ? (
       <div className="wizard-step">
         <Placeholder
-          name="main"
+          name="jss-main"
           rendering={routeData}
           onValueChange={onFormValueChange}
           formValues={formValues}

--- a/samples/sitecore-embedded-jss-app/src/app/index.js
+++ b/samples/sitecore-embedded-jss-app/src/app/index.js
@@ -4,7 +4,7 @@ import { Placeholder } from '@sitecore-jss/sitecore-jss-react';
 
 import '../../assets/css/app.css';
 
-const App = ({ route }) => <Placeholder name="main" rendering={route} />;
+const App = ({ route }) => <Placeholder name="jss-main" rendering={route} />;
 
 App.propTypes = {
   route: PropTypes.object,


### PR DESCRIPTION
This fixes the following problems:
- `config.js` missing from `/sitecore` (just copied from React project)
- `graphql` files cannot be `import`ed with the webpack config (copied fix from React project)
- placeholder `main` was renamed to `jss-main` but not in JS components

There is still an error after this lands: in the manifest, two `jss-main` placeholders are added. Until this is fixed, you need to remove one of them from `sitecore-import.json` and run with `--skipManifest`.