### PR TITLE
[sitecore-jss-manifest] Include media from Droptree and Multilist content

### DIFF
--- a/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
+++ b/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
@@ -55,7 +55,7 @@ function getMediaFieldValue(field: any) {
   return field.value;
 }
 
-function getTreelistFieldValue(field: any, templates: any) {
+function getNestedFieldValue(field: any, templates: any) {
   return field.value.reduce((result: any, item: any) => {
     // eslint-disable-next-line no-use-before-define
     const media = buildMediaOutput(item, templates);
@@ -69,8 +69,9 @@ function getFieldValues({ field, templates }: { field: any; templates: any }) {
       return [getMediaFieldValue(field)];
     case 'File':
       return [getMediaFieldValue(field)];
+    case 'Multilist':
     case 'Treelist':
-      return getTreelistFieldValue(field, templates);
+      return getNestedFieldValue(field, templates);
     default:
       return null;
   }

--- a/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
+++ b/packages/sitecore-jss-manifest/src/generator/pipelines/generateMedia/utils.ts
@@ -69,6 +69,7 @@ function getFieldValues({ field, templates }: { field: any; templates: any }) {
       return [getMediaFieldValue(field)];
     case 'File':
       return [getMediaFieldValue(field)];
+    case 'Droptree':
     case 'Multilist':
     case 'Treelist':
       return getNestedFieldValue(field, templates);


### PR DESCRIPTION
## Description
This change makes sure you also consider fields of type `Droptree` and `Multilist`.

## Motivation
Currently only `Treelist` content definitions are traversed recursively to look for media items. If you add a field of type `Multilist` or `Droptree` its media items will not be included in the JSS import.

## How Has This Been Tested?
Tested locally and is a minor change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
