### PR TITLE
QA/439759

### DIFF
--- a/samples/nextjs/package-lock.json
+++ b/samples/nextjs/package-lock.json
@@ -1398,85 +1398,6 @@
 				"@babel/plugin-transform-typescript": "^7.10.4"
 			}
 		},
-		"@babel/register": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.6.2.tgz",
-			"integrity": "sha512-xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==",
-			"dev": true,
-			"requires": {
-				"find-cache-dir": "^2.0.0",
-				"lodash": "^4.17.13",
-				"mkdirp": "^0.5.1",
-				"pirates": "^4.0.0",
-				"source-map-support": "^0.5.9"
-			},
-			"dependencies": {
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
-			}
-		},
 		"@babel/runtime": {
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
@@ -7515,6 +7436,12 @@
 				"form-data": "^3.0.0"
 			}
 		},
+		"graphql-tag": {
+			"version": "2.10.4",
+			"resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.4.tgz",
+			"integrity": "sha512-O7vG5BT3w6Sotc26ybcvLKNTdfr4GfsIVMD+LdYqXCeJIYPRyp8BIsDOUtxw7S1PYvRw5vH3278J2EDezR6mfA==",
+			"dev": true
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -10068,7 +9995,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
 			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"node-releases": {
 			"version": "1.1.66",
@@ -10671,6 +10599,7 @@
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
 			}

--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -53,8 +53,6 @@
     "react-dom": "^16.9.0"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.10.4",
-    "@babel/register": "~7.6.2",
     "@graphql-codegen/cli": "^1.19.1",
     "@graphql-codegen/plugin-helpers": "^1.18.1",
     "@graphql-codegen/typescript": "^1.17.11",
@@ -81,6 +79,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-yaml": "^0.2.0",
     "graphql-let": "^0.16.2",
+    "graphql-tag": "~2.10.1",
     "npm-run-all": "~4.1.5",
     "prettier": "^2.1.2",
     "ts-node": "^9.0.0",

--- a/samples/nextjs/src/components/GraphQL-ConnectedDemo/index.tsx
+++ b/samples/nextjs/src/components/GraphQL-ConnectedDemo/index.tsx
@@ -6,8 +6,7 @@ import {
   Item,
   GraphQlConnectedDemo as GrapQLConnectedDemoDatasource,
 } from './query.graphql';
-import initializeApollo from 'lib/GraphQLClientFactory';
-import config from 'temp/config';
+import GraphQLClientFactory from 'lib/GraphQLClientFactory';
 import {
   GetServerSideComponentProps,
   GetStaticComponentProps,
@@ -101,9 +100,9 @@ export const getStaticProps: GetStaticComponentProps = async (rendering, layoutD
     return null;
   }
 
-  const apolloClient = initializeApollo({ endpoint: config.graphQLEndpoint });
+  const graphQLClient = GraphQLClientFactory();
 
-  const result = await apolloClient.query({
+  const result = await graphQLClient.query({
     query: ConnectedDemoQueryDocument,
     variables: {
       datasource: rendering.dataSource,
@@ -125,9 +124,9 @@ export const getServerSideProps: GetServerSideComponentProps = async (rendering,
     return null;
   }
 
-  const apolloClient = initializeApollo({ endpoint: config.graphQLEndpoint });
+  const graphQLClient = GraphQLClientFactory();
 
-  const result = await apolloClient.query({
+  const result = await graphQLClient.query({
     query: ConnectedDemoQueryDocument,
     variables: {
       datasource: rendering.dataSource,

--- a/samples/nextjs/src/components/GraphQL-ConnectedDemo/query.graphql
+++ b/samples/nextjs/src/components/GraphQL-ConnectedDemo/query.graphql
@@ -7,8 +7,7 @@
 
 query ConnectedDemoQuery($datasource: String!, $contextItem: String!) {
   # Datasource query
-  # $datasource will always be set to the ID of the rendering's datasource item
-  # (as long as the GraphQLData helper is used)
+  # $datasource should be set to the ID of the rendering's datasource item
   datasource(value: $datasource) {
     id
     name
@@ -38,8 +37,7 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!) {
   }
 
   # Context/route item query
-  # $contextItem will always be set to the ID of the current context item (the route item)
-  # (as long as the GraphQLData helper is used)
+  # $contextItem should be set to the ID of the current context item (the route item)
   contextItem: item(path: $contextItem) {
     id
     # Get the page title from the app route template

--- a/samples/nextjs/src/pages/_app.tsx
+++ b/samples/nextjs/src/pages/_app.tsx
@@ -1,10 +1,7 @@
 import type { AppProps } from 'next/app';
 import Router from 'next/router';
-import { ApolloProvider } from 'react-apollo';
 import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
-import { useApollo } from 'lib/GraphQLClientFactory';
-import config from 'temp/config';
 
 // Using bootstrap and nprogress are completely optional.
 //  bootstrap is used here to provide a clean layout for samples, without needing extra CSS in the sample app
@@ -23,16 +20,12 @@ Router.events.on('routeChangeError', () => NProgress.done());
 function App({ Component, pageProps }: AppProps): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
-  const apolloClient = useApollo({ endpoint: config.graphQLEndpoint });
-
   return (
     // Use the next-localization (w/ rosetta) library to provide our translation dictionary to the app.
     // Note Next.js does not (currently) provide anything for translation, only i18n routing.
     // If your app is not multilingual, next-localization and references to it can be removed.
     <I18nProvider lngDict={dictionary} locale={pageProps.locale}>
-      <ApolloProvider client={apolloClient}>
-        <Component {...rest} />
-      </ApolloProvider>
+      <Component {...rest} />
     </I18nProvider>
   );
 }


### PR DESCRIPTION
Updates to Next.js GraphQL-Connected demo after QA / dev experience adding a new GraphQL-based component.

* Added missing 'graphql-let' peer dependency for 'graphql-tag'. Removed unused '@babel/preset-env' and '@babel/register' dependencies.
* Removed the ApolloProvider from root _app.tsx since we're never doing client-side GraphQL in this example (always SSG/SSR)
* ... which allows us to simplified the GraphQLClientFactory (always return new client, don't have to concern ourselves with initialState, default the endpoint)
* Updated comments on query.query.graphql to remove ref to GraphQLData