### PR TITLE
Improve tree shaking for @sitecore-jss/sitecore-jss-react

### DIFF
--- a/packages/sitecore-jss-react/tsconfig.json
+++ b/packages/sitecore-jss-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
+    "module": "ESNext",
     "newLine": "LF",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request is rather a proposal than a feature complete code change.

Right now `@sitecore-jss/sitecore-jss-react` is compiled to `commonjs`.  
In general that is a really good idea as commonjs is very compatible with javascript bundlers.  

From [https://unpkg.com/@sitecore-jss/sitecore-jss-react@11.0.2/dist/index.js](https://unpkg.com/@sitecore-jss/sitecore-jss-react@11.0.2/dist/index.js):

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
var sitecore_jss_1 = require("@sitecore-jss/sitecore-jss");
exports.dataApi = sitecore_jss_1.dataApi;
exports.mediaApi = sitecore_jss_1.mediaApi;
...
```

However tree shaking will not work in that case as webpack will not be able to detect if sitecore-jss-react includes any side effect and therefore will keep the entire code of all dependencies to stay safe.

[The author of Rollup](https://github.com/rollup/rollup/wiki/pkg.module) suggested in 2017 to bundle modules twice - once tree shakable using esnext and once using common js.

This pull request only changes the build from commonjs to esnext to keep the change as small as possible. Please challenge this idea and let me know what you think. 

Merging this pull request would change the file format to the following:

```
export { Placeholder } from './components/Placeholder';
export { Image } from './components/Image';
export { RichText } from './components/RichText';
export { Text } from './components/Text';
...
```

Just as a site note: For webpack there might be an [alternative solution]( https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) however I didn't look into it to much.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Decrease the size of @sitecore-jss/sitecore-jss-react by 70% in our project**. (8kb instead of 27kb)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only in our environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This will break any non esmodule compatible bundler.  
Unfortunately I just realized that this also broke your mocha setup.

So maybe we should release both versions as [written here](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features).

What do you think?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
