### PR TITLE
Remove SitecoreForm import from JSON example

### DIFF
--- a/docs/data/routes/docs/techniques/forms/en.md
+++ b/docs/data/routes/docs/techniques/forms/en.md
@@ -51,7 +51,6 @@ To make the form render as a form, we need to tell React how to render the Sitec
 
 ```jsx
 import React from 'react';
-import { SitecoreForm } from '@sitecore-jss/sitecore-jss-forms';
 
 export default function Form(props) {
   /** @type {SitecoreForm} */


### PR DESCRIPTION
`SitecoreForm` is not used and the guide does not tell you to install `@sitecore-jss/sitecore-jss-forms` yet so the example will throw a compilation error during `jss start` if you have not done that yet. If `SitecoreForm` just being used for typing (here: /** @type {SitecoreForm} */), maybe move the NPM package section to the beginning of the guide instead of in the middle.
