### PR TITLE
Implementation of edit frame component for sitecore-jss-react

### DIFF
--- a/packages/sitecore-jss-react/src/components/FieldEditFrame.tsx
+++ b/packages/sitecore-jss-react/src/components/FieldEditFrame.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { withSitecoreContext } from '../enhancers/withSitecoreContext';
+
+export interface FieldEditFrameProps {
+    itemId?: string,
+    fields?: string[],
+    header?: string,
+    icon?: string,
+    disabledIcon?: string,
+    tooltip?: string,
+    command?: string,
+    commandDisplayName?: string,
+    databaseName?: string,
+    language?: string,
+    hideIfNotPageEditing?: boolean,
+    sitecoreContext: {
+        language?: string,
+        pageEditing?: boolean,
+        route: {
+            databaseName?: string
+        }
+    }
+}
+
+export const FieldEditFrameWrapper: React.SFC<FieldEditFrameProps> = ({
+    itemId,
+    fields,
+    header,
+    icon,
+    disabledIcon,
+    tooltip,
+    command,
+    commandDisplayName,
+    databaseName,
+    language,
+    children
+}) => {
+    // ensure fields and itemId are configured
+    if (!itemId || !fields) {
+        return null;
+    }
+
+    // item uri for edit frame target
+    const contextItemUri = `sitecore://${databaseName}/${itemId}?lang=${language}`;
+
+    // click action for edit frame command
+    const clickCommandAction = `webedit:fieldeditor(command=${command},fields=${fields.join(
+        "|"
+    )},id=${itemId})`;
+
+    // click for command for the edit frame
+    const clickCommand = {
+        click: `javascript:Sitecore.PageModes.PageEditor.postRequest('${clickCommandAction}',null,false)`,
+        header: header,
+        icon: icon,
+        disabledIcon: disabledIcon,
+        isDivider: false,
+        tooltip: tooltip || `Edit the following fields: ${fields.join(", ")}`,
+        type: null
+    };
+
+    // command data that is serialized for the edit frame
+    const commandData = {
+        commands: [clickCommand],
+        contextItemUri: contextItemUri,
+        custom: {},
+        displayName: commandDisplayName || 'Edit Properties',
+        expandedDisplayName: ""
+    };
+
+    // edit frame attributes
+    const divAttrs = {
+        'sc_item': contextItemUri,
+        'sc-part-of': 'editframe'
+    }
+
+    return <div
+        className="scLooseFrameZone scEnabledChrome"
+        {...divAttrs}>
+        <span className="scChromeData">{JSON.stringify(commandData)}</span>
+        {children}
+    </div>
+};
+
+export const FieldEditFrameComponent: React.SFC<FieldEditFrameProps> = ({
+    sitecoreContext,
+    children,
+    itemId,
+    fields,
+    hideIfNotPageEditing,
+    databaseName,
+    language,
+    ...otherProps
+}) => {
+    // check if we're in experience editor and configured properly
+    const shouldRender = sitecoreContext.pageEditing && itemId && fields && fields.length;
+
+    // hide if not in page editing mode and prop is passed telling us to hide
+    if (!shouldRender && hideIfNotPageEditing) {
+        return null;
+    }
+
+    // if we're configured properly, wrap in edit frame.
+    const WrapperComponent = shouldRender ? FieldEditFrameWrapper : React.Fragment;
+
+    // build the props for our edit frame
+    const WrapperProps = {
+        itemId,
+        fields,
+        databaseName: databaseName || sitecoreContext.route.databaseName,
+        language: language || sitecoreContext.language,
+        sitecoreContext,
+        ...otherProps
+    }
+
+    return <WrapperComponent {...WrapperProps}>
+        {children}
+    </WrapperComponent>
+}
+
+FieldEditFrameComponent.defaultProps = {
+    itemId: '',
+    fields: [],
+    header: 'Edit Fields',
+    icon: '/temp/iconcache/people/16x16/cubes_blue.png',
+    disabledIcon: '/temp/cubes_blue_disabled16x16.png',
+    command: '{70C4EED5-D4CD-4D7D-9763-80C42504F5E7}'
+};
+
+export const FieldEditFrame = withSitecoreContext()(FieldEditFrameComponent);

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -22,6 +22,7 @@ export { Text } from './components/Text';
 export { DateField } from './components/Date';
 export { Link } from './components/Link';
 export { File } from './components/File';
+export { FieldEditFrame } from './components/FieldEditFrame';
 export { VisitorIdentification } from './components/VisitorIdentification';
 export { SitecoreContext, SitecoreContextFactory, SitecoreContextReactContext } from './components/SitecoreContext';
 export { withSitecoreContext } from './enhancers/withSitecoreContext';


### PR DESCRIPTION
I miss edit frames. I implemented a new component to allow the placement of edit frames in Sitecore JSS applications built with React. 

Shout out @jammykam for this blog post that helped with some of the meta data: https://jammykam.wordpress.com/2017/09/11/glass-edit-frame-immediately-invoking-wrapper/.

## Description
Implemented a new component named `FieldEditFrame` that allows you to pass in an `itemId` and an array of `fields` and the component will generate the HTML markup necessary for displaying the edit frame in Experience Editor.

By default this uses the standard `Edit` Sitecore command from `core` (`{70C4EED5-D4CD-4D7D-9763-80C42504F5E7}`) and passes in the `fields` prop values to the command, which then will build out and display the edit frame modal.

Some values have defaults but can be overwritten by props on the component itself. Defaults were used to try to make this component as easy to use as possible.

## Motivation
I miss edit frames and I always enjoyed using them doing traditional MVC/WebForms development and I think they still have a place even with JSS built apps.

## How Has This Been Tested?
Manually, only locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
