### PR TITLE
Feature/section classname

### DIFF
--- a/packages/sitecore-jss-forms/src/FormField.ts
+++ b/packages/sitecore-jss-forms/src/FormField.ts
@@ -1,5 +1,5 @@
 import { HtmlFormField } from './HtmlFormField';
-import { InputViewModel, TitleFieldViewModel, ViewModel } from './ViewModel';
+import { InputViewModel, TitleFieldViewModel, ViewModel, FieldViewModel } from './ViewModel';
 
 export interface FormField<TViewModel extends ViewModel = ViewModel> {
   model: TViewModel;
@@ -29,9 +29,8 @@ export function instanceOfButtonFormField(object: FormField): object is ButtonFo
   return 'buttonField' in object;
 }
 
-export interface FormFieldSection extends FormField<ViewModel> {
+export interface FormFieldSection extends FormField<FieldViewModel> {
   fields: FormField[];
-  cssClass?: string;
 }
 
 export function instanceOfFormFieldSection(object: FormField): object is FormFieldSection {

--- a/packages/sitecore-jss-forms/src/FormField.ts
+++ b/packages/sitecore-jss-forms/src/FormField.ts
@@ -31,6 +31,7 @@ export function instanceOfButtonFormField(object: FormField): object is ButtonFo
 
 export interface FormFieldSection extends FormField<ViewModel> {
   fields: FormField[];
+  cssClass?: string;
 }
 
 export function instanceOfFormFieldSection(object: FormField): object is FormFieldSection {

--- a/packages/sitecore-jss-react-forms/src/components/field-templates/section.tsx
+++ b/packages/sitecore-jss-react-forms/src/components/field-templates/section.tsx
@@ -6,7 +6,7 @@ const Section: React.FunctionComponent<FieldProps<FormFieldSection>> = ({
   field,
   fieldFactory,
 }) => (
-  <fieldset className={field.cssClass}>
+  <fieldset className={field.model.cssClass}>
     {field.fields.map(fieldFactory)}
   </fieldset>
 );

--- a/packages/sitecore-jss-react-forms/src/components/field-templates/section.tsx
+++ b/packages/sitecore-jss-react-forms/src/components/field-templates/section.tsx
@@ -6,7 +6,7 @@ const Section: React.FunctionComponent<FieldProps<FormFieldSection>> = ({
   field,
   fieldFactory,
 }) => (
-  <fieldset>
+  <fieldset className={field.cssClass}>
     {field.fields.map(fieldFactory)}
   </fieldset>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modified the section field template to use FormFieldSection in order to pass cssClass to the fieldset element and be able to customize the styles for it. 

## Motivation
Event though the sections in the form editor allow for setting a css class, it does not pass it down to the component.
Sitecore Case nr.: CS0178480

## How Has This Been Tested?
a forms was created in the forms editor. Added classes to sections. Was able to verify the fieldset gets the class assigned <fieldset class="test">

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
