### PR TITLE
Correctly evaluates the value of SITECORE_ENABLE_DEBUG

### DIFF
--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -71,7 +71,7 @@ const config = {
    * Writes verbose request info to stdout for debugging.
    * Must be disabled in production for reasonable performance.
    */
-  debug: process.env.SITECORE_ENABLE_DEBUG || false,
+  debug: ((process.env.SITECORE_ENABLE_DEBUG || '').toLowerCase() === 'true') || false,
   /**
    * Maximum allowed proxy reply size in bytes. Replies larger than this are not sent.
    * Avoids starving the proxy of memory if large requests are proxied.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At the moment, setting the `SITECORE_ENABLE_DEBUG` environment variable to anything will enable debug, even if we set it to "false".

This ensures that we only enable debug if `SITECORE_ENABLE_DEBUG` is set to "true" (independently of case)

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that users can set `SITECORE_ENABLE_DEBUG` to "false" to disable SSR debug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In our local implementation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
