### PR TITLE
added a note to publish the API key item

### DIFF
--- a/docs/data/routes/docs/getting-started/app-deployment/en.md
+++ b/docs/data/routes/docs/getting-started/app-deployment/en.md
@@ -64,7 +64,7 @@ The services used by JSS (including the [Layout Service](/docs/fundamentals/serv
 
         > **Do not ever use `sitecore\admin` or any other privileged user as the impersonation user.** A serious security breach will result. Use only `extranet\anonymous` or a app-specific dedicated user for impersonation.
 
-1. Save the API key item and make note of its **Item ID** (see screenshot below, highlighted). You'll need this ID to connect the JSS app.
+1. Save the API key item, publish it (Sitecore 9.1+) and make note of its **Item ID** (see screenshot below, highlighted). You'll need this ID to connect the JSS app.
 
   <img src="/assets/img/ssc-api-key.png" alt="API Key" class="img-fluid img-thumbnail" />
 


### PR DESCRIPTION
Minor update to the documentation, adding a comment about needing to publish the API key item in Sitecore 9.1 and above. 

## Description
see above

## Motivation
Following the "Getting started" guide, I noticed that the API key item needed to be published in Sitecore 9.1 (as it moved to the master database). 

## How Has This Been Tested?
n/a

## Types of changes
Documentation only 

## Checklist:
- [X] I have read the Contributing guide.
- [n/a] My code follows the code style of this project.
- [n/a] My change requires a change to the documentation.