### PR TITLE
Vue sample Specimen component updated with correct implementation path

### DIFF
--- a/samples/vue/src/components/Styleguide/Styleguide-Specimen.vue
+++ b/samples/vue/src/components/Styleguide/Styleguide-Specimen.vue
@@ -9,7 +9,7 @@
 
     <p>
       <small>
-        Implementation: <code>/src/components/{{ rendering.componentName }}/index.js</code>
+        Implementation: <code>/src/components/Styleguide/{{ rendering.componentName }}.vue</code>
         <br />
         Definition: <code>/sitecore/definitions/components/{{ rendering.componentName }}.sitecore.js</code>
       </small>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Vue sample Specimen component was displaying an incorrect implementation path.

Example:
**Single-Line Text**
Implementation: `/src/components/Styleguide-FieldUsage-Text/index.js`

But the actual path to this component src should be: 
Implementation: `/src/components/Styleguide/Styleguide-FieldUsage-Text.vue`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
