### PR TITLE
Fix return type of ComponentFactory to allow a component definition instead of an instantiated component

### DIFF
--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -12,10 +12,10 @@ import {
 import { convertedData as eeData } from '../testData/ee-data';
 
 const componentFactory: ComponentFactory = (componentName: string) => {
-  const components = new Map<string, any>();
+  const components = new Map<string, React.FC>();
 
   // pass otherProps to page-content to test property cascading through the Placeholder
-  const Home: React.SFC<any> = ({ rendering, render, renderEach, renderEmpty, ...otherProps }) => (
+  const Home: React.FC<any> = ({ rendering, render, renderEach, renderEmpty, ...otherProps }) => (
     <div className="home-mock">
       <Placeholder name="page-header" rendering={rendering} />
       <Placeholder name="page-content" rendering={rendering} {...otherProps} />
@@ -27,7 +27,7 @@ const componentFactory: ComponentFactory = (componentName: string) => {
 
   components.set('Home', Home);
 
-  const DownloadCallout: React.SFC<any> = (props) => (
+  const DownloadCallout: React.FC<any> = (props) => (
     <div className="download-callout-mock">
       {props.fields.message ? props.fields.message.value : ''}
     </div>
@@ -41,7 +41,7 @@ const componentFactory: ComponentFactory = (componentName: string) => {
   components.set('DownloadCallout', DownloadCallout);
   components.set('Jumbotron', () => <div className="jumbotron-mock" />);
 
-  return components.get(componentName);
+  return components.get(componentName) || null;
 };
 
 describe('<Placeholder />', () => {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import PropTypes, { Requireable } from 'prop-types';
 import { MissingComponent } from '../components/MissingComponent';
 import { ComponentFactory } from '../components/sharedTypes';
@@ -132,15 +132,14 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         return this.createRawElement(rendering, commonProps);
       }
 
-      let component: React.ReactNode | null = this.getComponentForRendering(rendering);
+      let component: ComponentType | null = this.getComponentForRendering(rendering);
       if (!component) {
         console.error(
-          `Placeholder ${name} contains unknown component ${
-          rendering.componentName
+          `Placeholder ${name} contains unknown component ${rendering.componentName
           }. Ensure that a React component exists for it, and that it is registered in your componentFactory.js.`
         );
 
-        component = missingComponentComponent || MissingComponent;
+        component = missingComponentComponent ?? MissingComponent;
       }
 
       const finalProps = {

--- a/packages/sitecore-jss-react/src/components/sharedTypes.ts
+++ b/packages/sitecore-jss-react/src/components/sharedTypes.ts
@@ -1,3 +1,3 @@
-import { Component } from 'react';
+import { ComponentType } from 'react';
 
-export type ComponentFactory = (componentName: string) => Component;
+export type ComponentFactory = (componentName: string) => ComponentType | null;


### PR DESCRIPTION
Fix the typing for `ComponentFactory` to support a component type instead of an instantiated component

## Description
Change the return type of the `ComponentFactory` function type to `ComponentType` instead of just `Component` which assumes an instantiated component

## Motivation
This incorrect type is causing typing issues when `componentFactory` prop is passed to `SitecoreContext`. The test that is changed in this PR will result into an error if ran with the old typing. The error would be something like this `Type '(componentName: string) => React.FC<{}>' is not assignable to type 'ComponentFactory'.`

## How Has This Been Tested?
The incorrect type is causing an error in the Placeholder.test.tsx file while with the updated type the error disappears.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
