### PR TITLE
Allow using SitecoreContext with a hook

### DIFF
--- a/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
@@ -32,3 +32,22 @@ export function withSitecoreContext(options?: WithSitecoreContextOptions) {
     };
   };
 }
+
+/**
+ * This hook grants acess to the current SiteCore page context
+ * by default JSS includes the following properties in this context:
+ * - pageEditing - Provided by Layout Service, a boolean indicating whether the route is being accessed via the Experience Editor.
+ * - pageState - Like pageEditing, but a string: normal, preview or edit.
+ * - site - Provided by Layout Service, an object containing the name of the current Sitecore site context.
+ *
+ * @see https://jss.sitecore.com/docs/techniques/extending-layout-service/layoutservice-extending-context
+ *
+ * @example
+ * const EditMode = () => {
+ *    const {pageEditing} = useSitecoreContext();
+ *    return <span>Edit Mode is {pageEditing ? 'active' : 'inactive'}</span>
+ * }
+ */
+export function useSitecoreContext() {
+  return React.useContext(SitecoreContextReactContext).context;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On February 16, 2019, React `16.8` was released by facebook and added `hooks` to make functional components more powerfull.

This pull request allows using the `SitecoreContext` with way less effort than the current High Order Component approach `withSitecoreContext`:

```ts
const EditMode = () => {
   const {pageEditing} = useSitecoreContext();
   return <span>Edit Mode is {pageEditing ? 'active' : 'inactive'}</span>
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This feature has **not** been tested.   
If you think this would be a good addition I will go on with testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
