### PR TITLE
Adds an 'Edit this on GitHub' link to documentation pages

### DIFF
--- a/docs/sitecore/definitions/routes.sitecore.js
+++ b/docs/sitecore/definitions/routes.sitecore.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-throw-literal */
 import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
@@ -29,6 +30,10 @@ export default function(manifest) {
         name: 'title',
         displayName: 'Page Title',
         type: CommonFieldTypes.SingleLineText,
+      },
+      {
+        name: 'editLink',
+        type: CommonFieldTypes.GeneralLink,
       },
     ],
   });
@@ -75,7 +80,7 @@ const parseRouteData = (sourceRouteData, file) => {
     throw `Specified routeTemplate doesn't exist: '${routeTemplate}'`;
   }
   const template = fs.readFileSync(routeTemplate, 'utf8');
-  let routeData = yaml.safeLoad(template);
+  const routeData = yaml.safeLoad(template);
 
   const tokenReplacements = new Map();
   tokenReplacements.set('$name$', name);
@@ -85,6 +90,13 @@ const parseRouteData = (sourceRouteData, file) => {
 
   if (parsedMatter.data.title) {
     routeData.fields.title.value = parsedMatter.data.title;
+
+    const rootPath = path.resolve(path.join(__dirname, '..', '..'));
+    const relativePath = path.relative(rootPath, file).replace(/\\/g, '/');
+    routeData.fields.editLink = {
+      text: 'Edit this on GitHub',
+      href: `https://github.com/Sitecore/jss/edit/dev/docs/${relativePath}`,
+    };
   }
 
   return routeData;

--- a/docs/src/app/components/Article.js
+++ b/docs/src/app/components/Article.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import { Link, withSitecoreContext } from '@sitecore-jss/sitecore-jss-react';
 import RouteLinkedRichText from './RouteLinkedRichText';
 
 class Article extends React.Component {
@@ -14,7 +15,7 @@ class Article extends React.Component {
 
   // enabling syntax highligher
   highlightBlocks() {
-    if (typeof hljs !== undefined) {
+    if (typeof hljs !== 'undefined') {
       // eslint-disable-next-line react/no-find-dom-node
       const container = ReactDOM.findDOMNode(this);
       container.querySelectorAll('pre code').forEach((el) => hljs.highlightBlock(el));
@@ -22,12 +23,17 @@ class Article extends React.Component {
   }
 
   render() {
+    const { fields, sitecoreContext } = this.props;
+
     return (
-      <RouteLinkedRichText
-        tag="div"
-        field={this.props.fields.text}
-        className="article markdown-section"
-      />
+      <React.Fragment>
+        <RouteLinkedRichText tag="div" field={fields.text} className="article markdown-section" />
+        <hr />
+        <div>
+          Found a problem? Have something to add?&nbsp;
+          <Link field={sitecoreContext.route.fields.editLink} />
+        </div>
+      </React.Fragment>
     );
   }
 }
@@ -41,4 +47,4 @@ Article.propTypes = {
   }),
 };
 
-export default Article;
+export default withSitecoreContext()(Article);


### PR DESCRIPTION
This makes it super easy to PR documentation fixes and clarifications! 🎉 

![image](https://user-images.githubusercontent.com/103677/49969947-b8b71080-fede-11e8-9cda-6b37fb67f94d.png)

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's too much work to fix a simple typo in the docs. This makes it a single click and you can open the PR right within GitHub.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
