### PR TITLE
Allow for canactivate and resolvers

### DIFF
--- a/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
+++ b/docs/data/routes/docs/client-frameworks/angular/angular-tips/en.md
@@ -47,7 +47,7 @@ If you're using the default code-generated `app-components.module.ts` that's all
       // in this case, 'path' = the component name, loadChildren = the module path to load for it
       // this is exactly like lazy loaded routes, in fact it uses the router under the hood to do it.
       // loadChildren is the relative path to the module, with the hash and then the name of the exported module class.
-      { path: 'My', loadChildren: './my/my.module#MyModule'},
+      { path: 'My', loadChildren: import('./my/my.module').then(mod => mod.MyModule),
     ]),
   ],
   exports: [
@@ -120,8 +120,40 @@ There aren't changes in your component module. If you use multiple components la
     JssModule.withComponents([
       // non-lazy components
     ], [
-      { path: 'FirstComponent', loadChildren: './my/my.module#MyModule'},
-      { path: 'SecondComponent', loadChildren: './my/my.module#MyModule'},
+      { path: 'FirstComponent', loadChildren: import('./my/my.module').then(mod => mod.MyModule)},
+      { path: 'SecondComponent', loadChildren: import('./my/my.module').then(mod => mod.MyModule)},
+    ]),
+  ],
+  exports: [
+    JssModule,
+    AppComponentsSharedModule,
+  ],
+  declarations: [
+    // non-lazy components
+  ],
+})
+export class AppComponentsModule { }
+```
+
+Components can also have a  for loading using canActivate and canResolve. Classes can be provided as well, they should be derived from JssCanActivate and/or JssResolve.
+
+```js
+@NgModule({
+  imports: [
+    AppComponentsSharedModule,
+    JssModule.withComponents([
+      // non-lazy components
+    ], [
+      { 
+        path: 'FirstComponent', 
+        loadChildren: import('./my/my.module').then(mod => mod.MyModule),
+        canActivate: (input: GuardInput) => { return of(true) }
+      },
+      { 
+        path: 'SecondComponent', 
+        loadChildren: import('./my/my.module').then(mod => mod.MyModule),
+        resolve: (input: GuardInput) => { return of(true) }
+      },
     ]),
   ],
   exports: [

--- a/packages/sitecore-jss-angular/src/components/data-resolver-factory.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/data-resolver-factory.spec.ts
@@ -1,0 +1,58 @@
+import { Injector } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { dataResolverFactory } from './data-resolver-factory';
+import { DataResolver, DATA_RESOLVER, JssResolve } from './placeholder.token';
+
+const mockSyncResolver: JssResolve<string> = {
+  resolve() {
+    return 'Sync';
+  },
+};
+
+class MockAsyncResolver implements JssResolve<string> {
+  resolve() {
+    return Promise.resolve('Async');
+  }
+}
+
+describe('dataResolverFactory', () => {
+  let resolver: DataResolver;
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        MockAsyncResolver,
+        {
+          provide: DATA_RESOLVER,
+          useFactory: dataResolverFactory,
+          deps: [Injector, ActivatedRoute, Router],
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    resolver = TestBed.get(DATA_RESOLVER);
+  });
+
+  it('Resolves data from sync, async, literal and type resolvers', (done) => {
+    const pending = resolver([
+      {
+        resolve: { sync: mockSyncResolver, async: MockAsyncResolver },
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    pending.then((rendering) => {
+      const first = rendering[0];
+      expect(first.data).toEqual({
+        sync: 'Sync',
+        async: 'Async',
+      });
+
+      done();
+    });
+  });
+});

--- a/packages/sitecore-jss-angular/src/components/data-resolver-factory.ts
+++ b/packages/sitecore-jss-angular/src/components/data-resolver-factory.ts
@@ -1,0 +1,61 @@
+import { Injector, Type } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { take } from 'rxjs/operators';
+import { ComponentFactoryResult } from '../jss-component-factory.service';
+import { wrapIntoObservable } from '../utils';
+import { JssResolve } from './placeholder.token';
+import { ComponentRendering } from '@sitecore-jss/sitecore-jss';
+
+export function dataResolverFactory(
+  injector: Injector,
+  activatedRoute: ActivatedRoute,
+  router: Router
+) {
+  function _getResolverInstance(resolver: JssResolve<any> | Type<JssResolve<any>>) {
+    return 'resolve' in resolver ? resolver : injector.get(resolver);
+  }
+
+  function _collectResolverInstances(
+    factory: ComponentFactoryResult
+  ): Array<[string, JssResolve<any>]> {
+    if (factory.resolve != null) {
+      const resolve = factory.resolve;
+      return Object.keys(factory.resolve).map(
+        (key): [string, JssResolve<any>] => [key, _getResolverInstance(resolve[key])]
+      );
+    }
+
+    return [];
+  }
+
+  function _resolveData(resolver: JssResolve<any>, factory: ComponentFactoryResult) {
+    const data = resolver.resolve({
+      activatedRoute: activatedRoute.snapshot,
+      routerState: router.routerState.snapshot,
+      rendering: factory.componentDefinition as ComponentRendering,
+    });
+    const data$ = wrapIntoObservable(data);
+
+    return data$.pipe(take(1)).toPromise();
+  }
+
+  return function resolveData(factories: ComponentFactoryResult[]) {
+    return Promise.all(
+      factories.map((factory) => {
+        const resolvers = _collectResolverInstances(factory);
+        const pendingData = resolvers.map(([key, resolver]) =>
+          _resolveData(resolver, factory).then((data): [string, any] => [key, data])
+        );
+
+        return Promise.all(pendingData)
+          .then((allData) =>
+            allData.reduce<Record<string, any>>((acc, [key, data]) => {
+              acc[key] = data;
+              return acc;
+            }, {})
+          )
+          .then((data) => ({ factory, data }));
+      })
+    );
+  };
+}

--- a/packages/sitecore-jss-angular/src/components/guard-resolver-factory.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/guard-resolver-factory.spec.ts
@@ -1,0 +1,146 @@
+// tslint:disable: max-classes-per-file
+
+import { Injector } from '@angular/core';
+import { async, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Observable, of } from 'rxjs';
+import { guardResolverFactory } from './guard-resolver-factory';
+import { GUARD_RESOLVER, GuardResolver, JssCanActivate } from './placeholder.token';
+
+const createLiteralGuard = (
+  canActivate: boolean | Promise<boolean> | Observable<boolean>
+): JssCanActivate => ({
+  canActivate() {
+    return canActivate;
+  },
+});
+
+class MockSyncTrueGuard implements JssCanActivate {
+  canActivate() {
+    return true;
+  }
+}
+
+class MockSyncFalseGuard implements JssCanActivate {
+  canActivate() {
+    return false;
+  }
+}
+
+class MockAsyncTrueGuard implements JssCanActivate {
+  canActivate() {
+    return Promise.resolve(true);
+  }
+}
+
+class MockAsyncFalseGuard implements JssCanActivate {
+  canActivate() {
+    return of(false);
+  }
+}
+
+describe('guardResolverFactory', () => {
+  let resolver: GuardResolver;
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        MockSyncTrueGuard,
+        MockSyncFalseGuard,
+        MockAsyncTrueGuard,
+        MockAsyncFalseGuard,
+        {
+          provide: GUARD_RESOLVER,
+          useFactory: guardResolverFactory,
+          deps: [Injector, ActivatedRoute, Router],
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    resolver = TestBed.get(GUARD_RESOLVER);
+  });
+
+  it('Returns rendering if single sync guard returns true', async () => {
+    const nonGuarded = await resolver([
+      {
+        canActivate: createLiteralGuard(true),
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    expect(nonGuarded.length).toBe(1);
+  });
+
+  it('Returns rendering if single async guard returns true', async () => {
+    const nonGuarded = await resolver([
+      {
+        canActivate: MockAsyncTrueGuard,
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    expect(nonGuarded.length).toBe(1);
+  });
+
+  it('Blocks rendering if single async guard returns false', async () => {
+    const nonGuarded = await resolver([
+      {
+        canActivate: MockAsyncFalseGuard,
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    expect(nonGuarded.length).toBe(0);
+  });
+
+  it('Returns rendering if multiple guards all return true', async () => {
+    const nonGuarded = await resolver([
+      {
+        canActivate: [MockAsyncTrueGuard, createLiteralGuard(true), MockSyncTrueGuard],
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    expect(nonGuarded.length).toBe(1);
+  });
+
+  it('Does not return rendering if one guard returns false', async () => {
+    const nonGuarded = await resolver([
+      {
+        canActivate: [MockAsyncTrueGuard, createLiteralGuard(false), MockSyncTrueGuard],
+        componentDefinition: {} as any,
+      },
+    ]);
+
+    expect(nonGuarded.length).toBe(0);
+  });
+
+  it('Only returns renderings of which all guards return true', async () => {
+    const compFactoryResults = [
+      {
+        canActivate: [MockAsyncTrueGuard, createLiteralGuard(false), MockSyncTrueGuard],
+        componentDefinition: 'Rendering 1' as any,
+      },
+      {
+        canActivate: [MockAsyncTrueGuard, createLiteralGuard(true), MockSyncTrueGuard],
+        componentDefinition: 'Rendering 2' as any,
+      },
+      {
+        canActivate: [MockAsyncTrueGuard, createLiteralGuard(true), MockSyncFalseGuard],
+        componentDefinition: 'Rendering 3' as any,
+      },
+      {
+        canActivate: [MockAsyncFalseGuard, createLiteralGuard(true), MockSyncTrueGuard],
+        componentDefinition: 'Rendering 4' as any,
+      },
+    ];
+
+    const nonGuarded = await resolver(compFactoryResults);
+
+    expect(nonGuarded.length).toBe(1);
+    expect(nonGuarded[0]).toBe(compFactoryResults[1]);
+  });
+});

--- a/packages/sitecore-jss-angular/src/components/guard-resolver-factory.ts
+++ b/packages/sitecore-jss-angular/src/components/guard-resolver-factory.ts
@@ -1,0 +1,74 @@
+import { Injector, Type } from '@angular/core';
+import { ActivatedRoute, Router, UrlTree } from '@angular/router';
+import { take, mergeMap } from 'rxjs/operators';
+import { ComponentFactoryResult } from '../jss-component-factory.service';
+import { wrapIntoObservable } from '../utils';
+import { JssCanActivate } from './placeholder.token';
+import { ComponentRendering } from '@sitecore-jss/sitecore-jss';
+import { throwError, of } from 'rxjs';
+
+function isRedirectValue(
+  value: boolean | string | string[] | UrlTree
+): value is string | string[] | UrlTree {
+  return value instanceof UrlTree || typeof value === 'string' || Array.isArray(value);
+}
+
+export function guardResolverFactory(
+  injector: Injector,
+  activatedRoute: ActivatedRoute,
+  router: Router
+) {
+  function _getGuardInstance(guard: JssCanActivate | Type<JssCanActivate>) {
+    return 'canActivate' in guard ? guard : injector.get(guard);
+  }
+
+  function _collectGuardInstances(factory: ComponentFactoryResult): JssCanActivate[] {
+    if (factory.canActivate != null) {
+      return Array.isArray(factory.canActivate)
+        ? factory.canActivate.map(_getGuardInstance)
+        : [_getGuardInstance(factory.canActivate)];
+    }
+
+    return [];
+  }
+
+  function _resolveGuard(guard: JssCanActivate, factory: ComponentFactoryResult) {
+    const guardValue = guard.canActivate({
+      activatedRoute: activatedRoute.snapshot,
+      routerState: router.routerState.snapshot,
+      rendering: factory.componentDefinition as ComponentRendering,
+    });
+
+    const canActivate$ = wrapIntoObservable(guardValue);
+
+    return canActivate$
+      .pipe(
+        take(1),
+        mergeMap((value) => {
+          if (isRedirectValue(value)) {
+            return throwError(value);
+          } else {
+            return of(value);
+          }
+        })
+      )
+      .toPromise();
+  }
+
+  return function resolveGuards(factories: ComponentFactoryResult[]) {
+    const resolved = factories.map((factory) => {
+      const guards = _collectGuardInstances(factory);
+      const pending = guards.map((guard) => _resolveGuard(guard, factory));
+      return Promise.all(pending)
+        .then((canActive) => canActive.every((v) => v))
+        .then((canActivate) => ({
+          factory,
+          canActivate,
+        }));
+    });
+
+    return Promise.all(resolved).then((mapped) =>
+      mapped.filter((m) => m.canActivate).map((m) => m.factory)
+    );
+  };
+}

--- a/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
@@ -1,13 +1,21 @@
 // tslint:disable:max-classes-per-file
-import { Component, DebugElement, EventEmitter, Input, NgModuleFactoryLoader, Output } from '@angular/core';
+import {
+  Component,
+  DebugElement,
+  EventEmitter,
+  Input,
+  NgModuleFactoryLoader,
+  Output,
+} from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { SpyNgModuleFactoryLoader } from '@angular/router/testing';
-
+import { RouterTestingModule, SpyNgModuleFactoryLoader } from '@angular/router/testing';
 import { JssModule } from '../lib.module';
-
 import { convertedData as eeData } from '../testData/ee-data';
-import { convertedDevData as nonEeDevData, convertedLayoutServiceData as nonEeLsData } from '../testData/non-ee-data';
+import {
+  convertedDevData as nonEeDevData,
+  convertedLayoutServiceData as nonEeLsData,
+} from '../testData/non-ee-data';
 
 @Component({
   selector: 'test-placeholder',
@@ -18,8 +26,10 @@ import { convertedDevData as nonEeDevData, convertedLayoutServiceData as nonEeLs
   `,
 })
 class TestPlaceholderComponent {
-  @Input() rendering: any;
-  @Input() name: string;
+  @Input()
+  rendering: any;
+  @Input()
+  name: string;
 }
 
 @Component({
@@ -29,26 +39,28 @@ class TestPlaceholderComponent {
   `,
 })
 class TestDownloadCalloutComponent {
-  @Input() rendering: any;
+  @Input()
+  rendering: any;
 }
 
 @Component({
   selector: 'test-home',
-  styles: [ 'sc-placeholder[name="page-content"] { background-color: red }' ],
+  styles: ['sc-placeholder[name="page-content"] { background-color: red }'],
   template: `
     <sc-placeholder name="page-header" [rendering]="rendering"></sc-placeholder>
     <sc-placeholder name="page-content" [rendering]="rendering"></sc-placeholder>
   `,
 })
 class TestHomeComponent {
-  @Input() rendering: any;
+  @Input()
+  rendering: any;
 }
 
 @Component({
   selector: 'test-jumbotron',
   template: ``,
 })
-class TestJumbotronComponent { }
+class TestJumbotronComponent {}
 
 describe('<sc-placeholder />', () => {
   let fixture: ComponentFixture<TestPlaceholderComponent>;
@@ -64,15 +76,14 @@ describe('<sc-placeholder />', () => {
         TestJumbotronComponent,
       ],
       imports: [
+        RouterTestingModule,
         JssModule.withComponents([
           { name: 'DownloadCallout', type: TestDownloadCalloutComponent },
           { name: 'Home', type: TestHomeComponent },
           { name: 'Jumbotron', type: TestJumbotronComponent },
         ]),
       ],
-      providers: [
-        { provide: NgModuleFactoryLoader, value: SpyNgModuleFactoryLoader },
-      ],
+      providers: [{ provide: NgModuleFactoryLoader, value: SpyNgModuleFactoryLoader }],
     }).compileComponents();
   }));
 
@@ -103,14 +114,15 @@ describe('<sc-placeholder />', () => {
   testData.forEach((dataSet: any) => {
     describe(`with ${dataSet.label}`, () => {
       it('should render a placeholder with given key', async(() => {
-        const component = dataSet.data.sitecore.route.placeholders.main.find((c: any) => c.componentName);
+        const component = dataSet.data.sitecore.route.placeholders.main.find(
+          (c: any) => c.componentName
+        );
         const phKey = 'page-content';
         comp.name = phKey;
         comp.rendering = component;
         fixture.detectChanges();
 
-        fixture.whenStable()
-        .then(() => {
+        fixture.whenStable().then(() => {
           fixture.detectChanges();
 
           const downloadCallout = de.query(By.directive(TestDownloadCalloutComponent));
@@ -131,18 +143,16 @@ describe('<sc-placeholder />', () => {
 
         // because nested placeholders result in additional async loading _after_ whenStable,
         // we have to check for stability AGAIN internally
-        fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
 
-            fixture.whenStable()
-              .then(() => {
-                fixture.detectChanges();
-                const downloadCallout = de.query(By.directive(TestDownloadCalloutComponent));
-                expect(downloadCallout).not.toBeNull();
-                expect(downloadCallout.nativeElement.innerHTML).toContain('Download');
-              });
+          fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            const downloadCallout = de.query(By.directive(TestDownloadCalloutComponent));
+            expect(downloadCallout).not.toBeNull();
+            expect(downloadCallout.nativeElement.innerHTML).toContain('Download');
           });
+        });
       }));
     });
   });
@@ -155,17 +165,16 @@ describe('<sc-placeholder />', () => {
     comp.rendering = component;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
 
-        const eeChrome = de.query(By.css(`[chrometype="placeholder"][kind="open"][id="${phKey}"]`));
-        expect(eeChrome).not.toBeNull();
+      const eeChrome = de.query(By.css(`[chrometype="placeholder"][kind="open"][id="${phKey}"]`));
+      expect(eeChrome).not.toBeNull();
 
-        const keyAttribute = eeChrome.nativeElement.getAttribute('key');
-        expect(keyAttribute).toBeDefined();
-        expect(keyAttribute).toBe(phKey);
-      });
+      const keyAttribute = eeChrome.nativeElement.getAttribute('key');
+      expect(keyAttribute).toBeDefined();
+      expect(keyAttribute).toBe(phKey);
+    });
   }));
 
   it('should copy parent style attribute', async(() => {
@@ -175,37 +184,40 @@ describe('<sc-placeholder />', () => {
     comp.rendering = component;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      // let's grab the style name from the parent
+      let parentKey = '';
+      const homeComp = de.query(By.directive(TestHomeComponent));
+      const homeAttributes = homeComp.nativeElement.attributes;
+      if (homeAttributes.length) {
+        const parentAttribute = homeComp.nativeElement.attributes.item(0).name;
+        parentKey = parentAttribute.replace('_nghost-', '');
+      }
+
+      fixture.whenStable().then(() => {
         fixture.detectChanges();
-
-        // let's grab the style name from the parent
-        let parentKey = '';
-        const homeComp = de.query(By.directive(TestHomeComponent));
-        const homeAttributes = homeComp.nativeElement.attributes;
-        if (homeAttributes.length) {
-          const parentAttribute = homeComp.nativeElement.attributes.item(0).name;
-          parentKey = parentAttribute.replace('_nghost-', '');
-        }
-
-        fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            const downloadCallout = de.query(By.directive(TestDownloadCalloutComponent));
-            expect(downloadCallout.nativeElement.attributes.item(0).name).toEqual(`_ngcontent-${parentKey}`);
-          });
+        const downloadCallout = de.query(By.directive(TestDownloadCalloutComponent));
+        expect(downloadCallout.nativeElement.attributes.item(0).name).toEqual(
+          `_ngcontent-${parentKey}`
+        );
       });
+    });
   }));
 
   it('should skip rendering unknown components', async(() => {
     const phKey = 'main';
     const route = {
       placeholders: {
-        main: [{
-          componentName: 'Home',
-        }, {
-          componentName: 'whatisthis',
-        }],
+        main: [
+          {
+            componentName: 'Home',
+          },
+          {
+            componentName: 'whatisthis',
+          },
+        ],
       },
     };
 
@@ -213,24 +225,25 @@ describe('<sc-placeholder />', () => {
     comp.rendering = route;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
 
-        expect(de.children.length).toBe(1);
+      expect(de.children.length).toBe(1);
 
-        const homeDiv = de.query(By.directive(TestHomeComponent));
-        expect(homeDiv).not.toBeNull();
-      });
+      const homeDiv = de.query(By.directive(TestHomeComponent));
+      expect(homeDiv).not.toBeNull();
+    });
   }));
 
   it('should render null for unknown placeholder', async(() => {
     const phKey = 'unknown';
     const route = {
       placeholders: {
-        main: [{
-          componentName: 'Home',
-        }],
+        main: [
+          {
+            componentName: 'Home',
+          },
+        ],
       },
     };
 
@@ -238,13 +251,12 @@ describe('<sc-placeholder />', () => {
     comp.rendering = route;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
 
-        const element = de.query(By.css('sc-placeholder')).nativeElement;
-        expect(element.children.length).toBe(0);
-      });
+      const element = de.query(By.css('sc-placeholder')).nativeElement;
+      expect(element.children.length).toBe(0);
+    });
   }));
 });
 
@@ -257,9 +269,12 @@ describe('<sc-placeholder />', () => {
 })
 class TestParentComponent {
   clickMessage = '';
-  @Input() rendering: any;
-  @Input() name: string;
-  @Input() set childMessage(message: string) {
+  @Input()
+  rendering: any;
+  @Input()
+  name: string;
+  @Input()
+  set childMessage(message: string) {
     this.inputs.childMessage = message;
   }
   public inputs = {
@@ -282,9 +297,12 @@ class TestParentComponent {
   `,
 })
 class TestChildComponent {
-  @Input() childMessage: string;
-  @Input() childNumber: number;
-  @Output() childEvent: EventEmitter<string> = new EventEmitter<string>();
+  @Input()
+  childMessage: string;
+  @Input()
+  childNumber: number;
+  @Output()
+  childEvent: EventEmitter<string> = new EventEmitter<string>();
 
   triggerEvent() {
     this.childEvent.emit('dolor');
@@ -298,19 +316,15 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [
-        TestParentComponent,
-        TestChildComponent,
-      ],
+      declarations: [TestParentComponent, TestChildComponent],
       imports: [
+        RouterTestingModule,
         JssModule.withComponents([
           { name: 'Parent', type: TestParentComponent },
           { name: 'Child', type: TestChildComponent },
         ]),
       ],
-      providers: [
-        { provide: NgModuleFactoryLoader, value: SpyNgModuleFactoryLoader },
-      ],
+      providers: [{ provide: NgModuleFactoryLoader, value: SpyNgModuleFactoryLoader }],
     });
 
     fixture = TestBed.createComponent(TestParentComponent);
@@ -338,16 +352,15 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
     comp.childMessage = expectedMessage;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
-        const childComponent = de.query(By.directive(TestChildComponent));
-        expect(childComponent.nativeElement.innerHTML).toContain(expectedMessage);
-        expect(childComponent.nativeElement.innerHTML).toContain(functionResult);
-        comp.childMessage = changedMessage;
-        fixture.detectChanges();
-        expect(childComponent.nativeElement.innerHTML).toContain(changedMessage);
-      });
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      const childComponent = de.query(By.directive(TestChildComponent));
+      expect(childComponent.nativeElement.innerHTML).toContain(expectedMessage);
+      expect(childComponent.nativeElement.innerHTML).toContain(functionResult);
+      comp.childMessage = changedMessage;
+      fixture.detectChanges();
+      expect(childComponent.nativeElement.innerHTML).toContain(changedMessage);
+    });
   }));
 
   it('should bind inputs to multiple', async(() => {
@@ -372,15 +385,14 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
     comp.childMessage = expectedMessage;
     fixture.detectChanges();
 
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
-        const childComponents = de.queryAll(By.directive(TestChildComponent));
-        expect(childComponents.length).toBe(3);
-        childComponents.forEach((childComponent) => {
-          expect(childComponent.nativeElement.innerHTML).toContain(expectedMessage);
-        });
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      const childComponents = de.queryAll(By.directive(TestChildComponent));
+      expect(childComponents.length).toBe(3);
+      childComponents.forEach((childComponent) => {
+        expect(childComponent.nativeElement.innerHTML).toContain(expectedMessage);
       });
+    });
   }));
 
   it('should bind outputs to children', async(() => {
@@ -395,14 +407,13 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
     };
     comp.name = 'children';
     fixture.detectChanges();
-    fixture.whenStable()
-      .then(() => {
-        fixture.detectChanges();
-        const button = de.query(By.css('button'));
-        button.nativeElement.click();
-        fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      const button = de.query(By.css('button'));
+      button.nativeElement.click();
+      fixture.detectChanges();
 
-        expect(de.nativeElement.innerHTML).toContain('dolor');
-      });
+      expect(de.nativeElement.innerHTML).toContain('dolor');
+    });
   }));
 });

--- a/packages/sitecore-jss-angular/src/components/placeholder.token.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.token.ts
@@ -1,9 +1,25 @@
 import { InjectionToken, Type } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  Data,
+  Resolve,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { ComponentFactoryResult } from '../jss-component-factory.service';
+import { ComponentRendering } from '../public_api';
 
 /** Registers a statically loaded component */
 export class ComponentNameAndType {
   name: string;
   type: Type<any>;
+
+  canActivate?:
+    | JssCanActivate
+    | Type<JssCanActivate>
+    | Array<JssCanActivate | Type<JssCanActivate>>;
+  resolve?: { [key: string]: JssResolve<any> | Type<JssResolve<any>> };
 }
 
 /** Registers a lazily loaded component by name and module to lazy load when it's needed */
@@ -15,6 +31,11 @@ export interface ComponentNameAndModule {
    * e.g. () => import('./path/to/lazyloadedcomponent.module').then(m => m.LazyLoadedComponentModuleExportName)
    */
   loadChildren: () => Promise<any>;
+  canActivate?:
+    | JssCanActivate
+    | Type<JssCanActivate>
+    | Array<JssCanActivate | Type<JssCanActivate>>;
+  resolve?: { [key: string]: Resolve<any> | Type<Resolve<any>> };
 }
 
 export function instanceOfComponentNameAndType(object: any): object is ComponentNameAndType {
@@ -25,7 +46,47 @@ export function instanceOfComponentNameAndModule(object: any): object is Compone
   return 'module' in object;
 }
 
-export const PLACEHOLDER_COMPONENTS = new InjectionToken<ComponentNameAndType[]>('Sc.placeholder.components');
-export const PLACEHOLDER_LAZY_COMPONENTS = new InjectionToken<ComponentNameAndType[]>('Sc.placeholder.lazyComponents');
-export const PLACEHOLDER_MISSING_COMPONENT_COMPONENT = new InjectionToken<Type<any>>('Sc.placeholder.missingComponentComponent');
-export const DYNAMIC_COMPONENT = new InjectionToken<Type<any> | {[s: string]: any}> ('Sc.placeholder.dynamicComponent');
+export const PLACEHOLDER_COMPONENTS = new InjectionToken<ComponentNameAndType[]>(
+  'Sc.placeholder.components'
+);
+export const PLACEHOLDER_LAZY_COMPONENTS = new InjectionToken<ComponentNameAndType[]>(
+  'Sc.placeholder.lazyComponents'
+);
+export const PLACEHOLDER_MISSING_COMPONENT_COMPONENT = new InjectionToken<Type<any>>(
+  'Sc.placeholder.missingComponentComponent'
+);
+export const DYNAMIC_COMPONENT = new InjectionToken<Type<any> | { [s: string]: any }>(
+  'Sc.placeholder.dynamicComponent'
+);
+
+export type GuardResolver = (result: ComponentFactoryResult[]) => Promise<ComponentFactoryResult[]>;
+
+export const GUARD_RESOLVER = new InjectionToken<GuardResolver>('Sc.placeholder.guardResolver');
+
+export type DataResolver = (
+  result: ComponentFactoryResult[]
+) => Promise<Array<{ factory: ComponentFactoryResult; data: Data }>>;
+
+export const DATA_RESOLVER = new InjectionToken<DataResolver>('Sc.placeholder.dataResolver');
+
+export interface GuardInput {
+  activatedRoute: ActivatedRouteSnapshot;
+  routerState: RouterStateSnapshot;
+  rendering: ComponentRendering;
+}
+
+export interface JssCanActivate {
+  canActivate(
+    input: GuardInput
+  ):
+    | Observable<boolean | UrlTree | string | string[]>
+    | Promise<boolean | UrlTree | string | string[]>
+    | boolean
+    | UrlTree
+    | string
+    | string[];
+}
+
+export interface JssResolve<T> {
+  resolve(input: GuardInput): Observable<T> | Promise<T> | T;
+}

--- a/packages/sitecore-jss-angular/src/components/render-component.component.ts
+++ b/packages/sitecore-jss-angular/src/components/render-component.component.ts
@@ -14,7 +14,10 @@ import {
 import { ComponentRendering, HtmlElementRendering } from '@sitecore-jss/sitecore-jss';
 import { Observable } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
-import { ComponentFactoryResult, JssComponentFactoryService } from '../jss-component-factory.service';
+import {
+  ComponentFactoryResult,
+  JssComponentFactoryService,
+} from '../jss-component-factory.service';
 import { PLACEHOLDER_MISSING_COMPONENT_COMPONENT } from './placeholder.token';
 import { RawComponent } from './raw.component';
 import { isRawRendering } from './rendering';
@@ -34,9 +37,12 @@ export class RenderComponentComponent implements OnChanges {
   private _differ: KeyValueDiffer<string, any>;
   private destroyed = false;
 
-  @Input() rendering: ComponentRendering | HtmlElementRendering;
-  @Input() outputs: { [k: string]: (eventType: any) => void };
-  @ViewChild('view', { read: ViewContainerRef, static: true }) private view: ViewContainerRef;
+  @Input()
+  rendering: ComponentRendering | HtmlElementRendering;
+  @Input()
+  outputs: { [k: string]: (eventType: any) => void };
+  @ViewChild('view', { read: ViewContainerRef, static: true })
+  private view: ViewContainerRef;
 
   @Input()
   set inputs(value: { [key: string]: any }) {
@@ -51,7 +57,7 @@ export class RenderComponentComponent implements OnChanges {
     private differs: KeyValueDiffers,
     private componentFactory: JssComponentFactoryService,
     @Inject(PLACEHOLDER_MISSING_COMPONENT_COMPONENT) private missingComponentComponent: Type<any>
-  ) { }
+  ) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes['rendering']) {
@@ -60,17 +66,24 @@ export class RenderComponentComponent implements OnChanges {
   }
 
   private _setComponentInputs(componentInstance: any, inputs: { [key: string]: any }) {
-    Object.entries(inputs).forEach(([input, inputValue]) => componentInstance[input] = inputValue);
+    Object.entries(inputs).forEach(
+      ([input, inputValue]) => (componentInstance[input] = inputValue)
+    );
   }
 
-  private _subscribeComponentOutputs(componentInstance: any, outputs: { [k: string]: (eventType: any) => void }) {
+  private _subscribeComponentOutputs(
+    componentInstance: any,
+    outputs: { [k: string]: (eventType: any) => void }
+  ) {
     Object.keys(outputs)
-      .filter((output) => componentInstance[output] && componentInstance[output] instanceof Observable)
-      .forEach((output) => (componentInstance[output] as Observable<any>)
-        .pipe(
-        takeWhile(() => !this.destroyed)
+      .filter(
+        (output) => componentInstance[output] && componentInstance[output] instanceof Observable
       )
-      .subscribe(outputs[output]));
+      .forEach((output) =>
+        (componentInstance[output] as Observable<any>)
+          .pipe(takeWhile(() => !this.destroyed))
+          .subscribe(outputs[output])
+      );
   }
 
   private _render() {
@@ -81,14 +94,18 @@ export class RenderComponentComponent implements OnChanges {
     }
 
     const resolveComponent: Promise<ComponentFactoryResult> = isRawRendering(this.rendering)
-      ? Promise.resolve({ componentImplementation: RawComponent, componentDefinition: this.rendering })
+      ? Promise.resolve({
+          componentImplementation: RawComponent,
+          componentDefinition: this.rendering,
+        })
       : this.componentFactory.getComponent(this.rendering);
 
     resolveComponent.then((rendering) => {
       if (!rendering.componentImplementation) {
         const componentName = (rendering.componentDefinition as ComponentRendering).componentName;
         console.error(
-          `Attempted to render unknown component ${componentName}.`, `Ensure component is mapped, like:
+          `Attempted to render unknown component ${componentName}.`,
+          `Ensure component is mapped, like:
           JssModule.withComponents([
             { name: '${componentName}', type: ${componentName}Component }
           ])`
@@ -98,7 +115,8 @@ export class RenderComponentComponent implements OnChanges {
       }
 
       const componentFactory =
-        rendering.componentFactory || this.componentFactoryResolver.resolveComponentFactory(rendering.componentImplementation);
+        rendering.componentFactory ||
+        this.componentFactoryResolver.resolveComponentFactory(rendering.componentImplementation);
 
       const componentInstance = this.view.createComponent(componentFactory, 0).instance;
       componentInstance.rendering = rendering.componentDefinition;

--- a/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
+++ b/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
@@ -1,46 +1,62 @@
 import {
+  Compiler,
   ComponentFactory,
   Inject,
   Injectable,
   Injector,
-  Type
+  NgModuleFactory,
+  NgModuleFactoryLoader,
+  Type,
 } from '@angular/core';
+import { LoadChildren } from '@angular/router';
 import { ComponentRendering, HtmlElementRendering } from '@sitecore-jss/sitecore-jss';
+import { from, of } from 'rxjs';
+import { mergeMap, take } from 'rxjs/operators';
 import {
   ComponentNameAndModule,
   ComponentNameAndType,
   DYNAMIC_COMPONENT,
+  JssCanActivate,
+  JssResolve,
   PLACEHOLDER_COMPONENTS,
-  PLACEHOLDER_LAZY_COMPONENTS
+  PLACEHOLDER_LAZY_COMPONENTS,
 } from './components/placeholder.token';
 import { RawComponent } from './components/raw.component';
 import { isRawRendering } from './components/rendering';
+import { wrapIntoObservable } from './utils';
 
 export interface ComponentFactoryResult {
   componentImplementation?: Type<any>;
   componentDefinition: ComponentRendering | HtmlElementRendering;
   componentFactory?: ComponentFactory<any>;
+  canActivate?:
+    | JssCanActivate
+    | Type<JssCanActivate>
+    | Array<JssCanActivate | Type<JssCanActivate>>;
+  resolve?: { [key: string]: JssResolve<any> | Type<JssResolve<any>> };
 }
 
 @Injectable()
 export class JssComponentFactoryService {
-  private componentMap: Map<string, Type<any>>;
+  private componentMap: Map<string, ComponentNameAndType>;
   private lazyComponentMap: Map<string, ComponentNameAndModule>;
 
   constructor(
+    private compiler: Compiler,
+    private loader: NgModuleFactoryLoader,
     private injector: Injector,
     @Inject(PLACEHOLDER_COMPONENTS) private components: ComponentNameAndType[],
     @Inject(PLACEHOLDER_LAZY_COMPONENTS) private lazyComponents: ComponentNameAndModule[]
   ) {
-      this.componentMap = new Map();
-      this.lazyComponentMap = new Map();
+    this.componentMap = new Map();
+    this.lazyComponentMap = new Map();
 
-      this.components.forEach((c) => this.componentMap.set(c.name, c.type));
+    this.components.forEach((c) => this.componentMap.set(c.name, c));
 
-      if (this.lazyComponents) {
-        this.lazyComponents.forEach((c) => this.lazyComponentMap.set(c.path, c));
-      }
-   }
+    if (this.lazyComponents) {
+      this.lazyComponents.forEach((c) => this.lazyComponentMap.set(c.path, c));
+    }
+  }
 
   getComponent(component: ComponentRendering): Promise<ComponentFactoryResult> {
     const loadedComponent = this.componentMap.get(component.componentName);
@@ -48,34 +64,38 @@ export class JssComponentFactoryService {
     if (loadedComponent) {
       return Promise.resolve({
         componentDefinition: component,
-        componentImplementation: this.componentMap.get(component.componentName),
+        componentImplementation: loadedComponent.type,
+        canActivate: loadedComponent.canActivate,
       });
     }
 
     const lazyComponent = this.lazyComponentMap.get(component.componentName);
 
     if (lazyComponent) {
-      return lazyComponent.loadChildren()
-      .then((ngModuleFactory) => {
+      return this.loadModuleFactory(lazyComponent.loadChildren).then((ngModuleFactory) => {
         let componentType = null;
         const moduleRef = ngModuleFactory.create(this.injector);
         const dynamicComponentType = moduleRef.injector.get(DYNAMIC_COMPONENT);
         if (!dynamicComponentType) {
           throw new Error(
             // tslint:disable-next-line:max-line-length
-            `JssComponentFactoryService: Lazy load module for component "${lazyComponent.path}" missing DYNAMIC_COMPONENT provider. Missing JssModule.forChild()?`
+            `JssComponentFactoryService: Lazy load module for component "${
+              lazyComponent.path
+            }" missing DYNAMIC_COMPONENT provider. Missing JssModule.forChild()?`
           );
         }
 
         if (component.componentName in dynamicComponentType) {
-          componentType = (dynamicComponentType as {[s: string]: any})[component.componentName];
+          componentType = (dynamicComponentType as { [s: string]: any })[component.componentName];
         } else {
           if (typeof dynamicComponentType === 'function') {
             componentType = dynamicComponentType;
           } else {
             throw new Error(
               // tslint:disable-next-line:max-line-length
-              `JssComponentFactoryService: Lazy load module for component "${lazyComponent.path}" missing DYNAMIC_COMPONENT provider. Missing JssModule.forChild()?`
+              `JssComponentFactoryService: Lazy load module for component "${
+                lazyComponent.path
+              }" missing DYNAMIC_COMPONENT provider. Missing JssModule.forChild()?`
             );
           }
         }
@@ -83,7 +103,10 @@ export class JssComponentFactoryService {
         return {
           componentDefinition: component,
           componentImplementation: componentType,
-          componentFactory: moduleRef.componentFactoryResolver.resolveComponentFactory(componentType),
+          componentFactory: moduleRef.componentFactoryResolver.resolveComponentFactory(
+            componentType
+          ),
+          canActivate: lazyComponent.canActivate,
         };
       });
     }
@@ -93,12 +116,34 @@ export class JssComponentFactoryService {
     });
   }
 
-  getComponents(components: Array<ComponentRendering | HtmlElementRendering>): Promise<ComponentFactoryResult[]> {
+  private loadModuleFactory(loadChildren: LoadChildren): Promise<NgModuleFactory<any>> {
+    if (typeof loadChildren === 'string') {
+      return this.loader.load(loadChildren);
+    } else {
+      return wrapIntoObservable(loadChildren())
+        .pipe(
+          mergeMap((t: any) => {
+            if (t instanceof NgModuleFactory) {
+              return of(t);
+            } else {
+              return from(this.compiler.compileModuleAsync(t));
+            }
+          }),
+          take(1)
+        )
+        .toPromise();
+    }
+  }
+
+  getComponents(
+    components: Array<ComponentRendering | HtmlElementRendering>
+  ): Promise<ComponentFactoryResult[]> {
     // acquire all components and keep them in order while handling their potential async-ness
     return Promise.all(
-      components.map((component) => isRawRendering(component)
-        ? this.getRawComponent(component)
-        : this.getComponent(component))
+      components.map(
+        (component) =>
+          isRawRendering(component) ? this.getRawComponent(component) : this.getComponent(component)
+      )
     );
   }
 

--- a/packages/sitecore-jss-angular/src/lib.module.ts
+++ b/packages/sitecore-jss-angular/src/lib.module.ts
@@ -1,14 +1,17 @@
 import { CommonModule, DatePipe } from '@angular/common';
 import {
   ANALYZE_FOR_ENTRY_COMPONENTS,
+  Injector,
   ModuleWithProviders,
   NgModule,
-  Type
+  Type,
 } from '@angular/core';
-import { ROUTES } from '@angular/router';
+import { ActivatedRoute, Router, ROUTES } from '@angular/router';
+import { dataResolverFactory } from './components/data-resolver-factory';
 import { DateDirective } from './components/date.directive';
 import { FileDirective } from './components/file.directive';
 import { GenericLinkDirective } from './components/generic-link.directive';
+import { guardResolverFactory } from './components/guard-resolver-factory';
 import { ImageDirective } from './components/image.directive';
 import { LinkDirective } from './components/link.directive';
 import { MissingComponentComponent } from './components/missing-component.component';
@@ -17,10 +20,12 @@ import { PlaceholderComponent } from './components/placeholder.component';
 import {
   ComponentNameAndModule,
   ComponentNameAndType,
+  DATA_RESOLVER,
   DYNAMIC_COMPONENT,
+  GUARD_RESOLVER,
   PLACEHOLDER_COMPONENTS,
   PLACEHOLDER_LAZY_COMPONENTS,
-  PLACEHOLDER_MISSING_COMPONENT_COMPONENT
+  PLACEHOLDER_MISSING_COMPONENT_COMPONENT,
 } from './components/placeholder.token';
 import { RawComponent } from './components/raw.component';
 import { RenderComponentComponent } from './components/render-component.component';
@@ -85,6 +90,16 @@ export class JssModule {
         LayoutService,
         DatePipe,
         JssComponentFactoryService,
+        {
+          provide: GUARD_RESOLVER,
+          useFactory: guardResolverFactory,
+          deps: [Injector, ActivatedRoute, Router],
+        },
+        {
+          provide: DATA_RESOLVER,
+          useFactory: dataResolverFactory,
+          deps: [Injector, ActivatedRoute, Router],
+        },
       ],
     };
   }

--- a/packages/sitecore-jss-angular/src/public_api.ts
+++ b/packages/sitecore-jss-angular/src/public_api.ts
@@ -4,10 +4,24 @@ export { LinkDirective } from './components/link.directive';
 export { RouterLinkDirective } from './components/router-link.directive';
 export { GenericLinkDirective } from './components/generic-link.directive';
 export { PlaceholderComponent } from './components/placeholder.component';
+export {
+  ComponentNameAndType,
+  DYNAMIC_COMPONENT,
+  ComponentNameAndModule,
+  JssResolve,
+  JssCanActivate,
+  GuardInput,
+} from './components/placeholder.token';
 export { PlaceholderLoadingDirective } from './components/placeholder-loading.directive';
-export { ComponentNameAndType, DYNAMIC_COMPONENT } from './components/placeholder.token';
 export { isRawRendering } from './components/rendering';
-export { FileField, ImageField, LinkField, RenderingField, RichTextField, TextField } from './components/rendering-field';
+export {
+  FileField,
+  ImageField,
+  LinkField,
+  RenderingField,
+  RichTextField,
+  TextField,
+} from './components/rendering-field';
 export { RichTextDirective } from './components/rich-text.directive';
 export { TextDirective } from './components/text.directive';
 export { LayoutService } from './layout.service';
@@ -31,5 +45,5 @@ export {
   ComponentParams,
   HttpJsonFetcher,
   HttpResponse,
-  isServer
+  isServer,
 } from '@sitecore-jss/sitecore-jss';

--- a/packages/sitecore-jss-angular/src/utils.ts
+++ b/packages/sitecore-jss-angular/src/utils.ts
@@ -1,0 +1,16 @@
+import { ɵisObservable as isObservable, ɵisPromise as isPromise } from '@angular/core';
+import { from, Observable, of } from 'rxjs';
+
+export type InnerType<T> = T extends Promise<infer P> ? P : T extends Observable<infer O> ? O : T;
+
+export function wrapIntoObservable<T>(value: T): Observable<InnerType<T>> {
+  if (isObservable(value)) {
+    return value as any;
+  }
+
+  if (isPromise(value)) {
+    return from(Promise.resolve(value)) as any;
+  }
+
+  return of(value) as any;
+}

--- a/samples/angular/scripts/generate-component-factory.ts
+++ b/samples/angular/scripts/generate-component-factory.ts
@@ -66,7 +66,11 @@ function generateComponentFactory() {
       return;
     }
 
-    const componentFilePath = path.join(componentRootPath, componentFolder, `${componentFolder}.component.ts`);
+    const componentFilePath = path.join(
+      componentRootPath,
+      componentFolder,
+      `${componentFolder}.component.ts`
+    );
 
     if (!fs.existsSync(componentFilePath)) {
       return;
@@ -79,26 +83,34 @@ function generateComponentFactory() {
     const componentClassMatch = /export class (.+)Component/g.exec(componentFileContents);
 
     if (componentClassMatch === null) {
-      console.debug(`Component ${componentFilePath} did not seem to export a component class. It will be skipped.`);
+      console.debug(
+        `Component ${componentFilePath} did not seem to export a component class. It will be skipped.`
+      );
       return;
     }
 
     const componentName = componentClassMatch[1];
     const importVarName = `${componentName}Component`;
 
-
-
     // check for lazy loading needs
-    const moduleFilePath = path.join(componentRootPath, componentFolder, `${componentFolder}.module.ts`);
+    const moduleFilePath = path.join(
+      componentRootPath,
+      componentFolder,
+      `${componentFolder}.module.ts`
+    );
     const isLazyLoaded = fs.existsSync(moduleFilePath);
 
     if (isLazyLoaded) {
       console.debug(`Registering JSS component (lazy) ${componentName}`);
       // tslint:disable-next-line:max-line-length
-      lazyRegistrations.push(`{ path: '${componentName}', loadChildren: () => import('./${componentFolder}/${componentFolder}.module').then(m => m.${componentName}Module) },`);
+      lazyRegistrations.push(
+        `{ path: '${componentName}', loadChildren: () => import('./${componentFolder}/${componentFolder}.module').then(m => m.${componentName}Module) },`
+      );
     } else {
       console.debug(`Registering JSS component ${componentName}`);
-      imports.push(`import { ${importVarName} } from './${componentFolder}/${componentFolder}.component';`);
+      imports.push(
+        `import { ${importVarName} } from './${componentFolder}/${componentFolder}.component';`
+      );
       registrations.push(`{ name: '${componentName}', type: ${importVarName} },`);
       declarations.push(`${importVarName},`);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With these changes you can add canactive and resolvers to your application, allowing for components to load their data before rendering. 

Combine this with the sc-placeholder loaded event for optimal loading experience.

## Description
With these changes you can add canactive and resolvers to your application, allowing for components to load their data before rendering. 

Combine this with the sc-placeholder loaded event for optimal loading experience.

## Motivation
We needed a better loading experience for customers. This change allowed us to add a pretty skeleton loading before the data was loaded.

## How Has This Been Tested?
We included this change into the application.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change and it requires an update to the documentation.
- [x] My change is a documentation change and it requires an update to the navigation.
