### PR TITLE
Vue sample app - set i18n initial language based on SSR language or s…

### DIFF
--- a/samples/vue/src/main.js
+++ b/samples/vue/src/main.js
@@ -1,7 +1,10 @@
 import i18ninit from './i18n';
 import { createApp } from './createApp';
+import config from './temp/config';
 
 /* eslint-disable no-underscore-dangle */
+
+let initLanguage = config.defaultLanguage;
 
 /*
   SSR Data
@@ -13,19 +16,21 @@ import { createApp } from './createApp';
 
   SSR is initiated from /server/server.js.
 */
+let __JSS_STATE__ = null;
+const ssrRawJson = document.getElementById('__JSS_STATE__');
+if (ssrRawJson) {
+  __JSS_STATE__ = JSON.parse(ssrRawJson.innerHTML);
+}
+if (__JSS_STATE__) {
+  // set i18n language SSR state language instead of static config default language
+  initLanguage = __JSS_STATE__.sitecore.context.language;
+}
 
 // initialize the dictionary, then render the app
 // note: if not making a multlingual app, the dictionary init can be removed.
-i18ninit().then((i18n) => {
+i18ninit(initLanguage).then((i18n) => {
   // HTML element to place the app into
   const rootElement = document.getElementById('root');
-
-  // retrieve the initial app state if it is defined
-  let __JSS_STATE__ = null;
-  const ssrRawJson = document.getElementById('__JSS_STATE__');
-  if (ssrRawJson) {
-    __JSS_STATE__ = JSON.parse(ssrRawJson.innerHTML);
-  }
 
   const initialState = __JSS_STATE__ || null;
 


### PR DESCRIPTION
## Description
Vue sample - Set i18n initial language based on SSR language or static config defaultLanguage to prevent re-renders in multi-lingual apps during the hydration process. (Same fix as #330, but for Vue sample app)

## Motivation
To fix the flicker after initial page load issue when using the Vue sample.

## How Has This Been Tested?
I have tested local Sitecore 9.3 instance with a JSS 13.0 site and debug via chrome dev tools.
My change simply initializes the language for i18ninit by pulling the SSR language from JSS_STATE, or using the config defaultLanguage setting.
The comments in code seem to support this, but I feel this could be introduced to prevent others from experiencing this issue OOTB.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
