### PR TITLE
[NextJs] Override distDir with an environment variable

### DIFF
--- a/samples/nextjs/next.config.js
+++ b/samples/nextjs/next.config.js
@@ -11,6 +11,9 @@ const disconnected = process.env.JSS_MODE === JSS_MODE_DISCONNECTED;
 
 const nextConfig = {
 
+  // Allow specifying a distinct distDir when concurrently running app in a container
+  distDir: process.env.NEXTJS_DIST_DIR || ".next",
+
   i18n: {
     // These are all the locales you want to support in your application.
     // These should generally match (or at least be a subset of) those in Sitecore.

--- a/samples/nextjs/next.config.js
+++ b/samples/nextjs/next.config.js
@@ -12,7 +12,7 @@ const disconnected = process.env.JSS_MODE === JSS_MODE_DISCONNECTED;
 const nextConfig = {
 
   // Allow specifying a distinct distDir when concurrently running app in a container
-  distDir: process.env.NEXTJS_DIST_DIR || ".next",
+  distDir: process.env.NEXTJS_DIST_DIR || '.next',
 
   i18n: {
     // These are all the locales you want to support in your application.


### PR DESCRIPTION
* Allow specifying a distinct distDir when concurrently running app in a container

## Motivation
If the Next.js app is running concurrently in a container, ensures there are no concurrency issues with the .next directory.

## How Has This Been Tested?
* Implemented changes in my containerized environment
* Set the env var
* Saw the new distDir created

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
