### PR TITLE
Section field type - cssClass Property

### DIFF
--- a/packages/sitecore-jss-forms/src/FormField.ts
+++ b/packages/sitecore-jss-forms/src/FormField.ts
@@ -1,5 +1,5 @@
 import { HtmlFormField } from './HtmlFormField';
-import { InputViewModel, TitleFieldViewModel, ViewModel } from './ViewModel';
+import { InputViewModel, TitleFieldViewModel, ViewModel, FieldViewModel } from './ViewModel';
 
 export interface FormField<TViewModel extends ViewModel = ViewModel> {
   model: TViewModel;
@@ -29,7 +29,7 @@ export function instanceOfButtonFormField(object: FormField): object is ButtonFo
   return 'buttonField' in object;
 }
 
-export interface FormFieldSection extends FormField<ViewModel> {
+export interface FormFieldSection extends FormField<FieldViewModel> {
   fields: FormField[];
 }
 


### PR DESCRIPTION
Section field type needs to inherit from FieldViewModel, so it has access to read the cssClass property on the field rendering.

## Description
I changed the inherited type for `FormFieldSection` to be of type `FormField<FieldViewModel` to expose the `cssClass` property on the model: `field.model.cssClass`

## Motivation
We can get to the property using bracket notation (`this.field.model['cssClass']`). Setting the Css Class for a section is an available option in the Sitecore Forms Builder, and other properties are able to access it via the strong typing: `field.model.cssClass`. It makes sense to be able to do this with a Section, too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
