### PR TITLE
Fix prop-types for missingComponentComponent to allow a functional component

### DIFF
--- a/packages/sitecore-jss-react/src/components/MissingComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/MissingComponent.tsx
@@ -7,7 +7,7 @@ export interface MissingComponentProps {
   };
 }
 
-export const MissingComponent: React.SFC<MissingComponentProps> = (props) => {
+export const MissingComponent: React.FC<MissingComponentProps> = (props) => {
   const componentName =
     props.rendering && props.rendering.componentName
       ? props.rendering.componentName

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -10,6 +10,7 @@ import {
   convertedLayoutServiceData as nonEeLsData,
 } from '../testData/non-ee-data';
 import { convertedData as eeData } from '../testData/ee-data';
+import { MissingComponent, MissingComponentProps } from './MissingComponent';
 
 const componentFactory: ComponentFactory = (componentName: string) => {
   const components = new Map<string, any>();
@@ -224,6 +225,35 @@ describe('<Placeholder />', () => {
     );
     expect(renderedComponent.html()).to.be.empty;
   });
+});
+
+it('should render MissingComponent for unknown rendering', () => {
+  const route: any = {
+    placeholders: {
+      main: [
+        {
+          componentName: 'Unknown',
+        },
+      ],
+    },
+  };
+  const phKey = 'main';
+
+  const CustomMissingComponent: React.FC<MissingComponentProps> = (props) => (
+    <div className="missing-component">
+      <MissingComponent {...props} />
+    </div>
+  );
+
+  const renderedComponent = mount(
+    <Placeholder
+      name={phKey}
+      rendering={route}
+      componentFactory={componentFactory}
+      missingComponentComponent={CustomMissingComponent}
+    />
+  );
+  expect(renderedComponent.find('.missing-component').length).to.equal(1);
 });
 
 after(() => {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -38,7 +38,7 @@ export interface PlaceholderProps {
    * A component that is rendered in place of any components that are in this placeholder,
    * but do not have a definition in the componentFactory (i.e. don't have a React implementation)
    */
-  missingComponentComponent?: React.ComponentClass<any> | React.SFC<any>;
+  missingComponentComponent?: React.ComponentClass<any> | React.FC<any>;
 
   /**
    * A component that is rendered in place of the placeholder when an error occurs rendering
@@ -62,7 +62,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     params: PropTypes.objectOf(PropTypes.string.isRequired),
     missingComponentComponent: PropTypes.oneOfType([
       PropTypes.object as Requireable<React.ComponentClass<any>>,
-      PropTypes.object as Requireable<React.SFC<any>>
+      PropTypes.func as Requireable<React.FC<any>>
     ]),
     errorComponent: PropTypes.oneOfType([
       PropTypes.object as Requireable<React.ComponentClass<any>>,
@@ -135,8 +135,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       let component: React.ReactNode | null = this.getComponentForRendering(rendering);
       if (!component) {
         console.error(
-          `Placeholder ${name} contains unknown component ${
-          rendering.componentName
+          `Placeholder ${name} contains unknown component ${rendering.componentName
           }. Ensure that a React component exists for it, and that it is registered in your componentFactory.js.`
         );
 


### PR DESCRIPTION
## Description
* Add a unit test in `Placeholder.test.tsx` that checks the case when an unknown component is requested for rendering -> then the passed `missingComponentComponent` prop of the `Placeholder` should be used.
* Fix prop-types for `missingComponentComponent` prop as it currently allows only objects while it should allow a function

## Motivation
When a custom `MissingComponent` implementation is passed to the `missingComponentComponent` prop there is a runtime error saying `Failed prop type: Invalid prop missingComponentComponent supplied to PlaceholderComponent.`
This is because the prop-types are incorrect and don't allow a function.

## How Has This Been Tested?
I have added a test case that is using the missingComponentComponent prop and when this test is ran with the old prop-types then the runtime error is reproduced.
When prop-types allow for a `func` the runtime error disappears.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
