### PR TITLE
React sample - set i18n init lang to prevent SSR hydration from re-rendering app

### DIFF
--- a/samples/react/src/index.js
+++ b/samples/react/src/index.js
@@ -11,6 +11,8 @@ import i18ninit from './i18n';
 
 let renderFunction = ReactDOM.render;
 
+let initLanguage = config.defaultLanguage;
+
 /*
   SSR Data
   If we're running in a server-side rendering scenario,
@@ -35,6 +37,9 @@ if (__JSS_STATE__) {
 
   // when React initializes from a SSR-based initial state, you need to render with `hydrate` instead of `render`
   renderFunction = ReactDOM.hydrate;
+
+  // set i18n language SSR state language instead of static config default language
+  initLanguage = __JSS_STATE__.sitecore.context.language;
 }
 
 /*
@@ -54,7 +59,7 @@ const graphQLClient = GraphQLClientFactory(config.graphQLEndpoint, false, initia
 */
 // initialize the dictionary, then render the app
 // note: if not making a multlingual app, the dictionary init can be removed.
-i18ninit().then(() => {
+i18ninit(initLanguage).then(() => {
   // HTML element to place the app into
   const rootElement = document.getElementById('root');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set i18n initial language based on SSR language or static config defaultLanguage to prevent re-renders in multi-lingual apps during the hydration process. 

## Motivation
To fix the flicker after initial page load issue when using the React sample. (This issue may exist in the other samples as well.)

## How Has This Been Tested?
I have tested local Sitecore 9.3 instance with a JSS 13.0 site and debug via chrome dev tools. 
My change simply initializes the language for i18ninit by pulling the SSR language from JSS_STATE, or using the config defaultLanguage setting.  
The comments in code seem to support this, but I feel this could be introduced to prevent others from experiencing this issue OOTB.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
