### PR TITLE
Fix issue with VisitorIdentification control on Next.js

### DIFF
--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -3,7 +3,6 @@ import { withSitecoreContext } from '../enhancers/withSitecoreContext';
 
 interface VIProps {
   sitecoreContext: {
-    pageEditing?: boolean;
     visitorIdentificationTimestamp?: string;
   };
 }
@@ -13,12 +12,10 @@ const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
   if (
     emittedVI ||
     typeof document === 'undefined' ||
-    sitecoreContext.pageEditing ||
     !sitecoreContext.visitorIdentificationTimestamp
   ) {
     // Don't emit VI script and meta tag if we've already done so,
-    // aren't rendering client-side, are in Experience Editor, or
-    // don't have a VI timestamp.
+    // aren't rendering client-side, or don't have a VI timestamp.
     return null;
   }
   emittedVI = true;
@@ -31,9 +28,9 @@ const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
   meta.name = 'VIcurrentDateTime';
   meta.content = sitecoreContext.visitorIdentificationTimestamp;
 
-  const head = document.getElementsByTagName('head')[0];
-  head.appendChild(script);
-  head.appendChild(meta);
+  const head = document.querySelector('head');
+  head && head.appendChild(script);
+  head && head.appendChild(meta);
 
   return null;
 };

--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -3,27 +3,37 @@ import { withSitecoreContext } from '../enhancers/withSitecoreContext';
 
 interface VIProps {
   sitecoreContext: {
+    pageEditing?: boolean;
     visitorIdentificationTimestamp?: string;
   };
 }
 
 let emittedVI = false;
-let VIComponent: React.SFC<VIProps> = ({ sitecoreContext }) => {
+const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
   if (
-    !emittedVI &&
-    typeof document !== 'undefined' &&
-    sitecoreContext.visitorIdentificationTimestamp
+    emittedVI ||
+    typeof document === 'undefined' ||
+    sitecoreContext.pageEditing ||
+    !sitecoreContext.visitorIdentificationTimestamp
   ) {
-    emittedVI = true;
-    const script = document.createElement('script');
-    script.src = `/layouts/system/VisitorIdentification.js`;
-    script.type = 'text/javascript';
-    document.getElementsByTagName('head')[0].appendChild(script);
-
-    return (
-      <meta name="VIcurrentDateTime" content={sitecoreContext.visitorIdentificationTimestamp} />
-    );
+    // Don't emit VI script and meta tag if we've already done so,
+    // aren't rendering client-side, are in Experience Editor, or
+    // don't have a VI timestamp.
+    return null;
   }
+  emittedVI = true;
+
+  const script = document.createElement('script');
+  script.src = `/layouts/system/VisitorIdentification.js`;
+  script.type = 'text/javascript';
+
+  const meta = document.createElement('meta');
+  meta.name = 'VIcurrentDateTime';
+  meta.content = sitecoreContext.visitorIdentificationTimestamp;
+
+  const head = document.getElementsByTagName('head')[0];
+  head.appendChild(script);
+  head.appendChild(meta);
 
   return null;
 };

--- a/samples/nextjs/src/components/Layout.tsx
+++ b/samples/nextjs/src/components/Layout.tsx
@@ -2,13 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useI18n } from 'next-localization';
-import {
-  Placeholder,
-  VisitorIdentification,
-  RouteData,
-  withSitecoreContext,
-} from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideSitecoreContext } from 'lib/component-props';
+import { Placeholder, RouteData, VisitorIdentification } from '@sitecore-jss/sitecore-jss-nextjs';
 
 const LOGO_SIZE = { WIDTH: 221, HEIGHT: 48 };
 
@@ -51,11 +45,11 @@ const Navigation = () => {
   );
 };
 
-type LayoutProps = StyleguideSitecoreContext & {
+type LayoutProps = {
   route: RouteData;
 };
 
-const Layout = ({ route, sitecoreContext }: LayoutProps) => {
+const Layout = ({ route }: LayoutProps): JSX.Element => {
   return (
     <>
       <Head>
@@ -72,7 +66,7 @@ const Layout = ({ route, sitecoreContext }: LayoutProps) => {
 
         VI detection only runs once for a given analytics ID, so this is not a recurring operation once cookies are established.
       */}
-      {!sitecoreContext.pageEditing && <VisitorIdentification />}
+      <VisitorIdentification />
 
       <Navigation />
 
@@ -84,4 +78,4 @@ const Layout = ({ route, sitecoreContext }: LayoutProps) => {
   );
 };
 
-export default withSitecoreContext()(Layout);
+export default Layout;


### PR DESCRIPTION
- Fixes an issue with `VisitorIdentification` React control on Next.js by moving everything (script and meta tag addition) to purely client-side 
- A pageEditing check has also been added within the control which avoids having to check in consuming app
