### PR TITLE
Added ability for manifest media to be extracted from inherited template fields.

### DIFF
--- a/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
+++ b/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
@@ -1,10 +1,55 @@
 export const enhanceTemplates = (templates: any) => {
-  const newTemplates: {[k: string]: any} = [...templates];
+  const newTemplates: { [k: string]: any } = [...templates];
   newTemplates.getTemplate = function getTemplate(templateName: string) {
-    return this.find((template: any) => template.name === templateName);
+    const foundTemplate = this.find((template) => template.name === templateName);
+    if (foundTemplate) {
+      foundTemplate.allFields = getAllTemplateFields(foundTemplate, templates);
+    }
+    return foundTemplate;
   };
   return newTemplates;
 };
+
+// NOTE: this function does not attempt to do anything about field names
+// that might be duplicated in the template inheritance tree. That said, for
+// the purposes of extracting media field values, we don't need to be concerned
+// about duplicates or naming collisions. We simply need a field type and
+// a field value.
+function getAllTemplateFields(template: any, templateCollection: any) {
+  if (!template) {
+    return null;
+  }
+
+  // If the template already has an `allFields` property, assume that
+  // its inheritance tree has already been resolved.
+  if (template.allFields && Array.isArray(template.allFields)) {
+    return template.allFields;
+  }
+
+  const allFields: any[] = [];
+  
+  // If the template has its own fields, add them to the `allFields` array.
+  if (template.fields && Array.isArray(template.fields)) {
+    allFields.push(...template.fields);
+  }
+
+  // Recursively add fields from all inherited templates and any ancestors.
+  if (template.inherits && Array.isArray(template.inherits)) {
+    template.inherits.forEach((inheritedTemplateName) => {
+      const inheritedTemplate = templateCollection.find((t) => t.name === inheritedTemplateName);
+      if (!inheritedTemplate || !inheritedTemplate.fields || !Array.isArray(inheritedTemplate.fields)) {
+        return;
+      }
+      
+      const inheritedFields = getAllTemplateFields(inheritedTemplate, templateCollection);
+      if (inheritedFields) {
+        allFields.push(...inheritedFields);
+      }
+    });
+  }
+
+  return allFields;
+}
 
 function getMediaFieldValue(field: any) {
   return field.value;
@@ -18,7 +63,7 @@ function getTreelistFieldValue(field: any, templates: any) {
   }, []);
 }
 
-function getFieldValues({ field, templates }: { field: any, templates: any }) {
+function getFieldValues({ field, templates }: { field: any; templates: any }) {
   switch (field.type) {
     case 'Image':
       return [getMediaFieldValue(field)];
@@ -42,11 +87,11 @@ export function buildMediaOutput(item: any, templates: any) {
   }
 
   const fields = item.fields.reduce((result: any, field: any) => {
-    if (!template.fields) {
+    if (!template.allFields) {
       return [];
     }
 
-    const templateField = template.fields.find((f: any) => f.name === field.name);
+    const templateField = template.allFields.find((f: any) => f.name === field.name);
     if (templateField) {
       return [...result, { ...field, type: templateField.type }];
     }


### PR DESCRIPTION
Fixes #174 

## How Has This Been Tested?
- [x] Passes all unit tests.
- [x] Manifest output for JSS sample apps is the same.
- [x] Manifest output for JSS app with declarations and data provided in #174 is correct. And media files are emitted to the `/sitecore/manifest` folder in the JSS app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
