### PR TITLE
Bug/duplicate function implementation

### DIFF
--- a/packages/sitecore-jss-angular-schematics/src/jss-component/manifest-files/sitecore/definitions/components/__name@dasherize__.sitecore.ts
+++ b/packages/sitecore-jss-angular-schematics/src/jss-component/manifest-files/sitecore/definitions/components/__name@dasherize__.sitecore.ts
@@ -4,7 +4,7 @@ import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore
  * Adds the <%= name %> component to the disconnected manifest.
  * This function is invoked by convention (*.sitecore.ts) when `jss manifest` is run.
  */
-export default function(manifest: Manifest) {
+export default function <%= name %>(manifest: Manifest) {
   manifest.addComponent({
     name: '<%= classify(name) %>',
     icon: SitecoreIcon.DocumentTag,

--- a/samples/angular/sitecore/definitions/component-content.sitecore.ts
+++ b/samples/angular/sitecore/definitions/component-content.sitecore.ts
@@ -22,7 +22,7 @@ export default function addComponentContentToManifest(manifest: Manifest): Promi
 
   return mergeFs(startPath)
     .then((result) => {
-      const items = convertToItems(
+      const items = convertToComponentItems(
         result,
         resolvePath(startPath),
         rootItemName,
@@ -40,8 +40,8 @@ export default function addComponentContentToManifest(manifest: Manifest): Promi
 /**
  * Maps filesystem content data into manifest content item data.
  */
-function convertToItems(data: MergeFsResult, basePath: string, rootItemName: string, language: string): ItemDefinition {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+function convertToComponentItems(data: MergeFsResult, basePath: string, rootItemName: string, language: string): ItemDefinition {
+  const itemPath = convertPhysicalComponentPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result: TemporaryItemDefinition;
@@ -78,7 +78,7 @@ function convertToItems(data: MergeFsResult, basePath: string, rootItemName: str
   // recursively process child paths
   if (data.folders.length > 0) {
     result.children = data.folders
-      .map((folder) => convertToItems(folder, basePath, rootItemName, language))
+      .map((folder) => convertToComponentItems(folder, basePath, rootItemName, language))
       .filter((item) => item); // remove null results
   }
 
@@ -89,7 +89,7 @@ function convertToItems(data: MergeFsResult, basePath: string, rootItemName: str
  * Converts a physical filesystem path into a relative Sitecore item path.
  * i.e. if physicalPath = /var/log and basePath = /var, this returns /log.
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath: string, basePath: string) {
+function convertPhysicalComponentPathToItemRelativePath(physicalPath: string, basePath: string) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /

--- a/samples/angular/sitecore/definitions/content.sitecore.ts
+++ b/samples/angular/sitecore/definitions/content.sitecore.ts
@@ -18,7 +18,7 @@ export default function addContentToManifest(manifest: Manifest): Promise<any> {
 
   return mergeFs(startPath)
     .then((result) => {
-      const items = convertToItems(
+      const items = convertToContentItems(
         result,
         resolvePath(startPath),
         rootItemName,
@@ -36,8 +36,8 @@ export default function addContentToManifest(manifest: Manifest): Promise<any> {
 /**
  * Maps filesystem content data into manifest content item data.
  */
-function convertToItems(data: MergeFsResult, basePath: string, rootItemName: string, language: string): ItemDefinition {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+function convertToContentItems(data: MergeFsResult, basePath: string, rootItemName: string, language: string): ItemDefinition {
+  const itemPath = convertPhysicalContentPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result;
@@ -74,7 +74,7 @@ function convertToItems(data: MergeFsResult, basePath: string, rootItemName: str
   // recursively process child paths
   if (data.folders.length > 0) {
     result.children = data.folders
-      .map((folder) => convertToItems(folder, basePath, rootItemName, language))
+      .map((folder) => convertToContentItems(folder, basePath, rootItemName, language))
       .filter((item) => item); // remove null results
   }
 
@@ -85,7 +85,7 @@ function convertToItems(data: MergeFsResult, basePath: string, rootItemName: str
  * Converts a physical filesystem path into a relative Sitecore item path.
  * i.e. if physicalPath = /var/log and basePath = /var, this returns /log.
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath: string, basePath: string) {
+function convertPhysicalContentPathToItemRelativePath(physicalPath: string, basePath: string) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /

--- a/samples/react/sitecore/definitions/component-content.sitecore.js
+++ b/samples/react/sitecore/definitions/component-content.sitecore.js
@@ -44,7 +44,7 @@ export default function addComponentContentToManifest(manifest) {
  * @returns {ItemDefinition}
  */
 function convertToItems(data, basePath, rootItemName, language) {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+  const itemPath = convertPhysicalPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result;
@@ -94,7 +94,7 @@ function convertToItems(data, basePath, rootItemName, language) {
  * @param {string} physicalPath
  * @param {string} basePath
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath, basePath) {
+function convertPhysicalPathToItemRelativePath(physicalPath, basePath) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /

--- a/samples/react/sitecore/definitions/content.sitecore.js
+++ b/samples/react/sitecore/definitions/content.sitecore.js
@@ -44,7 +44,7 @@ export default function addContentToManifest(manifest) {
  * @returns {ItemDefinition}
  */
 function convertToItems(data, basePath, rootItemName, language) {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+  const itemPath = convertPhysicalPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result;
@@ -94,7 +94,7 @@ function convertToItems(data, basePath, rootItemName, language) {
  * @param {string} physicalPath
  * @param {string} basePath
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath, basePath) {
+function convertPhysicalPathToItemRelativePath(physicalPath, basePath) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /

--- a/samples/vue/sitecore/definitions/component-content.sitecore.js
+++ b/samples/vue/sitecore/definitions/component-content.sitecore.js
@@ -44,7 +44,7 @@ export default function addComponentContentToManifest(manifest) {
  * @returns {ItemDefinition}
  */
 function convertToItems(data, basePath, rootItemName, language) {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+  const itemPath = convertPhysicalPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result;
@@ -94,7 +94,7 @@ function convertToItems(data, basePath, rootItemName, language) {
  * @param {string} physicalPath
  * @param {string} basePath
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath, basePath) {
+function convertPhysicalPathToItemRelativePath(physicalPath, basePath) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /

--- a/samples/vue/sitecore/definitions/content.sitecore.js
+++ b/samples/vue/sitecore/definitions/content.sitecore.js
@@ -44,7 +44,7 @@ export default function addContentToManifest(manifest) {
  * @returns {ItemDefinition}
  */
 function convertToItems(data, basePath, rootItemName, language) {
-  const itemPath = convertPhsyicalPathToItemRelativePath(data.path, basePath);
+  const itemPath = convertPhysicalPathToItemRelativePath(data.path, basePath);
   const name = itemPath.substr(itemPath.lastIndexOf('/') + 1);
 
   let result;
@@ -94,7 +94,7 @@ function convertToItems(data, basePath, rootItemName, language) {
  * @param {string} physicalPath
  * @param {string} basePath
  */
-function convertPhsyicalPathToItemRelativePath(physicalPath, basePath) {
+function convertPhysicalPathToItemRelativePath(physicalPath, basePath) {
   const targetPathSeparator = '/';
 
   // normalize path separators to /


### PR DESCRIPTION
## Description
1. With a fresh Angular project created from `@sitecore-jss/sitecore-jss-cli`, while running in disconnected mode -  if there any changes made to the **data/*.yml** files, it will result in: `error TS2393: Duplicate function implementation.` 
- By providing unique function names in `component-content.sitecore.ts` & `content.sitecore.ts `; as well as updating the schematics in `__name@dasherize__.sitecore.ts ` to give a name to the export default function, the error is resolved.

2. I also discovered a typo in one of the function names:
- `Phsyical` should be spelled `Physical` across all seed projects.

## Motivation
When Typescript errors out in the console, the browser does not refresh, and you need to restart the watch process each time, which is very time-consuming.

These changes fix #326 

## How Has This Been Tested?
`npm run reset` & `npm run test-packages` have run and passed on this branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.