### PR TITLE
Fixed case-sensitive markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Below is a list of samples included in this repo:
 
 We are very grateful to the community for contributing bugfixes and improvements. We welcome any and all efforts to evolve and improve Sitecore JavaScript Services; read below to learn how you can take part in those efforts.
 
-### [Code of Conduct](code_of_conduct.md)
+### [Code of Conduct](CODE_OF_CONDUCT.md)
 
-Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](code_of_conduct.md) so that you can understand what actions will and will not be tolerated.
+Sitecore has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
-### [Contributing Guide](contributing.md)
+### [Contributing Guide](CONTRIBUTING.md)
 
-Read our [contributing guide](contributing.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
+Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to React.
 
 ### License
 
-Sitecore JavaScript Services is using the [Apache 2.0 license](license.md).
+Sitecore JavaScript Services is using the [Apache 2.0 license](LICENSE.MD).
 
-## [Support](support.md)
+## [Support](SUPPORT.md)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The links to the relevant markdown files in the README.md are case-sensitive and so were giving 404s. This resolves them to the correct url.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I have committed this to my fork and clicked on the links in the readme

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
