### PR TITLE
Clarify that createDefaultDisconnectedServer is an API

### DIFF
--- a/docs/data/routes/docs/techniques/working-disconnected/customizing-disconnected/en.md
+++ b/docs/data/routes/docs/techniques/working-disconnected/customizing-disconnected/en.md
@@ -86,3 +86,7 @@ const proxyOptions = {
   ...
 };
 ```
+
+## Advanced Customizations
+
+The disconnected server in sample apps defaults to using the `createDefaultDisconnectedServer()` [helper function](https://github.com/Sitecore/jss/blob/master/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts). This function provides basic customization APIs and encapsulates the registrations of several middlewares that make the disconnected server work. You can also unpack the function and register the middleware yourself if you need to do advanced customizations that are not supported by the default `DisconnectedServerOptions`.

--- a/samples/angular/scripts/disconnected-mode-proxy.ts
+++ b/samples/angular/scripts/disconnected-mode-proxy.ts
@@ -38,4 +38,9 @@ const proxyOptions = {
   },
 };
 
+// Need to customize something that the proxy options don't support?
+// createDefaultDisconnectedServer() is a boilerplate that you can copy from
+// and customize the middleware registrations within as you see fit.
+// tslint:disable-next-line:max-line-length
+// See https://github.com/Sitecore/jss/blob/master/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
 createDefaultDisconnectedServer(proxyOptions);

--- a/samples/react/scripts/disconnected-mode-proxy.js
+++ b/samples/react/scripts/disconnected-mode-proxy.js
@@ -38,4 +38,8 @@ const proxyOptions = {
   },
 };
 
+// Need to customize something that the proxy options don't support?
+// createDefaultDisconnectedServer() is a boilerplate that you can copy from
+// and customize the middleware registrations within as you see fit.
+// See https://github.com/Sitecore/jss/blob/master/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
 createDefaultDisconnectedServer(proxyOptions);

--- a/samples/vue/scripts/disconnected-mode-proxy.js
+++ b/samples/vue/scripts/disconnected-mode-proxy.js
@@ -42,4 +42,9 @@ const proxyOptions = {
   },
 };
 
+
+// Need to customize something that the proxy options don't support?
+// createDefaultDisconnectedServer() is a boilerplate that you can copy from
+// and customize the middleware registrations within as you see fit.
+// See https://github.com/Sitecore/jss/blob/master/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
 createDefaultDisconnectedServer(proxyOptions);


### PR DESCRIPTION
...that you can steal code from and customize.

Fixes #79 by documenting that you can tweak the conventions by expanding the middleware yourself.