### PR TITLE
Add new link directive which work with angular route

### DIFF
--- a/packages/sitecore-jss-angular/package.json
+++ b/packages/sitecore-jss-angular/package.json
@@ -13,6 +13,10 @@
     "name": "Sitecore Corporation",
     "url": "https://jss.sitecore.net"
   },
+  "contributors": [{
+    "name": "Alexandar Galbulev",
+    "email": "a.galbulev@gmail.com"
+  }],
   "license": "Apache-2.0",
   "homepage": "https://jss.sitecore.net",
   "bugs": {

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -15,9 +15,9 @@ export class LinkDirective implements OnChanges {
   @Input('scLink') field: LinkField;
 
   constructor(
-    private viewContainer: ViewContainerRef,
-    private templateRef: TemplateRef<any>,
-    private renderer: Renderer2,
+    protected viewContainer: ViewContainerRef,
+    protected templateRef: TemplateRef<any>,
+    protected renderer: Renderer2,
     private elementRef: ElementRef
   ) { }
 
@@ -45,7 +45,7 @@ export class LinkDirective implements OnChanges {
     }
   }
 
-  private renderTemplate(props: any, linkText: string) {
+  protected renderTemplate(props: any, linkText: string) {
     const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
 
     viewRef.rootNodes.forEach((node) => {

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
@@ -1,0 +1,221 @@
+import { Component, DebugElement, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { generalLinkField as eeLinkData } from '../testData/ee-data';
+import { RouterLinkDirective } from './router-link.directive';
+import { RouterTestingModule } from '@angular/router/testing';
+
+@Component({
+  selector: 'test-router-link',
+  template: `
+    <a *scRouterLink="field; editable: editable; attrs: attrs" id="my-link"></a>
+  `,
+})
+class TestComponent {
+  @Input() field: any;
+  @Input() editable = true;
+  @Input() attrs = {};
+}
+
+describe('<a *scRouterLink />', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let comp: TestComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [RouterLinkDirective, TestComponent],
+      imports: [RouterTestingModule]
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    de = fixture.debugElement;
+
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render nothing with missing field', () => {
+    expect(de.children.length).toBe(0);
+  });
+
+  it('should render nothing with missing editable and value', () => {
+    const field = {};
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.children.length).toBe(0);
+  });
+
+  it('should render editable with an editable value', () => {
+    const field = {
+      editableFirstPart: '<a class="yo" href="/services">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.query(By.css('span')).nativeElement.innerHTML).toContain(field.editableFirstPart);
+  });
+
+  it('should render value with editing explicitly disabled', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+      },
+      editable: '<a href="/services" class="yo">Lorem</a>',
+    };
+    comp.field = field;
+    comp.editable = false;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toBe(field.value.text);
+  });
+
+  it('should render with href directly on provided field', () => {
+    const field = {
+      href: '/lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toBe(field.text);
+  });
+
+  it('should render ee HTML', () => {
+    const field = {
+      editableFirstPart: eeLinkData,
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered).not.toBeNull();
+    expect(rendered.nativeElement.innerHTML).toContain('<input');
+    expect(rendered.nativeElement.innerHTML).toContain('chrometype="field"');
+  });
+
+  it('should render all value attributes', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.className).toContain(field.value.class);
+    expect(rendered.nativeElement.title).toContain(field.value.title);
+    expect(rendered.nativeElement.target).toContain(field.value.target);
+  });
+
+  it('should render other attributes on wrapper span with other props provided with editable', () => {
+    const field = {
+      editableFirstPart: '<a href="/services" class="yo">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered.nativeElement.id).toBe('my-link');
+  });
+
+  it('should apply attributes from attrs on wrapper span when rendering in editable mode', () => {
+    const field = {
+      editableFirstPart: '<a href="/services" class="yo">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    comp.attrs = { title: 'footip' };
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered.nativeElement.title).toBe('footip');
+  });
+
+  it('should merge attributes from attrs on link when rendering standard (non-editable mode) field', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    comp.field = field;
+    comp.attrs = { title: 'footip' };
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.target).toBe('_blank');
+    expect(rendered.nativeElement.title).toBe('footip');
+  });
+});
+
+// tslint:disable-next-line:max-classes-per-file
+@Component({
+  selector: 'test-router-link-children',
+  template: `
+    <a *scRouterLink="field; editable: editable; attrs: attrs" id="my-link"><span *ngIf="true">hello world</span></a>
+  `,
+})
+class TestWithChildrenComponent {
+  @Input() field: any;
+  @Input() editable = true;
+  @Input() attrs = {};
+}
+
+describe('<a *scRouterLink>children</a>', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let comp: TestComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [RouterLinkDirective, TestWithChildrenComponent],
+      imports: [RouterTestingModule]
+    });
+
+    fixture = TestBed.createComponent(TestWithChildrenComponent);
+    de = fixture.debugElement;
+
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render children with an editable value', () => {
+    const field = {
+      editableFirstPart: '<a class="yo" href="/services">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.innerHTML).toContain('hello world');
+  });
+
+  it('should render children with href directly on provided field', () => {
+    const field = {
+      href: '/lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toContain('<span>hello world</span>');
+  });
+});

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.ts
@@ -1,0 +1,48 @@
+import { LinkDirective } from "./link.directive";
+import { Directive, ViewContainerRef, TemplateRef, Renderer2, ElementRef, Input } from "@angular/core";
+import { Router } from "@angular/router";
+import { LinkField } from "./rendering-field";
+
+@Directive({ selector: '[scRouterLink]' })
+export class RouterLinkDirective extends LinkDirective {
+
+    // tslint:disable-next-line:no-input-rename
+    @Input('scRouterLinkEditable') editable = true;
+
+    // tslint:disable-next-line:no-input-rename
+    @Input('scRouterLinkAttrs') attrs: any = {};
+
+    // tslint:disable-next-line:no-input-rename
+    @Input('scRouterLink') field: LinkField;
+
+    constructor(
+        viewContainer: ViewContainerRef,
+        templateRef: TemplateRef<any>,
+        renderer: Renderer2,
+        elementRef: ElementRef,
+        private router: Router
+    ) {
+        super(viewContainer, templateRef, renderer, elementRef);
+    }
+
+    protected renderTemplate(props: any, linkText: string) {
+        const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
+
+        viewRef.rootNodes.forEach((node) => {
+            Object.keys(props).forEach((key) => {
+                if (key === 'href') {
+                    this.renderer.listen(node, 'click', () => {
+                        this.router.navigate([props[key]]);
+                    })
+
+                } else {
+                    this.renderer.setAttribute(node, key, props[key]);
+                }
+            });
+
+            if (node.childNodes && node.childNodes.length === 0 && linkText) {
+                node.textContent = linkText;
+            }
+        });
+    }
+}

--- a/packages/sitecore-jss-angular/src/lib.module.ts
+++ b/packages/sitecore-jss-angular/src/lib.module.ts
@@ -11,6 +11,7 @@ import { DateDirective } from './components/date.directive';
 import { FileDirective } from './components/file.directive';
 import { ImageDirective } from './components/image.directive';
 import { LinkDirective } from './components/link.directive';
+import { RouterLinkDirective } from './components/router-link.directive';
 import { MissingComponentComponent } from './components/missing-component.component';
 import { PlaceholderComponent } from './components/placeholder.component';
 import {
@@ -38,6 +39,7 @@ import { LayoutService } from './layout.service';
     FileDirective,
     ImageDirective,
     LinkDirective,
+    RouterLinkDirective,
     DateDirective,
     RenderEachDirective,
     RenderEmptyDirective,
@@ -53,6 +55,7 @@ import { LayoutService } from './layout.service';
     ImageDirective,
     DateDirective,
     LinkDirective,
+    RouterLinkDirective,
     RenderEachDirective,
     RenderEmptyDirective,
     RenderComponentComponent,

--- a/packages/sitecore-jss-angular/src/public_api.ts
+++ b/packages/sitecore-jss-angular/src/public_api.ts
@@ -1,6 +1,7 @@
 export { FileDirective } from './components/file.directive';
 export { ImageDirective } from './components/image.directive';
 export { LinkDirective } from './components/link.directive';
+export { RouterLinkDirective } from './components/router-link.directive';
 export { PlaceholderComponent } from './components/placeholder.component';
 export { ComponentNameAndType, DYNAMIC_COMPONENT } from './components/placeholder.token';
 export { isRawRendering } from './components/rendering';


### PR DESCRIPTION
Add new link directive (scRouterLink) which work with angular route. This will prevent refresh the whole page and lost of state of app after refresh.

## Description
Extended the LinkDirective class and overwrited only one method renderTemplate(). New directive has access to Router Service and on click make navigation using navigate() method of Route service.

## Motivation
Prevent refresh of whole page and lost of state of app after refresh. 

## How Has This Been Tested?
Can be test in sample app after change one of *scLink with *scRouterLink. Open the DevTool and check the network tab, In the tab need to see, after click over navigation link,  only one call to Layout Service without call for main.js, vendor.js and other and also the loader for browser tab need to missing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
