### PR TITLE
[Docs] Mark javascript renderings as deprecated

### DIFF
--- a/docs/data/routes/docs/getting-started/quick-start/en.md
+++ b/docs/data/routes/docs/getting-started/quick-start/en.md
@@ -45,20 +45,30 @@ The JSS CLI is used to create applications, which can be created from a several 
 
 > Which framework you use for JSS is a matter of opinion. JSS provides equal support to React, Vue, and Angular. If you're a newcomer to modern frontend development and don't have your own opinion yet, React or Vue are the easiest to get started with.
 
-### Styleguide Templates
+### App Starter Templates
 
-Styleguide templates are mirror images of each other, supporting basic Sitecore features (routing, multilingual, GraphQL) and using popular supporting libraries for their frameworks. Each Styleguide template comes with a sample styleguide showing how to use and define various Sitecore field types and patterns in that framework.
+These are the main templates that should be used when you're getting started with JSS. They were designed as examples of JSS application starting points, and they contain StyleGuides that demonstrate how to work with JSS components using your chosen JS framework.
+
+The Styleguides in these templates are mirror images of each other, supporting basic Sitecore features (routing, multilingual, GraphQL) and using popular supporting libraries for their frameworks.
 
 * `react` The React Styleguide template, based on `create-react-app`.
 * `vue` The Vue Styleguide template, based on `vue-cli`.
 * `angular` The Angular Styleguide template.
 
+Note that these templates are examples of project starting points, and are not ready-for-production code. Developers are expected to extend and customize these examples according to their requirements.
+
 ### Experimental Templates
 
 Experimental templates are experimental specialized JSS examples. They are examples of how to do advanced tasks, but may not be stable or thoroughly documented.
 
+* `react-native` The React Native Styleguide template
 * `sitecore-embedded-jss-app` This app shows how to embed a JSS application inside an existing Sitecore site as a rendering. [Read more here](/docs/techniques/mvc-integration/client-side-embedding).
-* `sitecore-javascript-renderings` This app shows how to render a JavaScript app as a rendering embedded within a traditional Sitecore MVC site. See [JavaScript Renderings](/docs/techniques/mvc-integration/javascript-rendering) for details.
+
+### Special Templates
+* `node-headless-ssr-proxy` This app shows how to configure a Node server to act as a proxy between the browser and Sitecore. [Read more here]()
+
+### Deprecated Templates
+* `sitecore-javascript-renderings` This app shows how to render a JavaScript app as a rendering embedded within a traditional Sitecore MVC site. See [JavaScript Renderings](/docs/techniques/mvc-integration/javascript-rendering) for details. This template is flagged as deprecated as of Oct 2020 because these rendering don't scale well. They satisfy edge-case requirements, and should generally be avoided.
 
 ## Step 4: Create application using selected template
 

--- a/docs/data/routes/docs/techniques/mvc-integration/javascript-rendering/en.md
+++ b/docs/data/routes/docs/techniques/mvc-integration/javascript-rendering/en.md
@@ -4,13 +4,15 @@ routeTemplate: ./data/component-templates/article.yml
 title: JavaScript Renderings
 ---
 
-# Sitecore JavaScript rendering
+# Sitecore JavaScript rendering [Deprecated]
+
+> This template is flagged as deprecated as of Oct 2020 because these rendering don't scale well. They satisfy edge-case requirements, and should generally be avoided.
 
 This is a technique to allow JavaScript contents to render into a rendering added to a traditional Sitecore MVC page. Doing this allows embedding a JavaScript app within an existing Sitecore MVC site, as opposed to as its own standalone JSS site. This technique executes server-side rendering of the app and returns the rendered markup.
 
 Compared to [Client-Side Embedding](/docs/techniques/mvc-integration/javascript-rendering), JavaScript Renderings have a different scope. With client embedding, a JSS app is embedded into a Sitecore MVC rendering, and rendered on the browser. JS renderings are pre-rendered on the Sitecore server (SSR) and serve working HTML at page load time, _however you cannot use them to host JSS apps_, because they are only provided with the data for their rendering. JavaScript renderings are also only compatible with Sitecore MVC, and will not work with Web Forms.
 
-> Note: this feature is considered **experimental**. Please read the [important notes](#important-notes) section carefully to fully understand current limitations and potential pain points. It is important to understand that JS renderings are an alternate programming model from a JSS app. You cannot use JS renderings to place a regular JSS app within a Sitecore MVC rendering. This is because a JSS app is larger, full-layout-controlling app. A JS rendering is a piece within a Sitecore MVC site, and has the context of its datasource item not an entire layout.
+> Note: Please read the [important notes](#important-notes) section carefully to fully understand current limitations and potential pain points. It is important to understand that JS renderings are an alternate programming model from a JSS app. You cannot use JS renderings to place a regular JSS app within a Sitecore MVC rendering. This is because a JSS app is larger, full-layout-controlling app. A JS rendering is a piece within a Sitecore MVC site, and has the context of its datasource item not an entire layout.
 
 ## How it works
 

--- a/docs/data/routes/help/en.md
+++ b/docs/data/routes/help/en.md
@@ -35,10 +35,12 @@ Assistance with the JSS products can also be obtained in community-based channel
 
 Yes! The earliest version of JSS that is considered production-ready is JSS 11.0 for Sitecore 9.0 and 9.1. It is stable for React, Angular, Vue, and Layout Service API usage.
 
+There are multiple enterprise JSS sites running in production today.
+
 ### Why are some features marked as "Experimental"?
 [React Native](/docs/client-frameworks/react-native) is marked as experimental because React Native cannot render in the browser (RN apps are intended to be rendered on iOS/Android devices or emulators), so there is no Experience Editor support. This makes RN difficult to setup and difficult to work with.
 
-[JavaScript Renderings](/docs/techniques/mvc-integration/javascript-rendering) are marked as experimental because these rendering don't scale well. They satisfy edge-case requirements, and should be used sparingly.
+[JavaScript Renderings](/docs/techniques/mvc-integration/javascript-rendering) are marked as experimental because these rendering don't scale well. They satisfy edge-case requirements, and should be used sparingly. (**JavaScript Renderings have been deprecated as of Oct 2020**)
 
 ### Does JSS require a special Sitecore license and where can I get it?
 Sitecore offers different licensing bundles - some include JSS, and some require purchasing it an add-on.

--- a/samples/sitecore-javascript-renderings/README.md
+++ b/samples/sitecore-javascript-renderings/README.md
@@ -1,0 +1,2 @@
+# JavaScript renderings have been deprecated
+Do not use.


### PR DESCRIPTION
Updated docs to flag the JavaScript Renderings feature as deprecated.

## How Has This Been Tested?
Tested on local instance.

## Types of changes
- [X] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
- Added README to the JavaScript Rendering sample
