### PR TITLE
Changed proptypes in PlaceholderCommon

### DIFF
--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -54,8 +54,8 @@ export class PlaceholderCommon extends React.Component<PlaceholderProps> {
     rendering: PropTypes.object,
     fields: PropTypes.object,
     params: PropTypes.object,
-    missingComponentComponent: PropTypes.object,
-    errorComponent: PropTypes.object,
+    missingComponentComponent: PropTypes.node,
+    errorComponent: PropTypes.node,
   };
 
   nodeRefs: any[];


### PR DESCRIPTION
## Description
Changed proptypes of `missingComponentComponent` and `errorComponent` to `PropTypes.func` in 
 `packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx`


## Motivation
Whenever the following JSX is used:

```
<Placeholder 
   missingComponentComponent={MissingComponentComponent} 
   errorComponent={ErrorComponent}  {...placeholderProps} 
/>
```

The following warning will occur:
```
Warning: Failed prop type: Invalid prop `missingComponentComponent` of type `function` supplied to `PlaceholderComponent`, expected `object`.
```

This PR will stop that warning from showing

## How Has This Been Tested?

I've changed the proptypes and made sure the warning did not show up in my browser-console.

Browser: Chrome Version 73.0.3683.86 (Official Build) (64-bit) 
OS: OSX

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
