### PR TITLE
Added support for TypeScript when 'jss build'ing

### DIFF
--- a/samples/vue/server/server.vue.config.js
+++ b/samples/vue/server/server.vue.config.js
@@ -38,7 +38,7 @@ const vueConfig = {
     */
 
     config.module.rules.unshift({
-      test: /\.(?!js|vue|html|graphql|gql|png|jpe?g|gif|webp|svg|woff2?|eot|ttf|otf$)[^.]+$/,
+      test: /\.(?!js|vue|ts|html|graphql|gql|png|jpe?g|gif|webp|svg|woff2?|eot|ttf|otf$)[^.]+$/,
       use: {
         loader: 'null-loader',
       },


### PR DESCRIPTION
I've not added in 
```
config.module.rules.push({
    test: /\.(ts|tsx)?$/,
    loader: 'ts-loader',
    exclude: /node_modules/,
    options: {
      appendTsSuffixTo: [/\.vue$/],
    }
  });
```
as I figured people probably wanted to opt into that. 

If adding ^ we'd need to update package.json / package-lock.json with **ts-loader** and **typescript** and also add to webpack override: `config.resolve.extensions.push('.ts');`