### PR TITLE
implemented issue #261

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/package-deploy.ts
+++ b/packages/sitecore-jss-dev-tools/src/package-deploy.ts
@@ -37,6 +37,21 @@ function applyCertPinning(req: request.Request, options: PackageDeployOptions) {
   });
 }
 function normalizeFingerprint(fp: string): string {
+  //
+  // The fingerprint for a certificate is a 20-byte value.
+  // Such values are typically expressed as strings, but 
+  // there are many different formats that may be used.
+  //
+  // For example, the following values all represent
+  // the same fingerprint:
+  //  * 5E:D1:5E:D4:D4:42:71:CC:30:A5:B6:A2:DA:A4:79:06:67:CB:F6:36
+  //  * 5ED15ED4D44271CC30A5B6A2DAA4790667CBF636
+  //  * 5e:d1:5e:d4:d4:42:71:cc:30:a5:b6:a2:da:a4:79:06:67:cb:f6:36
+  //  * 5ed15ed4d44271cc30a5b6a2daa4790667cbf636
+  //
+  // Before two fingerprints can be properly compared,
+  // they must be converted into the same format. This
+  // function implements the logic for that conversion.
   return fp.toLowerCase().replace(new RegExp(':', 'g'),'');
 }
 function doFingerprintsMatch(fp1:string, fp2:string): boolean {

--- a/packages/sitecore-jss-dev-tools/src/package-deploy.ts
+++ b/packages/sitecore-jss-dev-tools/src/package-deploy.ts
@@ -26,7 +26,7 @@ function applyCertPinning(req: request.Request, options: PackageDeployOptions) {
       const fingerprint = (socket as TLSSocket).getPeerCertificate().fingerprint;
 
       // Match the fingerprint with our saved fingerprint
-      if (options.acceptCertificate && (options.acceptCertificate !== fingerprint)) {
+      if (options.acceptCertificate && (! doFingerprintsMatch(options.acceptCertificate, fingerprint))) {
         // Abort request, optionally emit an error event
         // tslint:disable-next-line:max-line-length
         req.emit('error', new Error(`Expected server SSL certificate to have thumbprint ${options.acceptCertificate} from acceptCertificate, but got ${fingerprint} from server. This may mean the certificate has changed, or that a malicious certificate is present.`));
@@ -36,7 +36,12 @@ function applyCertPinning(req: request.Request, options: PackageDeployOptions) {
     });
   });
 }
-
+function normalizeFingerprint(fp: string): string {
+  return fp.toLowerCase().replace(new RegExp(':', 'g'),'');
+}
+function doFingerprintsMatch(fp1:string, fp2:string): boolean {
+  return normalizeFingerprint(fp1) === normalizeFingerprint(fp2);
+}
 async function watchJobStatus(options: PackageDeployOptions, taskName: string) {
   let logOffset = 0;
   const errors: string[] = [];


### PR DESCRIPTION
## Description
Implemented issue #261 .

## Motivation
Currently, using the `--acceptCertificate` option requires the certificate thumbprint be in a specific format. This change expands support to other common formats.

## How Has This Been Tested?
Local testing and building.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
