### PR TITLE
Add beforeMiddlewareRegistered hook to DisconnectedServerOptions

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
@@ -47,6 +47,12 @@ export interface DisconnectedServerOptions {
   sourceFiles?: string[];
 
   /**
+   * Hook function that is called before the disconnected server middleware is registered with the server.
+   * Useful to add your own middleware before the disconnected middleware.
+   */
+  beforeMiddlewareRegistered?: (server: any) => void;
+
+  /**
    * Hook function that is called after the disconnected server middleware is registered with the server,
    * but before the server starts listening. Useful to add your own middleware after the disconnected middleware.
    */
@@ -146,6 +152,10 @@ export function createDefaultDisconnectedServer(options: DisconnectedServerOptio
           options.onManifestUpdated(newManifest);
         }
       });
+
+      if (options.beforeMiddlewareRegistered) {
+        options.beforeMiddlewareRegistered(app);
+      }
 
       // attach our disconnected service mocking middleware to webpack dev server
       app.use('/assets', Express.static(join(options.appRoot, 'assets')));


### PR DESCRIPTION
Add `beforeMiddlewareRegistered` hook to `DisconnectedServerOptions` that allows for the registration of middleware that should execute before the disconnected server middleware.

## Motivation
Some middleware needs to be registered before the disconnected server middleware, like `body-parser` and `cookie-parser`. For example, the `customizeRoute` method on `DisconnectedServerOptions` gives you access to the request and response objects, but to access the cookies on the request object, you need to register `cookie-parser` with Express so it executes before the `customizeRoute` method. Currently if you want to do this you have to add the Express package to your project, create an instance of Express, register your middleware, and pass the Express instance to `DisconnectedServerOptions`:

```javascript
// ... omitted for brevity ...
const app = Express();
app.use(cookieParser());

const proxyOptions = {
  // ... omitted for brevity ...
  server = app,
  customizeRoute: (route, rawRoute, currentManifest, request) => {
    // do something with request.cookies
  }
};
// ... omitted for brevity ...
```

It'd be nice to be able to register middleware that executes before the disconnected server middleware without having to include the `express` package in your project and new up your own instance:

```javascript
// ... omitted for brevity ...
const proxyOptions = {
  // ... omitted for brevity ...
  beforeMiddlewareRegistered: (app) => {
    app.use(cookieParser());
  },
  customizeRoute: (route, rawRoute, currentManifest, request) => {
    // do something with request.cookies
  }
};
// ... omitted for brevity ...
```

## How Has This Been Tested?
Updated `disconnected-mode-proxy.js` in the React sample app to reference `'../../../packages/sitecore-jss-dev-tools'` and verified that the code above works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
