### PR TITLE
fix: add component fields interface as type to component fields own type as union

### DIFF
--- a/packages/sitecore-jss/src/dataModels.ts
+++ b/packages/sitecore-jss/src/dataModels.ts
@@ -56,7 +56,7 @@ export type PlaceholdersData<TYPEDNAME extends string = string> = {
  * Content field data passed to a component
  */
 export interface ComponentFields {
-  [name: string]: Field | Item[];
+  [name: string]: ComponentFields | Field | Item[];
 }
 
 /**


### PR DESCRIPTION
## Description
When using `ComponentFields` for a custom field with the default Sitecore data shape pattern - the type gives an error. 

## Motivation
Consider the following the object:
```
export const routeData: RouteData = {
  name: 'Content Page',
  placeholders: {
    content: [
      {
        componentName: 'Paragraph',
        fields: {
          listType: {
            fields: {
              code: {
                value: 'bullet',
              },
            },
          },
        },
      },
    ],
  },
}
```
In this case the type error would occur on the nested property `code`, because the interface is expecting an object with key `value` and throws an error. Therefore I would like to suggest that the `ComponentFields` - aside of the union types `Field` and `Item[]` - could also have have a typing of itself. This to remove the aforementioned type error and to remove the need for potential custom backend code.

## How Has This Been Tested?
This is adjustment is tested by creating the above object example and not seeing a type error appear in any IDE that is supporting Typescript language mode (ie. Visual Studio Code).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
