### PR TITLE
 Only log pathRewriteExcludePredicate in debug env

### DIFF
--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -378,7 +378,7 @@ function isUrlIgnored(originalUrl: string, config: ProxyConfig, noDebug: boolean
           `DEBUG: URL ${originalUrl} did not match the proxy exclude list, and will be treated as a layout service route to render. Excludes:`,
           config.pathRewriteExcludeRoutes
         );
-      } else {
+      } else if(!noDebug) {
         console.log(
           `DEBUG: URL ${originalUrl} matched the proxy exclude list and will be served verbatim as received. Excludes: `,
           config.pathRewriteExcludeRoutes

--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -378,7 +378,7 @@ function isUrlIgnored(originalUrl: string, config: ProxyConfig, noDebug: boolean
           `DEBUG: URL ${originalUrl} did not match the proxy exclude list, and will be treated as a layout service route to render. Excludes:`,
           config.pathRewriteExcludeRoutes
         );
-      } else if(!noDebug) {
+      } else {
         console.log(
           `DEBUG: URL ${originalUrl} matched the proxy exclude list and will be served verbatim as received. Excludes: `,
           config.pathRewriteExcludeRoutes
@@ -392,14 +392,16 @@ function isUrlIgnored(originalUrl: string, config: ProxyConfig, noDebug: boolean
   if (config.pathRewriteExcludePredicate) {
     result = config.pathRewriteExcludePredicate(originalUrl);
 
-    if (config.debug && result) {
-      console.log(
-        `DEBUG: URL ${originalUrl} did not match the proxy exclude function, and will be treated as a layout service route to render.`
-      );
-    } else {
-      console.log(
-        `DEBUG: URL ${originalUrl} matched the proxy exclude function and will be served verbatim as received.`
-      );
+    if (!noDebug && config.debug) {
+      if (result) {
+        console.log(
+          `DEBUG: URL ${originalUrl} did not match the proxy exclude function, and will be treated as a layout service route to render.`
+        );
+      } else {
+        console.log(
+          `DEBUG: URL ${originalUrl} matched the proxy exclude function and will be served verbatim as received.`
+        );
+      }
     }
 
     return result;


### PR DESCRIPTION
Readd !noDebug to jss-proxy console logging to allow disabling of logging. 

## Description
Readd !noDebug to jss-proxy console logging to allow disabling of logging.

## Motivation
Since the last upgrade we have debug logging on production. This merge request solves it.

## How Has This Been Tested?
Tested this by reproducing it and adding this line to our local npm package.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
