### PR TITLE
[Angular] Add directive for general links that can be both internal and external

### DIFF
--- a/packages/sitecore-jss-angular/package-lock.json
+++ b/packages/sitecore-jss-angular/package-lock.json
@@ -90,6 +90,31 @@
 			"integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=",
 			"dev": true
 		},
+		"@sitecore-jss/sitecore-jss": {
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/@sitecore-jss/sitecore-jss/-/sitecore-jss-11.0.2.tgz",
+			"integrity": "sha512-jvJVMY2g/B7p7ewPN69BY2hceVeYP4irejUwLPuGpw2BrE0kQ+cJIk/KZTXKV5c9waIR1XOiIoRbcMwl/WR9dw==",
+			"requires": {
+				"lodash.unescape": "^4.0.1",
+				"url-parse": "^1.4.4"
+			},
+			"dependencies": {
+				"querystringify": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+					"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+				},
+				"url-parse": {
+					"version": "1.4.7",
+					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+					"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+					"requires": {
+						"querystringify": "^2.1.1",
+						"requires-port": "^1.0.0"
+					}
+				}
+			}
+		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2196,8 +2221,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2211,23 +2235,21 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
 				},
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"balanced-match": "1.0.0",
+						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2240,20 +2262,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2294,7 +2313,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
@@ -2309,14 +2328,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
@@ -2325,12 +2344,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -2345,7 +2364,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "2.1.2"
+						"safer-buffer": "^2.1.0"
 					}
 				},
 				"ignore-walk": {
@@ -2354,7 +2373,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "3.0.4"
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
@@ -2363,15 +2382,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2383,9 +2401,8 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
@@ -2398,25 +2415,22 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"brace-expansion": "1.1.11"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
@@ -2425,14 +2439,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "2.2.4"
+						"minipass": "^2.2.1"
 					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2449,9 +2462,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2460,16 +2473,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -2478,8 +2491,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
 				"npm-bundled": {
@@ -2494,8 +2507,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
 					}
 				},
 				"npmlog": {
@@ -2504,17 +2517,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2526,9 +2538,8 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -2549,8 +2560,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
@@ -2571,10 +2582,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2591,13 +2602,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
@@ -2606,14 +2617,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2649,11 +2659,10 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
@@ -2662,16 +2671,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -2686,13 +2694,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -2707,20 +2715,18 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -4328,6 +4334,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
 			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
 			"dev": true
+		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
 		},
 		"log4js": {
 			"version": "3.0.6",
@@ -6601,8 +6612,7 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-			"dev": true
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.1.7",

--- a/packages/sitecore-jss-angular/package-lock.json
+++ b/packages/sitecore-jss-angular/package-lock.json
@@ -90,31 +90,6 @@
 			"integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=",
 			"dev": true
 		},
-		"@sitecore-jss/sitecore-jss": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@sitecore-jss/sitecore-jss/-/sitecore-jss-11.0.2.tgz",
-			"integrity": "sha512-jvJVMY2g/B7p7ewPN69BY2hceVeYP4irejUwLPuGpw2BrE0kQ+cJIk/KZTXKV5c9waIR1XOiIoRbcMwl/WR9dw==",
-			"requires": {
-				"lodash.unescape": "^4.0.1",
-				"url-parse": "^1.4.4"
-			},
-			"dependencies": {
-				"querystringify": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-					"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
-				},
-				"url-parse": {
-					"version": "1.4.7",
-					"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-					"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-					"requires": {
-						"querystringify": "^2.1.1",
-						"requires-port": "^1.0.0"
-					}
-				}
-			}
-		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2221,7 +2196,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2235,21 +2211,23 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2262,17 +2240,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2313,7 +2294,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -2328,14 +2309,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -2344,12 +2325,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -2364,7 +2345,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -2373,7 +2354,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -2382,14 +2363,15 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2401,8 +2383,9 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2415,22 +2398,25 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -2439,13 +2425,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2462,9 +2449,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2473,16 +2460,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -2491,8 +2478,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -2507,8 +2494,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -2517,16 +2504,17 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2538,8 +2526,9 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2560,8 +2549,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -2582,10 +2571,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2602,13 +2591,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -2617,13 +2606,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2659,10 +2649,11 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2671,15 +2662,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -2694,13 +2686,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -2715,18 +2707,20 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -4334,11 +4328,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
 			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
 			"dev": true
-		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
 		},
 		"log4js": {
 			"version": "3.0.6",
@@ -6612,7 +6601,8 @@
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.1.7",

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
@@ -10,13 +10,14 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'test-router-link',
   template: `
-    <a *scGenericLink="field; editable: editable; attrs: attrs" id="my-link"></a>
+    <a *scGenericLink="field; editable: editable; attrs: attrs; extras: extras" id="my-link"></a>
   `,
 })
 class TestComponent {
   @Input() field: any;
   @Input() editable = true;
   @Input() attrs = {};
+  @Input() extras = {};
 }
 
 describe('<a *scGenericLink />', () => {
@@ -170,13 +171,14 @@ describe('<a *scGenericLink />', () => {
 @Component({
   selector: 'test-router-link-children',
   template: `
-    <a *scGenericLink="field; editable: editable; attrs: attrs" id="my-link"><span *ngIf="true">hello world</span></a>
+    <a *scGenericLink="field; editable: editable; attrs: attrs; extras: extras" id="my-link"><span *ngIf="true">hello world</span></a>
   `,
 })
 class TestWithChildrenComponent {
   @Input() field: any;
   @Input() editable = true;
   @Input() attrs = {};
+  @Input() extras = {};
 }
 
 describe('<a *scGenericLink>children</a>', () => {
@@ -186,7 +188,7 @@ describe('<a *scGenericLink>children</a>', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [GenericLinkDirective, TestWithChildrenComponent,],
+      declarations: [GenericLinkDirective, TestWithChildrenComponent],
       imports: [ RouterTestingModule ]
     });
 
@@ -251,10 +253,28 @@ describe('<a *scGenericLink></a>', () => {
     fixture.detectChanges();
 
     const renderedLink = de.query(By.css('a')).nativeElement;
-    expect(renderedLink.getAttribute('href')).toBe(field.href);
+    expect(renderedLink.getAttribute('href')).toBe(`/${field.href}`);
     renderedLink.click();
     fixture.detectChanges();
-    expect(router.navigate).toHaveBeenCalledWith(['lorem']);
+    expect(comp.extras).toEqual({});
+    expect(router.navigate).toHaveBeenCalledWith(['lorem'], comp.extras);
+  });
+
+  it('should navigate to an internal link with query parameters using routerlink', () => {
+    const field = {
+      href: 'lorem',
+      text: 'ipsum',
+    };
+    const queryParams = { queryParams: { foo: 'bar' } }
+    comp.field = field;
+    comp.extras = queryParams;
+    fixture.detectChanges();
+
+    const renderedLink = de.query(By.css('a')).nativeElement;
+    expect(renderedLink.getAttribute('href')).toBe(`/${field.href}?foo=bar`);
+    renderedLink.click();
+    fixture.detectChanges();
+    expect(router.navigate).toHaveBeenCalledWith(['lorem'], queryParams);
   });
 
   it('should navigate to an external link using routerlink', () => {

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
@@ -1,0 +1,271 @@
+import { Component, DebugElement, Input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { generalLinkField as eeLinkData } from '../testData/ee-data';
+import { GenericLinkDirective } from './generic-link.directive';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'test-router-link',
+  template: `
+    <a *scGenericLink="field; editable: editable; attrs: attrs" id="my-link"></a>
+  `,
+})
+class TestComponent {
+  @Input() field: any;
+  @Input() editable = true;
+  @Input() attrs = {};
+}
+
+describe('<a *scGenericLink />', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let comp: TestComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [GenericLinkDirective, TestComponent],
+      imports: [RouterTestingModule]
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    de = fixture.debugElement;
+
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render nothing with missing field', () => {
+    expect(de.children.length).toBe(0);
+  });
+
+  it('should render nothing with missing editable and value', () => {
+    const field = {};
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.children.length).toBe(0);
+  });
+
+  it('should render editable with an editable value', () => {
+    const field = {
+      editableFirstPart: '<a class="yo" href="/services">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.query(By.css('span')).nativeElement.innerHTML).toContain(field.editableFirstPart);
+  });
+
+  it('should render value with editing explicitly disabled', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+      },
+      editable: '<a href="/services" class="yo">Lorem</a>',
+    };
+    comp.field = field;
+    comp.editable = false;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toBe(field.value.text);
+  });
+
+  it('should render with href directly on provided field', () => {
+    const field = {
+      href: '/lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toBe(field.text);
+  });
+
+  it('should render ee HTML', () => {
+    const field = {
+      editableFirstPart: eeLinkData,
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered).not.toBeNull();
+    expect(rendered.nativeElement.innerHTML).toContain('<input');
+    expect(rendered.nativeElement.innerHTML).toContain('chrometype="field"');
+  });
+
+  it('should render all value attributes', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.className).toContain(field.value.class);
+    expect(rendered.nativeElement.title).toContain(field.value.title);
+    expect(rendered.nativeElement.target).toContain(field.value.target);
+  });
+
+  it('should render other attributes on wrapper span with other props provided with editable', () => {
+    const field = {
+      editableFirstPart: '<a href="/services" class="yo">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered.nativeElement.id).toBe('my-link');
+  });
+
+  it('should apply attributes from attrs on wrapper span when rendering in editable mode', () => {
+    const field = {
+      editableFirstPart: '<a href="/services" class="yo">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    comp.attrs = { title: 'footip' };
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('span'));
+    expect(rendered.nativeElement.title).toBe('footip');
+  });
+
+  it('should merge attributes from attrs on link when rendering standard (non-editable mode) field', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    comp.field = field;
+    comp.attrs = { title: 'footip' };
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.target).toBe('_blank');
+    expect(rendered.nativeElement.title).toBe('footip');
+  });
+});
+
+// tslint:disable-next-line:max-classes-per-file
+@Component({
+  selector: 'test-router-link-children',
+  template: `
+    <a *scGenericLink="field; editable: editable; attrs: attrs" id="my-link"><span *ngIf="true">hello world</span></a>
+  `,
+})
+class TestWithChildrenComponent {
+  @Input() field: any;
+  @Input() editable = true;
+  @Input() attrs = {};
+}
+
+describe('<a *scGenericLink>children</a>', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let comp: TestComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [GenericLinkDirective, TestWithChildrenComponent,],
+      imports: [ RouterTestingModule ]
+    });
+
+    fixture = TestBed.createComponent(TestWithChildrenComponent);
+    de = fixture.debugElement;
+
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should render children with an editable value', () => {
+    const field = {
+      editableFirstPart: '<a class="yo" href="/services">Lorem',
+      editableLastPart: '</a>',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.nativeElement.innerHTML).toContain('hello world');
+  });
+
+  it('should render children with href directly on provided field', () => {
+    const field = {
+      href: '/lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const rendered = de.query(By.css('a'));
+    expect(rendered.nativeElement.innerHTML).toContain('<span>hello world</span>');
+  });
+});
+
+describe('<a *scGenericLink></a>', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let comp: TestComponent;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [GenericLinkDirective, TestComponent],
+      imports: [ RouterTestingModule.withRoutes([{ path: 'lorem', component: TestComponent }])]
+    });
+
+    router = TestBed.get(Router);
+    spyOn(router, 'navigate');
+    fixture = TestBed.createComponent(TestComponent);
+    de = fixture.debugElement;
+
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should navigate to an internal link using routerlink', () => {
+    const field = {
+      href: 'lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const renderedLink = de.query(By.css('a')).nativeElement;
+    expect(renderedLink.getAttribute('href')).toBe(field.href);
+    renderedLink.click();
+    fixture.detectChanges();
+    expect(router.navigate).toHaveBeenCalledWith(['lorem']);
+  });
+
+  it('should navigate to an external link using routerlink', () => {
+    const field = {
+      href: 'http://foo.bar/lorem',
+      text: 'ipsum',
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    const renderedLink = de.query(By.css('a')).nativeElement;
+    expect(renderedLink.getAttribute('href')).toBe(field.href);
+  });
+});

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, Input, Renderer2, TemplateRef, ViewContainerRef } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, NavigationExtras } from '@angular/router';
 import { LinkDirective } from './link.directive';
 import { LinkField } from './rendering-field';
 
@@ -14,6 +14,9 @@ export class GenericLinkDirective extends LinkDirective {
 
   // tslint:disable-next-line:no-input-rename
   @Input('scGenericLink') field: LinkField;
+
+  // tslint:disable-next-line:no-input-rename
+  @Input('scGenericLinkExtras') extras?: NavigationExtras;
 
   constructor(
     viewContainer: ViewContainerRef,
@@ -30,13 +33,15 @@ export class GenericLinkDirective extends LinkDirective {
 
     viewRef.rootNodes.forEach((node) => {
       Object.keys(props).forEach((key) => {
-        this.renderer.setAttribute(node, key, props[key]);
-
         if (key === 'href' && !this.isAbsoluteUrl(props[key])) {
+          const urlTree = this.router.createUrlTree([props[key]], this.extras);
+          this.renderer.setAttribute(node, key, this.router.serializeUrl(urlTree));
           this.renderer.listen(node, 'click', (event) => {
-            this.router.navigate([props[key]]);
+            this.router.navigate([props[key]], this.extras);
             event.preventDefault();
           });
+        } else {
+          this.renderer.setAttribute(node, key, props[key]);
         }
       });
 

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
@@ -1,0 +1,59 @@
+import { Directive, ElementRef, Input, Renderer2, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Router } from '@angular/router';
+import { LinkDirective } from './link.directive';
+import { LinkField } from './rendering-field';
+
+@Directive({ selector: '[scGenericLink]' })
+export class GenericLinkDirective extends LinkDirective {
+
+  // tslint:disable-next-line:no-input-rename
+  @Input('scGenericLinkEditable') editable = true;
+
+  // tslint:disable-next-line:no-input-rename
+  @Input('scGenericLinkAttrs') attrs: any = {};
+
+  // tslint:disable-next-line:no-input-rename
+  @Input('scGenericLink') field: LinkField;
+
+  constructor(
+    viewContainer: ViewContainerRef,
+    templateRef: TemplateRef<any>,
+    renderer: Renderer2,
+    elementRef: ElementRef,
+    private router: Router
+  ) {
+    super(viewContainer, templateRef, renderer, elementRef);
+  }
+
+  protected renderTemplate(props: any, linkText: string) {
+    const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
+
+    viewRef.rootNodes.forEach((node) => {
+      Object.keys(props).forEach((key) => {
+        this.renderer.setAttribute(node, key, props[key]);
+
+        if (key === 'href' && !this.isAbsoluteUrl(props[key])) {
+          this.renderer.listen(node, 'click', (event) => {
+            this.router.navigate([props[key]]);
+            event.preventDefault();
+          });
+        }
+      });
+
+      if (node.childNodes && node.childNodes.length === 0 && linkText) {
+        node.textContent = linkText;
+      }
+    });
+  }
+
+  private isAbsoluteUrl(url?: string) {
+    if (url == null) {
+      return false;
+    }
+    if (typeof url !== 'string') {
+      throw new TypeError('Expected a string');
+    }
+
+    return /^[a-z][a-z0-9+.-]*:/.test(url);
+  }
+}

--- a/packages/sitecore-jss-angular/src/lib.module.ts
+++ b/packages/sitecore-jss-angular/src/lib.module.ts
@@ -29,6 +29,7 @@ import { RouterLinkDirective } from './components/router-link.directive';
 import { TextDirective } from './components/text.directive';
 import { JssComponentFactoryService } from './jss-component-factory.service';
 import { LayoutService } from './layout.service';
+import { GenericLinkDirective } from './components/generic-link.directive';
 
 @NgModule({
   imports: [
@@ -39,6 +40,7 @@ import { LayoutService } from './layout.service';
     ImageDirective,
     LinkDirective,
     RouterLinkDirective,
+    GenericLinkDirective,
     DateDirective,
     RenderEachDirective,
     RenderEmptyDirective,
@@ -55,6 +57,7 @@ import { LayoutService } from './layout.service';
     DateDirective,
     LinkDirective,
     RouterLinkDirective,
+    GenericLinkDirective,
     RenderEachDirective,
     RenderEmptyDirective,
     RenderComponentComponent,

--- a/packages/sitecore-jss-angular/src/public_api.ts
+++ b/packages/sitecore-jss-angular/src/public_api.ts
@@ -2,6 +2,7 @@ export { FileDirective } from './components/file.directive';
 export { ImageDirective } from './components/image.directive';
 export { LinkDirective } from './components/link.directive';
 export { RouterLinkDirective } from './components/router-link.directive';
+export { GenericLinkDirective } from './components/generic-link.directive';
 export { PlaceholderComponent } from './components/placeholder.component';
 export { ComponentNameAndType, DYNAMIC_COMPONENT } from './components/placeholder.token';
 export { isRawRendering } from './components/rendering';

--- a/samples/angular/src/app/components/styleguide-field-usage-link/styleguide-field-usage-link.component.html
+++ b/samples/angular/src/app/components/styleguide-field-usage-link/styleguide-field-usage-link.component.html
@@ -35,4 +35,10 @@
   <br />
   Link using Angular routing for the target:
   <a *scRouterLink="rendering.fields.internalLink">Router link to /</a>
+
+  Link using both internal and Angular routing links for the target:
+  <a *scGenericLink="rendering.fields.internalLink">Generic internal link</a>
+  <a *scGenericLink="rendering.fields.externalLink">Generic external link </a>
+  <a *scGenericLink="rendering.fields.emailLink">Generic email link</a>
+  <a *scGenericLink="rendering.fields.paramsLink">Generic parameterized link</a>
 </app-styleguide-specimen>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add angular directive for general links that can be both internal and external.
This allows Content Editors to not be limited to one type of predefined linkfield while maintaining angular routerlinks

## Description
Add angular directive for general links that can be both internal and external.
This allows Content Editors to not be limited to one type of predefined linkfield while maintaining angular routerlinks

## Motivation

Currently the implementation of a link is limited by developers. Either they choose *scLink which doesn't use angular routerlinks, or *scRouterLink which solely uses routerlinks. This directive decides whether the link has a protocol and is therefor an external link.

## How Has This Been Tested?
Added unit tests and tested it on our application.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
