### PR TITLE
Responsive image srcset fallback with src output

### DIFF
--- a/packages/sitecore-jss-react/src/components/Image.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.test.tsx
@@ -42,6 +42,35 @@ describe('<Image />', () => {
     });
   });
 
+  describe('with responsive image object', () => {
+    const props = {
+      media: {
+        src: '/assets/img/test0.png',
+      },
+      srcSet: [{ mw: 100 }, { mw: 300 }],
+      sizes: '(min-width: 960px) 300px, 100px',
+      id: 'some-id',
+      className: 'the-dude-abides',
+    };
+
+    const rendered = mount(<Image {...props} />).find('img');
+
+    it('should render <img /> with needed img tags', () => {
+      expect(rendered).to.have.length(1);
+      expect(rendered.prop('src')).to.equal(props.media.src);
+      expect(rendered.prop('srcSet')).to.equal('/assets/img/test0.png?mw=100 100w, /assets/img/test0.png?mw=300 300w');
+      expect(rendered.prop('sizes')).to.equal('(min-width: 960px) 300px, 100px');
+    });
+
+    it('should render <img /> with non-media props', () => {
+      expect(rendered.prop('id')).to.equal(props.id);
+    });
+
+    it('should render <img /> with style and className props', () => {
+      expect(rendered.prop('className')).to.eql(props.className);
+    });
+  });
+
   describe('with "value" property value', () => {
     const props = {
       media: { value: { src: '/assets/img/test0.png', alt: 'my image' } },

--- a/packages/sitecore-jss-react/src/components/Image.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.tsx
@@ -97,9 +97,9 @@ const getImageAttrs = (
   if (srcSet) {
     // replace with HTML-formatted srcset, including updated image URLs
     newAttrs.srcSet = mediaApi.getSrcSet(resolvedSrc, srcSet, imageParams);
-  } else {
-    newAttrs.src = resolvedSrc;
   }
+  // always output original src as fallback for older browsers
+  newAttrs.src = resolvedSrc;
   return newAttrs;
 };
 


### PR DESCRIPTION
## Description
Adding `srcSet` to \<Image> Component removes the `src` Attribute.
This PR will always output the `src` Attribute, even when a `srcSet` Object is passed.

This will improve the support for older Browsers, since they might don't support `srcSet` (like IE11). Using the Progressive Enhancement Approach newer Browsers can benefit from the `srcSet` and will ignore the `src` Attribute.

## Motivation
Improve Support for older Browsers without the need for a `srcSet` Polyfill - which is difficult to implement when using Jss <Link> or Router Links.

## How Has This Been Tested?
Tests for Image updated to test for `srcSet` / `sizes` Attributes output.
I used the same values as in the Styleguide Image Example.
Running `npm run test` inside `root` or `/packages/sitecore-jss-react` will run the new test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
