### PR TITLE
Pass through component types when using `withSitecoreContext`

### DIFF
--- a/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
@@ -5,12 +5,21 @@ export interface WithSitecoreContextOptions {
   updatable?: boolean;
 }
 
+export interface WithSitecoreContextProps {
+  sitecoreContext?: any;
+  updateSitecoreContext?: (value: any) => void;
+}
+
+export type WithSitecoreContextHocProps<ComponentProps> = Pick<ComponentProps, Exclude<keyof ComponentProps, keyof WithSitecoreContextProps>>;
+
 export function withSitecoreContext(options?: WithSitecoreContextOptions) {
-  return function withSitecoreContextHoc(Component: React.ComponentClass<any> | React.SFC<any>) {
-    return function WithSitecoreContext(props: any) {
+  return function withSitecoreContextHoc<ComponentProps extends WithSitecoreContextProps>(Component: React.ComponentType<ComponentProps>) {
+    return function WithSitecoreContext(props: WithSitecoreContextHocProps<ComponentProps>) {
       return (
         <SitecoreContextReactContext.Consumer>
-          {context => <Component {...props} sitecoreContext={context.context} updateSitecoreContext={options && options.updatable && context.setSitecoreContext} />}
+          {context => <Component {...props}
+                                 sitecoreContext={context.context}
+                                 updateSitecoreContext={options && options.updatable && context.setSitecoreContext} />}
         </SitecoreContextReactContext.Consumer>
       );
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This takes the props type from the original component and uses it to form the prop types for the HOC.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
The component prop types were getting lost when wrapped in `withSitecoreContext`

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
`npm run test-packages`

I've also packed the package and pulled it into our repo and built it successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
