### PR TITLE
Pass query string params from configuration to LayoutService

### DIFF
--- a/packages/sitecore-jss-proxy/src/ProxyConfig.ts
+++ b/packages/sitecore-jss-proxy/src/ProxyConfig.ts
@@ -9,6 +9,8 @@ export interface ProxyConfig {
   layoutServiceRoute: string;
   /** SSC endpoint to use when sending Layout Service requests to proxy */
   apiKey: string;
+  /** Custom Query String parameters to send to Layout Service, e.g. sc_site=my-site&tracing=false */
+  qsParams: string;
   /**
    * Array of paths to proxy without any SSR transformation (i.e. do not treat as app routes).
    * Note: exclusions are case-insensitive.

--- a/packages/sitecore-jss-proxy/src/RouteUrlParser.ts
+++ b/packages/sitecore-jss-proxy/src/RouteUrlParser.ts
@@ -1,1 +1,1 @@
-export type RouteUrlParser = (url: string) => { sitecoreRoute?: string; lang?: string };
+export type RouteUrlParser = (url: string) => { sitecoreRoute?: string; lang?: string; qsParams?: string };

--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -309,6 +309,10 @@ export function rewriteRequestPath(
     finalReqPath = finalReqPath.slice(0, qsIndex);
   }
 
+  if(config.qsParams){
+    qs += `&${config.qsParams}`;
+  }
+
   let lang;
   if (parseRouteUrl) {
     if (config.debug) {
@@ -326,6 +330,10 @@ export function rewriteRequestPath(
         finalReqPath = `/${finalReqPath}`;
       }
       lang = routeParams.lang;
+
+      if(routeParams.qsParams){
+        qs += `&${routeParams.qsParams}`;
+      }
 
       if (config.debug) {
         console.log(`DEBUG: parseRouteUrl() result`, routeParams);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add possibility to pass custom query string params from an SSR configuation file.

## Description
Added `qsParams` to `ProxyConfig` and to a return object of `RouteUrlParser`

## Motivation
Fixes #87 

## How Has This Been Tested?
Set `qsParams` to `sc_site=mySite` and was able to switch a context of the site for LayoutService.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
