### PR TITLE
Changed component factory to match only first occurence of component

### DIFF
--- a/samples/angular/scripts/generate-component-factory.ts
+++ b/samples/angular/scripts/generate-component-factory.ts
@@ -76,7 +76,7 @@ function generateComponentFactory() {
 
     // ASSUMPTION: your component should export a class directly that follows Angular conventions,
     // i.e. `export class FooComponent` - so we can detect the component's name for auto registration.
-    const componentClassMatch = /export class (.+)Component/g.exec(componentFileContents);
+    const componentClassMatch = /export class (.+?)Component/g.exec(componentFileContents);
 
     if (componentClassMatch === null) {
       console.debug(`Component ${componentFilePath} did not seem to export a component class. It will be skipped.`);

--- a/samples/vue/src/RouteHandler.vue
+++ b/samples/vue/src/RouteHandler.vue
@@ -112,10 +112,10 @@ export default {
   },
   watch: {
     // watch for a change in the 'route' prop
-    route(newRoute) {
+    route(newRoute, oldRoute) {
       // if the route contains a hash value, assume the URL is a named anchor/bookmark link, e.g. /page#anchorId.
       // in that scenario, we don't want to fetch new route data but instead allow default browser behavior.
-      if (newRoute.hash !== '') {
+      if (newRoute.hash !== '' && newRoute.path === oldRoute.path) {
         return;
       }
       // if in experience editor - force reload instead of route data update


### PR DESCRIPTION
## Motivation
The problem it solves is that currently generate component factory does not support components that extend or implement other components.

Thus it now supports the following naming conventions:

1. export class AComponent 
2. export class AComponent extends BComponent
3. export class AComponent implements CComponent

## How Has This Been Tested?
This has been tested locally by running jss start , with an existing JSS solution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the Contributing guide.
- [ x] My code follows the code style of this project.
- [x ] My code/comments/docs fully adhere to the Code of Conduct.
- [ x] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
