### PR TITLE
Call setSitecoreContext silently during SSR

### DIFF
--- a/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
@@ -35,9 +35,12 @@ export class SitecoreContextFactory {
     }
   }
 
-  setSitecoreContext = (value: any) => {
+  setSitecoreContext = (value: any, silent: boolean = false) => {
     this.context = value;
-    this.subscribers.forEach((func) => func(value));
+    
+    if (!silent) {
+      this.subscribers.forEach((func) => func(value));
+    }
   }
 }
 

--- a/samples/node-headless-ssr-proxy/README.md
+++ b/samples/node-headless-ssr-proxy/README.md
@@ -49,7 +49,7 @@ The following environment variables can be set to configure the proxy instead of
 You should be able to see the following message:
 `server listening on port 3000!` and see all the communication between this server and your Sitecore CD instance in the console.
 
-More info on this setup can be found [here](https://jss.sitecore.net/#/application-modes?id=headless-server-side-rendering-mode).
+More info on this setup can be found [here](https://jss.sitecore.com/docs/fundamentals/application-modes#headless-server-side-rendering-mode).
 
 ## Production Notes
 

--- a/samples/react/src/RouteHandler.js
+++ b/samples/react/src/RouteHandler.js
@@ -32,7 +32,7 @@ export default class RouteHandler extends React.Component {
         route: ssrInitialState.sitecore.route,
         itemId: ssrInitialState.sitecore.route.itemId,
         ...ssrInitialState.sitecore.context,
-      });
+      }, true);
     }
 
     // route data from react-router - if route was resolved, it's not a 404

--- a/samples/vue/src/RouteHandler.vue
+++ b/samples/vue/src/RouteHandler.vue
@@ -112,10 +112,10 @@ export default {
   },
   watch: {
     // watch for a change in the 'route' prop
-    route(newRoute) {
+    route(newRoute, oldRoute) {
       // if the route contains a hash value, assume the URL is a named anchor/bookmark link, e.g. /page#anchorId.
       // in that scenario, we don't want to fetch new route data but instead allow default browser behavior.
-      if (newRoute.hash !== '') {
+      if (newRoute.hash !== '' && newRoute.path === oldRoute.path) {
         return;
       }
       // if in experience editor - force reload instead of route data update


### PR DESCRIPTION
During some profiling Server-Side Rendering of the sample application `setSitecoreContext` stood out quite a bit and it seems like that when [setSitecoreContext is called with the initial SSR state](https://github.com/Sitecore/jss/blob/dev/samples/react/src/RouteHandler.js#L31), this [triggers subscribers to be called](https://github.com/Sitecore/jss/blob/dev/packages/sitecore-jss-react/src/components/SitecoreContext.tsx#L40), which [ends up calling forceUpdate](https://github.com/Sitecore/jss/blob/dev/packages/sitecore-jss-react/src/components/SitecoreContext.tsx#L74).

This doesn't _seem_ to be necessary during SSR and skipping the notification of subscribers seems to increase throughput of SSR by ~30% in my testing:

Before:
```
  Scenarios launched:  100
  Scenarios completed: 100
  Requests completed:  2000
  Mean response/sec: 147.49
  Response time (msec):
    min: 20.9
    max: 786.9
    median: 590.9
    p95: 716.4
    p99: 766.2
  Scenario counts:
    0: 100 (100%)
  Codes:
    200: 2000
```

After
```
  Scenarios launched:  100
  Scenarios completed: 100
  Requests completed:  2000
  Mean response/sec: 210.08
  Response time (msec):
    min: 61.3
    max: 572.2
    median: 411.2
    p95: 462.1
    p99: 493.5
  Scenario counts:
    0: 100 (100%)
  Codes:
    200: 2000
```

This could use some test coverage, which I can add if this change is adopted. Open to any/all questions here.

## Motivation
Increase performance of Server-Side Rendering.

## How Has This Been Tested?
Limited local testing, using https://artillery.io/ to simulate load against proxy. 
`artillery quick --count 100 -n 20 http://localhost:3000`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
