### PR TITLE
Fixes withSitecoreContext typescript definition

### DIFF
--- a/packages/sitecore-jss-react/src/components/SitecoreContext.test.tsx
+++ b/packages/sitecore-jss-react/src/components/SitecoreContext.test.tsx
@@ -9,8 +9,11 @@ import { SitecoreContext, SitecoreContextFactory } from './SitecoreContext';
 import { ComponentFactory } from './sharedTypes';
 import { withSitecoreContext, ComponentConsumerProps } from '../enhancers/withSitecoreContext'
 
-const NestedComponent: FC<ComponentConsumerProps> = (props: ComponentConsumerProps) => <div>{props.sitecoreContext && 'test'}</div>;
-const NestedComponentWithContext: FC = withSitecoreContext()(NestedComponent);
+interface NestedComponentProps extends ComponentConsumerProps {
+  anotherProperty?: string,
+}
+const NestedComponent: FC<NestedComponentProps> = (props: NestedComponentProps) => <div>{props.sitecoreContext && 'test'}</div>;
+const NestedComponentWithContext = withSitecoreContext()(NestedComponent);
 
 const components = new Map();
 const mockComponentFactory: ComponentFactory = name => components.get(name);

--- a/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
@@ -18,19 +18,19 @@ export type WithSitecoreContextHocProps<ComponentProps> = Pick<ComponentProps, E
 
 export function withSitecoreContext(options?: WithSitecoreContextOptions) {
 
-  return function withSitecoreContextHoc<ComponentProps extends ComponentConsumerProps>(Component: React.ComponentType<ComponentConsumerProps>) {
+  return function withSitecoreContextHoc<ComponentProps extends ComponentConsumerProps>(Component: React.ComponentType<ComponentProps>) {
 
     return function WithSitecoreContext(props: WithSitecoreContextHocProps<ComponentProps>) {
 
       return (
         <SitecoreContextReactContext.Consumer>
-          {context => <Component {...props}
+          {context => <Component {...props as ComponentProps}
                                  sitecoreContext={context.context}
                                  updateSitecoreContext={options && options.updatable && context.setSitecoreContext} />}
         </SitecoreContextReactContext.Consumer>
       );
     };
 
-    
+
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current typescript definition is forcing the component to have props of type `ComponentConsumerProps` instead of just forcing to extend that type.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Components should be able use more properties that the ones just on `ComponentConsumerProps`, this fixes that

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Typescript doesn't complain any more and tests pass. Assuming that users are actually including the context properties in their component props, there should be no impact.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
