### PR TITLE
Add type strength to Field and getFieldValue

### DIFF
--- a/packages/sitecore-jss/src/dataModels.ts
+++ b/packages/sitecore-jss/src/dataModels.ts
@@ -93,9 +93,11 @@ export interface HtmlElementRendering {
 /**
  * Field value data on a component
  */
-export interface Field {
-  value: string | boolean | number | { [key: string]: any } | Array<{ [key: string]: any }>;
-  editable?: string;
+export type GenericFieldValue = string | boolean | number | { [key: string]: any } | Array<{ [key: string]: any }>;
+
+export interface Field<T = GenericFieldValue> {
+    value: T;
+    editable?: string;
 }
 
 /**

--- a/packages/sitecore-jss/src/layoutDataUtils.ts
+++ b/packages/sitecore-jss/src/layoutDataUtils.ts
@@ -15,7 +15,7 @@ export function getFieldValue<T>(
 
   const fields = renderingOrFields as any;
   if (fields[fieldName] && typeof fields[fieldName].value !== 'undefined') {
-    return fields[fieldName].value;
+    return fields[fieldName].value as T;
   }
 
   const rendering = renderingOrFields as ComponentRendering;

--- a/packages/sitecore-jss/src/layoutDataUtils.ts
+++ b/packages/sitecore-jss/src/layoutDataUtils.ts
@@ -6,6 +6,13 @@ import { ComponentRendering, Field, HtmlElementRendering, Item } from './dataMod
  */
 export function getFieldValue<T>(
   renderingOrFields: ComponentRendering | { [name: string]: Field | Item[] },
+  fieldName: string): T | undefined;
+export function getFieldValue<T>(
+  renderingOrFields: ComponentRendering | { [name: string]: Field | Item[] },
+  fieldName: string,
+  defaultValue: T): T;
+export function getFieldValue<T>(
+  renderingOrFields: ComponentRendering | { [name: string]: Field | Item[] },
   fieldName: string,
   defaultValue?: T) {
 

--- a/packages/sitecore-jss/src/layoutDataUtils.ts
+++ b/packages/sitecore-jss/src/layoutDataUtils.ts
@@ -14,8 +14,9 @@ export function getFieldValue<T>(
   }
 
   const fields = renderingOrFields as any;
-  if (fields[fieldName] && typeof fields[fieldName].value !== 'undefined') {
-    return fields[fieldName].value as T;
+  const field = fields[fieldName] as Field<T>;
+  if (field && typeof field.value !== 'undefined') {
+    return field.value;
   }
 
   const rendering = renderingOrFields as ComponentRendering;
@@ -27,7 +28,7 @@ export function getFieldValue<T>(
     return defaultValue;
   }
 
-  return (rendering.fields[fieldName] as Field).value as T;
+  return (rendering.fields[fieldName] as Field<T>).value;
 }
 
 /**


### PR DESCRIPTION
This change makes two changes that improve typing around `Field.value` and the return value of `getFieldValue()`. This should be backwards compatible so long as users of `getFieldValue<T>()` were treating its output as `T | undefined`.

## Description
 1. Redefines `Field` as `Field<T = GenericFieldValue>`, where `T` refers to the type of the `.value` property in the field. The original value type is maintained as `GenericFieldValue`, so this change is backwards compatible.
 1. Updates `getFieldValue<T>(...)` to use this new type parameter in `Field` to produce predictably typed results. Thus, `getFieldValue<string>` will return a `string | undefined` instead of `any`.

## Motivation
https://github.com/Sitecore/jss/issues/156

## How Has This Been Tested?
I modified the code locally and used the following snippet in a TypeScript enabled editor to confirm that the implied type of `value` is `string | undefined`. Repeated with `boolean`, `{}`, and `MyClass`.

```
const rend: ComponentRendering = { componentName: 'name' };
const fieldName = 'name';
const value = getFieldValue<string>(rend, fieldName);
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
