### PR TITLE
Documentation for additional Web.config transform requirements to fully disable secure cookies

### DIFF
--- a/docs/data/routes/docs/fundamentals/services/layout-service/en.md
+++ b/docs/data/routes/docs/fundamentals/services/layout-service/en.md
@@ -90,7 +90,10 @@ If you don't want analytics tracking for your JSS app, or for particular Layout 
 > _NOTE_: As of Sitecore 10.0.1, Sitecore sets the `Secure` flag on all cookies by default. This can impact JSS local development in *Connected* and *Headless* modes, as the proxied Sitecore cookies (including analytics cookies) will be rejected by the browser if your application is not running under HTTPS, and thus visits will not be tracked and content may not be personalized. To work around this, you can either:
 > * Enable HTTPS in your local environment by modifying the node server, using a local reverse proxy, or using a service such as ngrok.
 >     * If you are running Sitecore in containers for development, you can make use of the Traefik reverse proxy that is provided in the `docker-compose` environment.
-> * Transform the Sitecore Web.config and set `requireSSL` to `false` in the `httpCookies` configuration. **This is not recommended for production.** `<httpCookies sameSite="None" requireSSL="false" />`
+> * Transform the Sitecore Web.config and set:
+>   * `requireSSL` to `false` and `sameSite` to `Unspecified` in the `httpCookies` configuration
+>   * `cookieSameSite` to `Unspecified` in the `sessionState` configuration
+>   * **This is not recommended for production.**
 
 ## Invoking the Layout Service from JSS
 

--- a/docs/data/routes/docs/fundamentals/services/tracking/en.md
+++ b/docs/data/routes/docs/fundamentals/services/tracking/en.md
@@ -14,7 +14,10 @@ The JSS tracker supports tracking Events, Goals, Outcomes, Campaigns, and Page/R
 > _NOTE_: As of Sitecore 10.0.1, Sitecore sets the `Secure` flag on all cookies by default. This can impact JSS local development in *Connected* and *Headless* modes, as the proxied Sitecore cookies (including analytics cookies) will be rejected by the browser if your application is not running under HTTPS, and thus visits will not be tracked and content may not be personalized. To work around this, you can either:
 > * Enable HTTPS in your local environment by modifying the node server, using a local reverse proxy, or using a service such as ngrok.
 >     * If you are running Sitecore in containers for development, you can make use of the Traefik reverse proxy that is provided in the `docker-compose` environment.
-> * Transform the Sitecore Web.config and set `requireSSL` to `false` in the `httpCookies` configuration. **This is not recommended for production.** `<httpCookies sameSite="None" requireSSL="false" />`
+> * Transform the Sitecore Web.config and set:
+>   * `requireSSL` to `false` and `sameSite` to `Unspecified` in the `httpCookies` configuration
+>   * `cookieSameSite` to `Unspecified` in the `sessionState` configuration
+>   * **This is not recommended for production.**
 
 ## Setup
 


### PR DESCRIPTION
Added documentation for additional Web.config transform requirements to fully disable secure cookies.

## Description
 Setting `requireSSL` to `false` is not enough since `sameSite` is set to `None` by default and [would be rejected by the browser](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). `sameSite` must also be set to `Unspecified` for `httpCookies` and `sessionState` (`cookieSameSite` attribute).

See related PR #524

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
