### PR TITLE
[Vue Sample] Fix  route changes with path and a hash

### DIFF
--- a/samples/vue/src/RouteHandler.vue
+++ b/samples/vue/src/RouteHandler.vue
@@ -112,10 +112,10 @@ export default {
   },
   watch: {
     // watch for a change in the 'route' prop
-    route(newRoute) {
+    route(newRoute, oldRoute) {
       // if the route contains a hash value, assume the URL is a named anchor/bookmark link, e.g. /page#anchorId.
       // in that scenario, we don't want to fetch new route data but instead allow default browser behavior.
-      if (newRoute.hash !== '') {
+      if (newRoute.hash !== '' && newRoute.path === oldRoute.path) {
         return;
       }
       // if in experience editor - force reload instead of route data update


### PR DESCRIPTION


## Description
When the route changes to a new url including a new path and a new hash the new page isn't being retrieved because the all route changes are being ignored when then contain a hash. This should only happen when the path of the newRoute equals the path of the old route.

## How Has This Been Tested?
Manually, locally connected dev mode

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
