### PR TITLE
Fix AOT compile for lazy loading modules

### DIFF
--- a/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
+++ b/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
@@ -68,18 +68,34 @@ You can also load multiple components from one module. This will improve code sp
 For lazy-loading with multiple components you need to register two or more components with `JssModule.forChild()` method into lazy-loading module. You need to provide component name and component type.
 
 ```js
-import { NgModule } from '@angular/core';
-import { JssModule } from '@sitecore-jss/sitecore-jss-angular';
+import { NgModule, ANALYZE_FOR_ENTRY_COMPONENTS } from '@angular/core';
+import { JssModule, DYNAMIC_COMPONENT } from '@sitecore-jss/sitecore-jss-angular';
 import { FirstComponent } from './first.component';
 import { SecondComponent } from './second.component';
 
 @NgModule({
   imports: [
     // secret sauce
-    JssModule.forChild([
-      { name: 'FirstComponent', type: FirstComponent },
-      { name: 'SecondComponent', type: SecondComponent }
-    ])
+    {
+      ngModule: JssModule,
+      providers: [
+        {
+          provide: DYNAMIC_COMPONENT,
+          useValue: {
+            'FirstComponent': FirstComponent,
+            'SecondComponent': SecondComponent
+          }
+        },
+        {
+          provide: ANALYZE_FOR_ENTRY_COMPONENTS,
+          useValue: [
+            { name: 'FirstComponent', type: FirstComponent },
+            { name: 'SecondComponent', type: SecondComponent }
+          ],
+          multi: true
+        }
+      ]
+    }
   ],
   declarations: [
     FirstComponent,

--- a/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
+++ b/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
@@ -69,6 +69,7 @@ For lazy-loading with multiple components you need to register two or more compo
 
 ```js
 import { NgModule, ANALYZE_FOR_ENTRY_COMPONENTS } from '@angular/core';
+import { ROUTES } from '@angular/router';
 import { JssModule, DYNAMIC_COMPONENT } from '@sitecore-jss/sitecore-jss-angular';
 import { FirstComponent } from './first.component';
 import { SecondComponent } from './second.component';
@@ -93,13 +94,17 @@ import { SecondComponent } from './second.component';
             { name: 'SecondComponent', type: SecondComponent }
           ],
           multi: true
+        }, 
+        {
+          provide: ROUTES,
+          useValue: [],
+          multi: true
         }
       ]
     }
   ],
   declarations: [
-    FirstComponent,
-    SecondComponent,
+    MyComponent,
   ],
 })
 export class MyModule { }

--- a/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
+++ b/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
@@ -104,7 +104,8 @@ import { SecondComponent } from './second.component';
     }
   ],
   declarations: [
-    MyComponent,
+    FirstComponent,
+    SecondComponent
   ],
 })
 export class MyModule { }

--- a/packages/sitecore-jss-angular/src/lib.module.ts
+++ b/packages/sitecore-jss-angular/src/lib.module.ts
@@ -82,28 +82,14 @@ export class JssModule {
   }
 
   /** Instantiates a module for a lazy-loaded JSS component */
-  static forChild(components: Type<any> | ComponentNameAndType[]): ModuleWithProviders {
-    const providers: Provider[] = [
-      { provide: ROUTES, useValue: [], multi: true },
-    ];
-
-    if (Array.isArray(components)) {
-      const dynamicComponent: {[s: string]: any} = {};
-
-      components.forEach((component) => {
-        dynamicComponent[component.name] = component.type;
-        providers.push({ provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: component.type, multi: true });
-      });
-
-      providers.push({ provide: DYNAMIC_COMPONENT, useValue: dynamicComponent });
-    } else {
-      providers.push({ provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: components, multi: true });
-      providers.push({ provide: DYNAMIC_COMPONENT, useValue: components });
-    }
-
+  static forChild(component: Type<any>): ModuleWithProviders {
     return {
       ngModule: JssModule,
-      providers,
+      providers: [
+        { provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: component, multi: true },
+        { provide: ROUTES, useValue: [], multi: true },
+        { provide: DYNAMIC_COMPONENT, useValue: component },
+      ],
     };
   }
 

--- a/packages/sitecore-jss-angular/src/public_api.ts
+++ b/packages/sitecore-jss-angular/src/public_api.ts
@@ -2,7 +2,7 @@ export { FileDirective } from './components/file.directive';
 export { ImageDirective } from './components/image.directive';
 export { LinkDirective } from './components/link.directive';
 export { PlaceholderComponent } from './components/placeholder.component';
-export { ComponentNameAndType } from './components/placeholder.token';
+export { ComponentNameAndType, DYNAMIC_COMPONENT } from './components/placeholder.token';
 export { isRawRendering } from './components/rendering';
 export { FileField, ImageField, LinkField, RenderingField, RichTextField, TextField } from './components/rendering-field';
 export { RichTextDirective } from './components/rich-text.directive';


### PR DESCRIPTION
Fix the issue with the Angular AOT compiler connect with static JssModule method forChild().

## Description
Revert changes in forChild() static method and make DYNAMIC_COMPONENT provider exportable. Now we can make the configuration directly in lazy loading module without using static method.

## Motivation
Fix issue which prevent using the lazy loading for JSS in production mode.

## How Has This Been Tested?
You can test with production build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
