### PR TITLE
Enable Configuration of Headless SSR Proxy with Environment Variables

### DIFF
--- a/samples/node-headless-ssr-proxy/README.md
+++ b/samples/node-headless-ssr-proxy/README.md
@@ -10,28 +10,41 @@ You can use this as a starting point to unlock deployment of your JSS apps to an
 
 ## Pre-requisites
 
-1.  Your Sitecore instance needs to be configured with JSS.Server and the API Key provisioned. Read more [here](https://jss.sitecore.net/#/setup/jss-server-install?id=jss-server-install) how to set it up.
+1. Your Sitecore instance needs to be configured with JSS.Server and the API Key provisioned. Read more [here](https://jss.sitecore.net/#/setup/jss-server-install?id=jss-server-install) how to set it up.
 
-    > LayoutService API should be returning output if you make the following request to your Sitecore instance. `http://sitecore-host/sitecore/api/layout/render/jss?item=/&sc_apikey={YOUR_API_KEY}`
+   > LayoutService API should be returning output if you make the following request to your Sitecore instance. `http://sitecore-host/sitecore/api/layout/render/jss?item=/&sc_apikey={YOUR_API_KEY}`
 
-1.  Build your JS app bundle with `jss build`.
+1. Build your JS app bundle with `jss build`.
 
-    > You can use any of the JSS sample apps. Other apps must support server side rendering (JSS integrated mode) to operate with this project.
+   > You can use any of the JSS sample apps. Other apps must support server side rendering (JSS integrated mode) to operate with this project.
 
-1.  Deploy the build artifacts from your app (`/dist` within the app) to the `sitecoreDistPath` set in your app's `package.json` under the proxy root path. Most apps use `/dist/${jssAppName}`, for example for the GraphQL sample you'd build it, then copy its `/dist` to `$proxyRoot/dist/JssBasicAppGraphQL`.
+1. Deploy the build artifacts from your app (`/dist` within the app) to the `sitecoreDistPath` set in your app's `package.json` under the proxy root path. Most apps use `/dist/${jssAppName}`, for example for the GraphQL sample you'd build it, then copy its `/dist` to `$proxyRoot/dist/JssBasicAppGraphQL`.
 
 > Another way to deploy the artifacts to the proxy is to change the `instancePath` in your app's `scjssconfig.json` to the proxy root path, and then use `jss deploy files` within the app to complete the deployment to the proxy. `jss deploy:watch` also works when configured this way.
 
 ## Setup
 
-1.  Open `config.js` and specify connection settings to your Sitecore CD instance. `config.js` is heavily commented for your perusal.
-1.  Open `index.js` and alter the `const app = require('./dist/AdvancedApp/server.bundle');` to instead require your app's `server.bundle` file.
+Open `config.js` and specify connection settings to your Sitecore CD instance. `config.js` is heavily commented for your perusal.
+
+### Environment Variables
+
+The following environment variables can be set to configure the proxy instead of modifying `config.js`:
+
+| Parameter                              | Description
+-----------------------------------------|------------------------------------------------
+| `SITECORE_APPLICATION_NAME`            | Name of the application that will be deployed to the `/dist` folder (e.g., `my-first-jss-app`).
+| `SITECORE_API_HOST`                    | Sitecore instance host name. Should be HTTPS in production.
+| `SITECORE_LAYOUT_SERVICE_ROUTE`        | Optional. The path to layout service for the JSS application. Defaults to `/sitecore/api/layout/render/jss`.
+| `SITECORE_API_KEY`                     | The Sitecore SSC API key your app uses.
+| `SITECORE_PATH_REWRITE_EXCLUDE_ROUTES` | Optional. Pipe-separated list of absolute paths that should not be rendered through SSR. Defaults can be seen in [config.js](./config.js).
+| `SITECORE_ENABLE_DEBUG`                | Optional. Writes verbose request info to stdout for debugging. Defaults to `false`.
+| `SITECORE_ALLOW_SELF_SIGNED_CERTS`     | Optional. For demo ONLY, allows self-signed SSL certs. Defaults to `false`.
 
 ## Build & run
 
-1.  Run `npm install`
+1. Run `npm install`
 
-1.  Run `npm run start`
+1. Run `npm run start`
 
 You should be able to see the following message:
 `server listening on port 3000!` and see all the communication between this server and your Sitecore CD instance in the console.

--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -3,22 +3,26 @@
  */
 const config = {
   /**
+   * appName: Name of the application that is deployed to the /dist folder.
+   */
+  appName: process.env.SITECORE_APPLICATION_NAME || "JssAngularWeb",
+  /**
    * apiHost: your Sitecore instance hostname that is the backend for JSS
    * Should be https for production. Must be https to use SSC auth service,
    * if supporting Sitecore authentication.
    */
-  apiHost: 'http://jssreactweb',
+  apiHost: process.env.SITECORE_API_HOST || "http://jssreactweb",
   /**
    * layoutServiceRoot: The path to layout service for the JSS application.
    * Some apps, like advanced samples, use a custom LS configuration,
    * e.g. /sitecore/api/layout/render/jss-advanced-react
    */
-  layoutServiceRoute: '/sitecore/api/layout/render/jss',
+  layoutServiceRoute: process.env.SITECORE_LAYOUT_SERVICE_ROUTE || "/sitecore/api/layout/render/jss",
   /**
    * apiKey: The Sitecore SSC API key your app uses.
    * Required.
    */
-  apiKey: '{YOUR API KEY HERE}',
+  apiKey: process.env.SITECORE_API_KEY || "{YOUR API KEY HERE}",
   /**
    * pathRewriteExcludeRoutes: A list of absolute paths
    * that are NOT app routes and should not attempt to render a route
@@ -26,12 +30,18 @@ const config = {
    * allowing the proxy to also proxy GraphQL requests, REST requests, etc.
    * Local static assets, Sitecore API paths, Sitecore asset paths, etc should be listed here.
    */
-  pathRewriteExcludeRoutes: ['/dist', '/assets', '/sitecore/api', '/api', '/-/jssmedia'],
+  pathRewriteExcludeRoutes: [
+    "/dist",
+    "/assets",
+    "/sitecore/api",
+    "/api",
+    "/-/jssmedia"
+  ].concat((process.env.SITECORE_PATH_REWRITE_EXCLUDE_ROUTES || "").split("|").filter(s => s)),
   /**
    * Writes verbose request info to stdout for debugging.
    * Must be disabled in production for reasonable performance.
    */
-  debug: false,
+  debug: process.env.SITECORE_ENABLE_DEBUG || false,
   /**
    * Maximum allowed proxy reply size in bytes. Replies larger than this are not sent.
    * Avoids starving the proxy of memory if large requests are proxied.
@@ -42,8 +52,8 @@ const config = {
    * Options object for http-proxy-middleware. Consult its docs.
    */
   proxyOptions: {
-    secure: false, // for demo ONLY, allows self-signed SSL certs
-  },
+    secure: process.env.SITECORE_ALLOW_SELF_SIGNED_CERTS || false // for demo ONLY, allows self-signed SSL certs
+  }
 };
 
 module.exports = config;

--- a/samples/node-headless-ssr-proxy/index.js
+++ b/samples/node-headless-ssr-proxy/index.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 const escapeStringRegexp = require('escape-string-regexp');
 const scProxy = require('@sitecore-jss/sitecore-jss-proxy').default;
 const ipaddr = require('ipaddr.js');
-const app = require('./dist/JssAngularWeb/server.bundle');
 const config = require('./config');
+const app = require(`./dist/${config.appName}/server.bundle`);
 
 const server = express();
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
For deployment to containers it's nice to configure the proxy settings through environment variables. Updated `config.js` to optionally read from any of the following environment variables:
- `SITECORE_APPLICATION_NAME`
- `SITECORE_API_HOST`
- `SITECORE_LAYOUT_SERVICE_ROUTE`
- `SITECORE_API_KEY`
- `SITECORE_PATH_REWRITE_EXCLUDE_ROUTES`
- `SITECORE_ENABLE_DEBUG`
- `SITECORE_ALLOW_SELF_SIGNED_CERTS`

Also introduced a new config setting to `config.js`, `appName`, so `index.js` no longer needs to be modified to pull in the `server.bundle` for the app the proxy is hosting.