### PR TITLE
[sitecore-jss] Merge specific params from layout service into query string

### DIFF
--- a/packages/sitecore-jss/src/mediaApi.test.ts
+++ b/packages/sitecore-jss/src/mediaApi.test.ts
@@ -4,7 +4,7 @@
 import chai = require('chai');
 import chaiString = require('chai-string');
 import URL = require('url-parse');
-import { findEditorImageTag, getSrcSet, updateImageUrl } from './mediaApi';
+import { findEditorImageTag, getSrcSet, updateImageUrl, getRequiredParams } from './mediaApi';
 
 // chai.should();
 const expect = chai.use(chaiString).expect;
@@ -34,6 +34,30 @@ describe('findEditorImageTag', () => {
     expect(imgMatch.attrs['lorem']).to.equal('&><');
   });
 });
+
+describe('getRequiredParams', () => {
+  it('should return required query string params', () => {
+    const parsedQs = { 
+      rev: '11',
+      db: '22',
+      xxx: 'ppp',
+      la: '33',
+      vs: '44',
+      ts: '55',
+      yyy: 'vvv'
+    }
+
+    const params = getRequiredParams(parsedQs);
+    
+    expect(params).to.deep.equal({
+      rev: '11',
+      db: '22',
+      la: '33',
+      vs: '44',
+      ts: '55'
+    })
+  })
+})
 
 describe('updateImageUrl', () => {
   it('should override parameters with those provided', () => {
@@ -94,16 +118,20 @@ describe('updateImageUrl', () => {
   });
 
   it('should merge querystring and params', () => {
-    const src = '/media/lorem/ipsum.jpg?x=valueX&y=value111&rev=109010';
+    const src = '/media/lorem/ipsum.jpg?x=valueX&y=value111&rev=109010&db=333&la=444&vs=555&ts=666&unknownParam=54321';
     const params = { y: 'valueY', z: 'valueZ' };
     const parsed = updateImageUrl(src, params);
     const url = URL(parsed, {}, true);
 
-    expect(url.toString()).equal('/media/lorem/ipsum.jpg?y=valueY&z=valueZ&rev=109010')
+    expect(url.toString()).equal('/media/lorem/ipsum.jpg?y=valueY&z=valueZ&rev=109010&db=333&la=444&vs=555&ts=666')
     expect(url.query).deep.equal({
       y: 'valueY',
 			z: 'valueZ',
-			rev: "109010"
+      rev: "109010",
+      db: '333',
+      la: '444',
+      vs: '555',
+      ts: '666'
     });
   })
 });

--- a/packages/sitecore-jss/src/mediaApi.ts
+++ b/packages/sitecore-jss/src/mediaApi.ts
@@ -36,6 +36,18 @@ export const findEditorImageTag = (editorMarkup: string) => {
 };
 
 /**
+ * Get required query string params which should be merged with user params
+ * @param qs layout service parsed query string
+ */
+export const getRequiredParams = (qs: { 
+  [key: string]: string | undefined 
+}) => {
+  const { rev, db, la, vs, ts } = qs;
+  
+  return { rev, db, la, vs, ts }
+}
+
+/**
  * Receives a Sitecore media URL and replaces `/~/media` or `/-/media` with `/~/jssmedia` or `/-/jssmedia`, respectively.
  * Can use `mediaUrlPrefix` in order to use custom checker.
  * This replacement allows the JSS media handler to be used for JSS app assets.
@@ -52,11 +64,18 @@ export const updateImageUrl = (
   }
 	const parsed = URL(url, {}, true);
  
-	const query = params || parsed.query
+  const query = params || parsed.query
 
-	if (parsed.query.rev) {
-		query.rev = parsed.query.rev
-	}
+  // In case if imageParams provided
+  if (params) {
+    const requiredParams = getRequiredParams(parsed.query);
+  
+    Object.entries(requiredParams).forEach(([key, param]) => {
+      if (param) {
+        query[key] = param;
+      }
+    })
+  }
 
   parsed.set('query', query);
 


### PR DESCRIPTION
Merge specific params from layout service into query string: rev, db, la, vs, ts

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
