### PR TITLE
[React sample] `Cannot read property 'sitecore' of null`, when 404 and routeData is null

### DIFF
--- a/docs/data/routes/release-notes/en.md
+++ b/docs/data/routes/release-notes/en.md
@@ -5,6 +5,15 @@ title: Release Notes
 ---
 # Release Notes
 
+## Sitecore JSS 16.0 for Sitecore 10
+
+### Upgrading
+
+### Breaking changes
+
+### New Features & Improvements
+### Bug Fixes
+* [PR #506](https://github.com/Sitecore/jss/pull/506) [React sample] `Cannot read property 'sitecore' of null`, when 404 and routeData is null
 ## Sitecore JSS 15.0.1
 
 ### Bug Fixes

--- a/samples/react/src/RouteHandler.js
+++ b/samples/react/src/RouteHandler.js
@@ -98,9 +98,11 @@ class RouteHandler extends React.Component {
         });
         this.setState({ notFound: false });
       } else {
-        this.setState({ notFound: true }, () =>
-          this.props.updateSitecoreContext(routeData.sitecore.context)
-        )
+        this.setState({ notFound: true }, () => {
+          const context = routeData && routeData.sitecore ? routeData.sitecore.context : null;
+
+          this.props.updateSitecoreContext(context)
+        })
       }
     });
   }


### PR DESCRIPTION
Related to #492 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
