### PR TITLE
Vue sample - SSR - fixed hydration bailouts

### DIFF
--- a/samples/vue/server/server.js
+++ b/samples/vue/server/server.js
@@ -119,7 +119,7 @@ export function renderView(callback, path, data, viewBag) {
         // or else you're vulnerable to XSS.
         let html = indexTemplate;
         // write the Vue app
-        html = assertReplace(html, '<div id="root"></div>', `<div id="root">${renderedApp}</div>`);
+        html = assertReplace(html, '<div id="root"></div>', `${renderedApp}`);
         // write the string version of our state
         html = assertReplace(
           html,
@@ -143,8 +143,7 @@ export function renderView(callback, path, data, viewBag) {
             ${meta.link.text()}
             ${meta.style.text()}
             ${meta.script.text()}
-            ${meta.noscript.text()}
-          </head>`
+            ${meta.noscript.text()}`
         );
         html = assertReplace(html, '<body>', `<body ${meta.bodyAttrs.text()}>`);
 

--- a/samples/vue/src/AppRoot.vue
+++ b/samples/vue/src/AppRoot.vue
@@ -1,7 +1,7 @@
 <!--
 -->
 <template>
-  <div>
+  <div id="root">
     <context-view :visible="contextViewVisible" />
     <!-- 'router-view' is a "global" component that is injected into the Vue component registry by vue-router. -->
     <router-view v-if="!languageIsChanging" />


### PR DESCRIPTION
## Description
When the server is rendering the template the id="root" element should be the first element of the AppRoot.vue element but it was set on a div enclosing the rendered app.
when the ssr rendered app was mounted in the client there was a dom-tree mismatch that forced an hydration bailout and complete dom refresh.

Also did a fix on a replace that caused two head tag terminations to be present on a server rendered page

## Motivation
Improves website loading performance when using ssr 

## How Has This Been Tested?
It was tested in sitecore 9.1 with jss 11.0, compiling in development to check the vue hydration bailout messages and running in integrated mode.
I patched the 11.0 version changes to this version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
