### PR TITLE
Prevent reloading Angular route when only hash changes

### DIFF
--- a/samples/angular/src/app/routing/jss-route-resolver.service.ts
+++ b/samples/angular/src/app/routing/jss-route-resolver.service.ts
@@ -14,7 +14,7 @@ export class JssRouteResolver implements Resolve<JssState> {
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<JssState> {
     // in experience editor, we need to reload to avoid confusing the editor ribbon
     if (isExperienceEditorActive() && window) {
-      const currentLocation = window.location.pathname + window.location.search;
+      const currentLocation = window.location.pathname + window.location.search + window.location.hash;
       if (currentLocation !== state.url) {
         window.location.assign(state.url);
         return null;


### PR DESCRIPTION
Fixes #132 - previously the change of the hash would change the route URL but the comparison to refresh the page was not including the current location hash in its comparison. `state.url` would have the hash added, but `currentLocation` would not. 

This meant it was treated as a page refresh situation - but it would never match the current location without the hash so it went into a loop instead attempting to get the location to match.

## How Has This Been Tested?

Issue affected angular links with _anchors_ in _EE only_. It has been tested in this state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

cc @AlexKasaku