### PR TITLE
Preserve classes on internal links using the scLink directive

### DIFF
--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -49,9 +49,13 @@ export class LinkDirective implements OnChanges {
     const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
 
     viewRef.rootNodes.forEach((node) => {
-      Object.entries(props).forEach(([key, propValue]: [string, any]) => 
+      Object.entries(props).forEach(([key, propValue]: [string, any]) => {
+        if (key === 'class' && node.className) {
+          propValue += ` ${node.className}`;
+        }
+
         this.renderer.setAttribute(node, key, propValue)
-      )
+      });
 
       if (node.childNodes && node.childNodes.length === 0 && linkText) {
         node.textContent = linkText;


### PR DESCRIPTION
This change prevents classes from being wiped on anchor elements using the scLink directive.

## Description
For Angular JSS projects, classes are preserved on anchor elements that use **external** Sitecore links:

```
<a class="foo bar" *scLink="externalLinkData"></a> <!-- before -->
<a class="foo bar" href="" alt=""></a> <!-- after -->
```

... However when using **internal** Sitecore links, the classes are wiped:

```
<a class="foo bar" *scLink="internalLinkData"></a> <!-- before -->
<a href="" alt=""></a> <!-- before -->
```

## Motivation
[https://github.com/Sitecore/jss/issues/378](https://github.com/Sitecore/jss/issues/378)

## How Has This Been Tested?
First, I ran `npm run test-packages`. Next, I packaged a local version of the npm package (.tgz file) and added it to our project. Then I confirmed that the CSS class wipe issue was fixed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
