### PR TITLE
Remove Hard Coded App Name from Headless SSR Proxy

### DIFF
--- a/samples/angular/server.bundle.ts
+++ b/samples/angular/server.bundle.ts
@@ -90,4 +90,5 @@ module.exports = {
   renderView,
   parseRouteUrl,
   apiKey: environment.sitecoreApiKey,
+  appName: environment.jssAppName
 };

--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -137,9 +137,9 @@ const config = {
     if (cached) return Promise.resolve(cached);
 
     return fetch(
-      `${config.apiHost}/sitecore/api/jss/dictionary/JssReactWeb/${language}?sc_apikey=${
-        config.apiKey
-      }`
+      `${config.apiHost}/sitecore/api/jss/dictionary/${
+        serverBundle.appName
+      }/${language}?sc_apikey=${config.apiKey}`
     )
       .then((result) => result.json())
       .then((json) => {

--- a/samples/react/server/server.js
+++ b/samples/react/server/server.js
@@ -30,6 +30,9 @@ function assertReplace(string, value, replacement) {
 /** Export the API key. This will be used by default in Headless mode, removing the need to manually configure the API key on the proxy. */
 export const apiKey = config.sitecoreApiKey;
 
+/** Export the app name. This will be used by default in Headless mode, removing the need to manually configure the app name on the proxy. */
+export const appName = config.jssAppName;
+
 /**
  * Main entry point to the application when run via Server-Side Rendering,
  * either in Integrated Mode, or with a Node proxy host like the node-headless-ssr-proxy sample.

--- a/samples/vue/server/server.js
+++ b/samples/vue/server/server.js
@@ -31,6 +31,9 @@ function assertReplace(string, value, replacement) {
 /** Export the API key. This will be used by default in Headless mode, removing the need to manually configure the API key on the proxy. */
 export const apiKey = config.sitecoreApiKey;
 
+/** Export the app name. This will be used by default in Headless mode, removing the need to manually configure the app name on the proxy. */
+export const appName = config.jssAppName;
+
 /**
  * Main entry point to the application when run via Server-Side Rendering,
  * either in Integrated Mode, or with a Node proxy host like the node-headless-ssr-proxy sample.


### PR DESCRIPTION
Export app name from Angular, React, and Vue sample app server bundles for the headless SSR proxy configuration.

## Motivation
Fixes #127. This makes the headless proxy more reusable, configurable, and easier to use by removing a configuration step.

## How Has This Been Tested?
I modified the proxy and tested it in Azure against my JSS React app.

I only tested against React, I did not test against a Vue or Angular app.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
