### PR TITLE
Adds faux script to prevent Heroku from running 'build' script

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,8 @@
     "prerender": "node -r babel-register ./build/prerender.js",
     "lint": "eslint --fix ./src/**/*.js ./sitecore/definitions/**/*.js ./build/**/*.js ./lib/**/*.js",
     "postinstall": "if-env HEROKU=true && npm run build || exit 0",
-    "deploy": "cd .. && git subtree push --prefix docs heroku master"
+    "deploy": "cd .. && git subtree push --prefix docs heroku master",
+    "heroku-postbuild": "echo Skip builds on Heroku"
   },
   "private": true,
   "babel": {


### PR DESCRIPTION
 (and thus building twice) when it deploys docs

See https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq