### PR TITLE
Make disconnected appRoot mean appRoot not scriptsRoot

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
@@ -10,8 +10,7 @@ export interface DisconnectedServerOptions {
   appName: string;
 
   /**
-   * Root physical path to the app's /scripts folder
-   * (i.e. __dirname from the calling script to start the middleware)
+   * Root physical path to the app (i.e. where your package.json is)
    */
   appRoot: string;
 

--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
@@ -10,7 +10,8 @@ export interface DisconnectedServerOptions {
   appName: string;
 
   /**
-   * Root physical path to the app
+   * Root physical path to the app's /scripts folder
+   * (i.e. __dirname from the calling script to start the middleware)
    */
   appRoot: string;
 
@@ -94,6 +95,21 @@ export function createDefaultDisconnectedServer(options: DisconnectedServerOptio
     app = Express();
   }
 
+  // backwards compatibility with fix for #80
+  // for GA the appRoot was expected to be $app/scripts
+  // which didn't make sense. This allows both sane app roots
+  // and GA-style app roots to keep working.
+  if(options.appRoot.endsWith('scripts')) {
+    options.appRoot = join(options.appRoot, '..');
+  }
+
+  // further backwards compatibility for #80
+  // allows apps with GA watch path of '../data' (relative to /scripts)
+  // to keep working even with appRoot now relative to the actual app root
+  // We do this by stripping '../' from path leads, making the path './data' instead - theoretically, the chance of
+  // wanting to actually escape from the app root entirely otherwise is awfully low.
+  options.watchPaths = options.watchPaths.map(path => path.startsWith('../') ? path.substring(1) : path);
+
   // the manifest manager maintains the state of the disconnected manifest data during the course of the dev run
   // it provides file watching services, and language switching capabilities
   const manifestManager = new ManifestManager({
@@ -132,8 +148,8 @@ export function createDefaultDisconnectedServer(options: DisconnectedServerOptio
       });
 
       // attach our disconnected service mocking middleware to webpack dev server
-      app.use('/assets', Express.static(join(options.appRoot, '../assets')));
-      app.use('/data/media', Express.static(join(options.appRoot, '../data/media')));
+      app.use('/assets', Express.static(join(options.appRoot, 'assets')));
+      app.use('/data/media', Express.static(join(options.appRoot, 'data/media')));
       app.use('/sitecore/api/layout/render', layoutService.middleware);
       app.use('/sitecore/api/jss/dictionary/:appName/:language', dictionaryService.middleware);
 

--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
@@ -3,8 +3,8 @@ import Express from 'express';
 import { join } from 'path';
 import { ManifestManager } from '../manifest-manager';
 import { createDisconnectedDictionaryService } from './dictionary-service';
-import { createDisconnectedLayoutService } from './layout-service';
 import { CustomizeContextFunction, CustomizeRenderFunction, CustomizeRouteFunction } from './DisconnectedLayoutServiceOptions';
+import { createDisconnectedLayoutService } from './layout-service';
 
 export interface DisconnectedServerOptions {
   appName: string;
@@ -15,7 +15,8 @@ export interface DisconnectedServerOptions {
   appRoot: string;
 
   /**
-   * File path(s) to watch for changes, and reload the manifest when they occur
+   * File path(s) to watch for changes, and reload the manifest when they occur.
+   * Paths can be relative (to the app root) or absolute.
    */
   watchPaths: string[];
 

--- a/samples/angular/scripts/disconnected-mode-proxy.ts
+++ b/samples/angular/scripts/disconnected-mode-proxy.ts
@@ -8,6 +8,7 @@
 */
 
 import * as fs from 'fs';
+import { join } from 'path';
 import { createDefaultDisconnectedServer } from '@sitecore-jss/sitecore-jss-dev-tools';
 const packageJson = require('../package.json');
 
@@ -16,9 +17,9 @@ const config = (packageJson as any).config;
 const touchToReloadFilePath = 'src/environments/environment.ts';
 
 const proxyOptions = {
-  appRoot: __dirname,
+  appRoot: join(__dirname, '..'),
   appName: config.appName,
-  watchPaths: ['../data'],
+  watchPaths: ['./data'],
   language: config.language,
   port: 3043,
   onManifestUpdated: (manifest) => {

--- a/samples/react/scripts/disconnected-mode-proxy.js
+++ b/samples/react/scripts/disconnected-mode-proxy.js
@@ -10,15 +10,16 @@
 /* eslint-disable no-console */
 
 const fs = require('fs');
+const path = require('path');
 const { createDefaultDisconnectedServer } = require('@sitecore-jss/sitecore-jss-dev-tools');
 const config = require('../package.json').config;
 
 const touchToReloadFilePath = 'src/temp/config.js';
 
 const proxyOptions = {
-  appRoot: __dirname,
+  appRoot: path.join(__dirname, '..'),
   appName: config.appName,
-  watchPaths: ['../data'],
+  watchPaths: ['./data'],
   language: config.language,
   port: process.env.PROXY_PORT || 3042,
   onManifestUpdated: (manifest) => {

--- a/samples/vue/scripts/disconnected-mode-proxy.js
+++ b/samples/vue/scripts/disconnected-mode-proxy.js
@@ -13,15 +13,16 @@ process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true;
 process.env.VUE_CLI_BABEL_TARGET_NODE = true;
 
 const fs = require('fs');
+const path = require('path');
 const { createDefaultDisconnectedServer } = require('@sitecore-jss/sitecore-jss-dev-tools');
 const config = require('../package.json').config;
 
 const touchToReloadFilePath = 'src/temp/config.js';
 
 const proxyOptions = {
-  appRoot: __dirname,
+  appRoot: path.join(__dirname, '..'),
   appName: config.appName,
-  watchPaths: ['../data'],
+  watchPaths: ['./data'],
   language: config.language,
   port: process.env.PROXY_PORT || 3042,
   compilers: ['@babel/register'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Per #80 the appRoot of the proxy actually meant "/config", which makes no sense.

This commit causes the behaviour of appRoot to expect the actual app root path, in such a way that existing JSS apps will continue to work unchanged as well (each sample app was tested with old and tweaked configs in disconnected-mode-proxy)

## Motivation
Removes principle of least surprise violation

## How Has This Been Tested?
Ran each sample app with old and new proxy config to verify backwards compatibility.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
