### PR TITLE
Sitecore-first component deployment fixes

### DIFF
--- a/packages/sitecore-jss-cli/src/micro-manifest.ts
+++ b/packages/sitecore-jss-cli/src/micro-manifest.ts
@@ -1,4 +1,4 @@
-import { packageDeploy, verifySetup, resolveScJssConfig } from '@sitecore-jss/sitecore-jss-dev-tools';
+import { packageDeploy, resolveScJssConfig, verifySetup } from '@sitecore-jss/sitecore-jss-dev-tools';
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';

--- a/packages/sitecore-jss-cli/src/scripts/deploy.component.ts
+++ b/packages/sitecore-jss-cli/src/scripts/deploy.component.ts
@@ -5,7 +5,7 @@ import { args as templateArgs } from './deploy.template';
 
 export default function builder(yargs: Argv) {
   return yargs.command(
-    'component <Name>',
+    'component <name>',
     // tslint:disable-next-line:max-line-length
     'Deploys a new component (or updates an existing component) to the Sitecore server when using Sitecore-first development. `jss deploy component --help` for options.',
     args,
@@ -48,7 +48,7 @@ async function handler(argv: any) {
     name: argv.name,
     displayName: argv.displayName,
     icon: argv.icon,
-    fields,
+    fields: fields.length === 0 ? null : fields,
     placeholders: argv.exposesPlaceholders,
     allowedPlaceholders: argv.allowedPlaceholders,
   };

--- a/packages/sitecore-jss-manifest/src/generator/manifest.ts
+++ b/packages/sitecore-jss-manifest/src/generator/manifest.ts
@@ -54,8 +54,11 @@ export const createManifestInstance = ({
 
   const addTemplateInternal = (...templates: InternalTemplateDefinition[]) => {
     templates.forEach((template) => {
-      if (validateTemplate(template).valid) {
+      const validationResult = validateTemplate(template);
+      if (validationResult.valid) {
         manifestSourceData.templates.push(template);
+      } else {
+        throw validationResult.error;
       }
     });
   };

--- a/packages/sitecore-jss-manifest/src/generator/pipelines/generateManifest/generateTemplates.ts
+++ b/packages/sitecore-jss-manifest/src/generator/pipelines/generateManifest/generateTemplates.ts
@@ -31,10 +31,12 @@ export default (args: any) => {
     delete template.graphQLQuery;
     delete template.customExperienceButtons;
 
-    if (validateTemplate(template).valid) {
+    const validationResult = validateTemplate(template);
+    if (validationResult.valid) {
       return [...result, template];
     }
-    return result;
+
+    throw validationResult.error;
   }, []);
 
   const finalTemplates = [...args.templates, ...templates];

--- a/packages/sitecore-jss-manifest/src/generator/validators.ts
+++ b/packages/sitecore-jss-manifest/src/generator/validators.ts
@@ -17,7 +17,10 @@ const placeholderSchema = joi.object().keys({
   displayName: joi.string(),
 });
 
-const validate = (object: any, schema: any, allowUnknown: any) => {
+const validate = (object: any, schema: any, allowUnknown: any): {
+  valid: boolean;
+  error?: joi.ValidationError;
+} => {
   const { error } = joi.validate(object, schema, { allowUnknown });
   if (!error) {
     return { valid: true };


### PR DESCRIPTION
- Fixes `jss deploy component` having invalid casing on `<Name>` param, which broke it because the code expected `<name>` instead (maybe a new thing in a yargs update, used to work fine)
- Fixes `jss deploy component` creating a datasource template even if `--fields` was not passed. It should be usable to create datasource-less components as well. This is a breaking change but breaks it in the direction of sanity.
- `jss manifest` will now stop if a template fails validation, instead of ignoring it and continuing without that template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)