### PR TITLE
Add extra parameters to customizeRendering method

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/DisconnectedLayoutServiceOptions.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/DisconnectedLayoutServiceOptions.ts
@@ -2,7 +2,10 @@ import { ManifestInstance } from '@sitecore-jss/sitecore-jss-manifest';
 
 export type CustomizeRenderFunction = (
   transformedRendering: any,
-  rawRendering: any
+  rawRendering: any,
+  currentManifest: ManifestInstance,
+  request?: any,
+  response?: any
 ) => any;
 
 export type CustomizeContextFunction = (

--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/layout-service.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/layout-service.ts
@@ -219,7 +219,7 @@ export function remapFieldsArrayToFieldsObject(input: any) {
   }, {});
 }
 
-function convertManifestLayoutDataToLayoutServiceFormat(manifestLayout: any, placeholders: string[], customizeHook?: CustomizeRenderFunction) {
+function convertManifestLayoutDataToLayoutServiceFormat(manifestLayout: any, placeholders: string[], currentManifest: ManifestInstance, request: any, response: any, customizeHook?: CustomizeRenderFunction) {
   const result: any = {};
 
   // we sort by placeholder key length to ensure we create the rendering tree in hierarchy order
@@ -248,7 +248,7 @@ function convertManifestLayoutDataToLayoutServiceFormat(manifestLayout: any, pla
         transformedRendering.fields = remapFieldsArrayToFieldsObject(rendering.dataSource.fields);
       }
 
-      const customizeResult = (customizeHook && customizeHook(transformedRendering, rendering)) || transformedRendering;
+      const customizeResult = (customizeHook && customizeHook(transformedRendering, rendering, currentManifest, request, response)) || transformedRendering;
 
       // adds the rendering object to its placeholder in the LS output
       placeholder.push(customizeResult);
@@ -264,7 +264,7 @@ function convertManifestLayoutDataToLayoutServiceFormat(manifestLayout: any, pla
   return result;
 }
 
-function defaultCustomizeRoute(route: any, language: string, customizeRendering?: CustomizeRenderFunction) {
+function defaultCustomizeRoute(route: any, language: string, currentManifest: ManifestInstance, request: any, response: any, customizeRendering?: CustomizeRenderFunction) {
   const transformedRoute = Object.assign(
     {
       databaseName: 'available-in-connected-mode',
@@ -282,6 +282,9 @@ function defaultCustomizeRoute(route: any, language: string, customizeRendering?
   transformedRoute.placeholders = convertManifestLayoutDataToLayoutServiceFormat(
     transformedRoute.layout.renderings,
     transformedRoute.layout.placeholders,
+    currentManifest,
+    request,
+    response,
     customizeRendering
   );
 
@@ -350,7 +353,7 @@ export function createDisconnectedLayoutService({
       let route;
 
       if (rawRoute) {
-        route = defaultCustomizeRoute(rawRoute, language, customizeRendering);
+        route = defaultCustomizeRoute(rawRoute, language, currentManifest, customizeRendering, request, response);
         if (customizeRoute && typeof customizeRoute === 'function') {
           route = customizeRoute(route, rawRoute, currentManifest, request, response);
         }


### PR DESCRIPTION
Add `currentManifest`, `request`, and `response` parameters to `customizeRendering` method.

## Motivation
The Layout Service `customizeRendering` method does not expose the `currentManifest`, `request`, or `response`, so if you want to customize your renderings based on data from either of these sources, you have to use `customizeRoute` and a mountain of extra code to pull the renderings from the route.

For example, with this new method you can now customize renderings based on manifest data:

### ContentBlock.sitecore.js
```javascript
export default function(manifest) {
  manifest.addComponent({
    name: 'ContentBlock',
    displayName: 'Content Block',
    icon: SitecoreIcon.DocumentTag,
    fields: [
      { name: 'heading', type: CommonFieldTypes.SingleLineText },
      { name: 'content', type: CommonFieldTypes.RichText },
    ],
    addCoolStuff: true
  });
}
```

### disconnected-mode-proxy.js
```javascript
// ... omitted for brevity ...
const proxyOptions = {
  // ... omitted for brevity ...
  customizeRendering: (transformedRendering, rawRendering, currentManifest) => {
    const manifestRendering = currentManifest.renderings.find(
      (r) => r.name === transformedRendering.componentName
    );
    if (!manifestRendering || !manifestRendering.addCoolStuff) return undefined;

    return {
      ...transformedRendering,
      coolStuff: [
        'React',
        'Vue',
      ],
    };
  },
};
// ... omitted for brevity ...
```

## How Has This Been Tested?
Updated `disconnected-mode-proxy.js` in the React sample app to reference `'../../../packages/sitecore-jss-dev-tools'` and verified that the code above works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
