### PR TITLE
Fix bug (#141) XP editor for react requires save and refresh before adding new renderings

### DIFF
--- a/samples/react/server/server.js
+++ b/samples/react/server/server.js
@@ -119,6 +119,10 @@ export function renderView(callback, path, data, viewBag) {
           `<head>${helmet.title.toString()}${helmet.meta.toString()}${helmet.link.toString()}`
         );
 
+        // replace phkey attribute with key attribute so that newly added renderings
+        // show correct placeholders, so save and refresh won't be needed after adding each rendering
+        html = html.replace(new RegExp('phkey', 'g'), 'key');
+
         callback(null, { html });
       })
       .catch((error) => callback(error, null));


### PR DESCRIPTION
Fixes issue #141: when working in XP editor in the react version, after adding a rendering with a placeholder, another rendering cannot be added in the freshly loaded placeholder but save and refresh of the page is required

## Description
The issue is caused by the fact that the very important key attribute of the `<code>` DOM element that represents the placeholder is missing after SSR. Because it is a react special prop it cannot be set directly as a prop and then transferred as an attribute and that's why in the sitecore jss library for react this problem is solved by adding the key attribute by directly modifying the DOM on the client side. But after a rendering is freshly added through SSR, it is not hydrated and the lifecycle methods are not running, so the key attribute is never added. 
The fix replaces phkey attribute with key attribute directly in the html that is about to be sent to XP editor to inject. 

## Motivation
It is quite annoying to have to save your page on each step if you want to add renderings within other renderings. It is much faster and smoother to be able to add multiple renderings in one go.

Fixes issue #141 

## How Has This Been Tested?
Tested manually on my local environment

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
