### PR TITLE
[Next.js] [EE] Finalize editing secret following JSS.Server implementation

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.test.ts
@@ -3,7 +3,7 @@
 import { expect, use, spy } from 'chai';
 import spies from 'chai-spies';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { QUERY_PARAM_SECURITY_TOKEN } from '../services/editing-data-service';
+import { QUERY_PARAM_EDITING_SECRET } from '../services/editing-data-service';
 import { EditingData } from '../sharedTypes/editing-data';
 import { EditingDataCache } from './editing-data-cache';
 import { EditingDataMiddleware } from './editing-data-middleware';
@@ -54,20 +54,20 @@ const mockEditingData = {
 } as EditingData;
 
 describe('EditingDataMiddleware', () => {
-  const token = 'token1234';
+  const secret = 'secret1234';
 
   beforeEach(() => {
-    process.env.SITECORE_SECURITY_TOKEN = token;
+    process.env.JSS_EDITING_SECRET = secret;
   });
 
   after(() => {
-    delete process.env.SITECORE_SECURITY_TOKEN;
+    delete process.env.JSS_EDITING_SECRET;
   });
 
   it('should handle PUT request', async () => {
     const key = 'key1234';
     const query = { key } as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const cache = mockCache();
     const req = mockRequest('PUT', query, mockEditingData);
     const res = mockResponse();
@@ -87,7 +87,7 @@ describe('EditingDataMiddleware', () => {
   it('should handle GET request', async () => {
     const key = 'key1234';
     const query = { key } as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const cache = mockCache(mockEditingData);
     const req = mockRequest('GET', query);
     const res = mockResponse();
@@ -110,7 +110,7 @@ describe('EditingDataMiddleware', () => {
     const key = 'key1234';
     const query = {} as Query;
     query[dynamicRouteKey] = key;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const cache = mockCache(mockEditingData);
     const req = mockRequest('GET', query);
     const res = mockResponse();
@@ -134,7 +134,7 @@ describe('EditingDataMiddleware', () => {
   it('should respond with 400 for invalid editing data', async () => {
     const key = 'key1234';
     const query = { key } as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const cache = mockCache();
     const req = mockRequest('PUT', query, { invalid: 'data' });
     const res = mockResponse();
@@ -150,7 +150,7 @@ describe('EditingDataMiddleware', () => {
     expect(res.end).to.have.been.called.once;
   });
 
-  it('should respond with 401 for missing token', async () => {
+  it('should respond with 401 for missing secret', async () => {
     const key = 'key1234';
     const query = { key } as Query;
     const cache = mockCache();
@@ -168,10 +168,10 @@ describe('EditingDataMiddleware', () => {
     expect(res.end).to.have.been.called.once;
   });
 
-  it('should respond with 401 for invalid token', async () => {
+  it('should respond with 401 for invalid secret', async () => {
     const key = 'key1234';
     const query = { key } as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = 'nope';
+    query[QUERY_PARAM_EDITING_SECRET] = 'nope';
     const cache = mockCache();
     const req = mockRequest('GET', query);
     const res = mockResponse();
@@ -190,7 +190,7 @@ describe('EditingDataMiddleware', () => {
   it('should respond with 405 for unsupported method', async () => {
     const key = 'key1234';
     const query = { key } as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const cache = mockCache();
     const req = mockRequest('POST', query);
     const res = mockResponse();

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.ts
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { EditingDataCache, editingDataDiskCache } from './editing-data-cache';
 import { EditingData, isEditingData } from '../sharedTypes/editing-data';
-import { QUERY_PARAM_SECURITY_TOKEN } from '../services/editing-data-service';
-import { getSitecoreSecurityToken } from '../utils';
+import { QUERY_PARAM_EDITING_SECRET } from '../services/editing-data-service';
+import { getJssEditingSecret } from '../utils';
 
 export interface EditingDataMiddlewareConfig {
   /**
@@ -48,12 +48,12 @@ export class EditingDataMiddleware {
 
   private handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     const { method, query, body } = req;
-    const token = query[QUERY_PARAM_SECURITY_TOKEN];
+    const secret = query[QUERY_PARAM_EDITING_SECRET];
     const key = query[this.queryParamKey];
 
-    // Validate security token
-    if (token !== getSitecoreSecurityToken()) {
-      return res.status(401).end('Missing or invalid security token');
+    // Validate secret
+    if (secret !== getJssEditingSecret()) {
+      return res.status(401).end('Missing or invalid secret');
     }
 
     switch (method) {

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
@@ -5,7 +5,7 @@ import spies from 'chai-spies';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { EditingDataService } from '../services/editing-data-service';
-import { QUERY_PARAM_SECURITY_TOKEN } from '../services/editing-data-service';
+import { QUERY_PARAM_EDITING_SECRET } from '../services/editing-data-service';
 import { EditingPreviewData } from '../sharedTypes/editing-data';
 import { EE_PATH, EE_LANGUAGE, EE_LAYOUT, EE_DICTIONARY, EE_BODY } from '../testData/ee-data';
 import { EditingRenderMiddleware, extractEditingData } from './editing-render-middleware';
@@ -68,22 +68,22 @@ const mockDataService = (previewData?: EditingPreviewData) => {
 
 describe('EditingRenderMiddleware', () => {
   const publicUrl = 'http://test.com';
-  const token = 'token1234';
+  const secret = 'secret1234';
 
   beforeEach(() => {
     process.env.PUBLIC_URL = publicUrl;
-    process.env.SITECORE_SECURITY_TOKEN = token;
+    process.env.JSS_EDITING_SECRET = secret;
   });
 
   after(() => {
     delete process.env.PUBLIC_URL;
-    delete process.env.SITECORE_SECURITY_TOKEN;
+    delete process.env.JSS_EDITING_SECRET;
   });
 
   it('should handle request', async () => {
     const html = '<html><body>Something amazing</body></html>';
     const query = {} as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const previewData = { key: 'key1234' } as EditingPreviewData;
 
     const fetcher = mockFetcher(html);
@@ -134,7 +134,7 @@ describe('EditingRenderMiddleware', () => {
     expect(res.json).to.have.been.called.once;
   });
 
-  it('should respond with 401 for missing token', async () => {
+  it('should respond with 401 for missing secret', async () => {
     const fetcher = mockFetcher();
     const dataService = mockDataService();
     const query = {} as Query;
@@ -154,11 +154,11 @@ describe('EditingRenderMiddleware', () => {
     expect(res.json).to.have.been.called.once;
   });
 
-  it('should respond with 401 for invalid token', async () => {
+  it('should respond with 401 for invalid secret', async () => {
     const fetcher = mockFetcher();
     const dataService = mockDataService();
     const query = {} as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = 'nope';
+    query[QUERY_PARAM_EDITING_SECRET] = 'nope';
     const req = mockRequest(EE_BODY, query);
     const res = mockResponse();
 
@@ -175,13 +175,13 @@ describe('EditingRenderMiddleware', () => {
     expect(res.json).to.have.been.called.once;
   });
 
-  it('should use security token from body', async () => {
+  it('should use editing secret from body', async () => {
     const html = '<html><body>Something amazing</body></html>';
     const fetcher = mockFetcher(html);
     const dataService = mockDataService();
     const query = {} as Query;
-    const bodyWithToken = Object.assign({}, EE_BODY, { SecurityToken: token });
-    const req = mockRequest(bodyWithToken, query);
+    const bodyWithSecret = Object.assign({}, EE_BODY, { JssEditingSecret: secret });
+    const req = mockRequest(bodyWithSecret, query);
     const res = mockResponse();
 
     const middleware = new EditingRenderMiddleware({
@@ -201,7 +201,7 @@ describe('EditingRenderMiddleware', () => {
     const fetcher = mockFetcher('');
     const dataService = mockDataService();
     const query = {} as Query;
-    query[QUERY_PARAM_SECURITY_TOKEN] = token;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
     const req = mockRequest(EE_BODY, query);
     const res = mockResponse();
 

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
@@ -2,8 +2,8 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { EditingData } from '../sharedTypes/editing-data';
 import { EditingDataService, editingDataService } from '../services/editing-data-service';
-import { QUERY_PARAM_SECURITY_TOKEN } from '../services/editing-data-service';
-import { getPublicUrl, getSitecoreSecurityToken } from '../utils';
+import { QUERY_PARAM_EDITING_SECRET } from '../services/editing-data-service';
+import { getPublicUrl, getJssEditingSecret } from '../utils';
 
 export interface EditingRenderMiddlewareConfig {
   /**
@@ -67,11 +67,11 @@ export class EditingRenderMiddleware {
       });
     }
 
-    // Validate security token
-    const token = query[QUERY_PARAM_SECURITY_TOKEN] ?? body?.SecurityToken;
-    if (token !== getSitecoreSecurityToken()) {
+    // Validate secret
+    const secret = query[QUERY_PARAM_EDITING_SECRET] ?? body?.JssEditingSecret;
+    if (secret !== getJssEditingSecret()) {
       return res.status(401).json({
-        html: '<html><body>Missing or invalid security token</body></html>',
+        html: '<html><body>Missing or invalid secret</body></html>',
       });
     }
 

--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
@@ -5,7 +5,7 @@ import spies from 'chai-spies';
 import chaiAsPromised from 'chai-as-promised';
 import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { EditingData } from '../sharedTypes/editing-data';
-import { EditingDataService, QUERY_PARAM_SECURITY_TOKEN } from './editing-data-service';
+import { EditingDataService, QUERY_PARAM_EDITING_SECRET } from './editing-data-service';
 
 use(spies);
 use(chaiAsPromised);
@@ -23,16 +23,16 @@ const mockFetcher = (data?: any) => {
 
 describe('EditingDataService', () => {
   const publicUrl = 'http://test.com';
-  const token = 'token1234';
+  const secret = 'secret1234';
 
   beforeEach(() => {
     process.env.PUBLIC_URL = publicUrl;
-    process.env.SITECORE_SECURITY_TOKEN = token;
+    process.env.JSS_EDITING_SECRET = secret;
   });
 
   after(() => {
     delete process.env.PUBLIC_URL;
-    delete process.env.SITECORE_SECURITY_TOKEN;
+    delete process.env.JSS_EDITING_SECRET;
   });
 
   it('should throw for apiRoute missing [key]', () => {
@@ -45,7 +45,7 @@ describe('EditingDataService', () => {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_SECURITY_TOKEN}=${token}`;
+      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher();
 
@@ -81,7 +81,7 @@ describe('EditingDataService', () => {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_SECURITY_TOKEN}=${token}`;
+      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher(data);
 

--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.ts
@@ -1,8 +1,8 @@
 import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { EditingData, EditingPreviewData } from '../sharedTypes/editing-data';
-import { getPublicUrl, getSitecoreSecurityToken } from '../utils';
+import { getPublicUrl, getJssEditingSecret } from '../utils';
 
-export const QUERY_PARAM_SECURITY_TOKEN = 'token';
+export const QUERY_PARAM_EDITING_SECRET = 'secret';
 
 export interface EditingDataServiceConfig {
   /**
@@ -78,11 +78,11 @@ export class EditingDataService {
 
   protected getUrl(key: string): string {
     // Example URL format:
-    //  http://localhost:3000/api/editing/data/52961eea-bafd-5287-a532-a72e36bd8a36-qkb4e3fv5x?token=1234token
+    //  http://localhost:3000/api/editing/data/52961eea-bafd-5287-a532-a72e36bd8a36-qkb4e3fv5x?secret=1234secret
     const publicUrl = getPublicUrl();
     const apiRoute = this.apiRoute?.replace('[key]', key);
     const url = new URL(apiRoute, publicUrl);
-    url.searchParams.append(QUERY_PARAM_SECURITY_TOKEN, getSitecoreSecurityToken());
+    url.searchParams.append(QUERY_PARAM_EDITING_SECRET, getJssEditingSecret());
     return url.toString();
   }
 }

--- a/packages/sitecore-jss-nextjs/src/utils.test.ts
+++ b/packages/sitecore-jss-nextjs/src/utils.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-expressions */
-import { expect, use, spy } from 'chai';
-import { getPublicUrl, getSitecoreSecurityToken } from './utils';
+import { expect } from 'chai';
+import { getPublicUrl, getJssEditingSecret } from './utils';
 
 describe('utils', () => {
   describe('getPublicUrl', () => {
@@ -32,20 +32,20 @@ describe('utils', () => {
       expect(() => getPublicUrl()).to.throw();
     });
   });
-  describe('getSitecoreSecurityToken', () => {
+  describe('getJssEditingSecret', () => {
     after(() => {
-      delete process.env.SITECORE_SECURITY_TOKEN;
+      delete process.env.JSS_EDITING_SECRET;
     });
 
     it('should throw if env variable missing', () => {
-      expect(() => getSitecoreSecurityToken()).to.throw();
+      expect(() => getJssEditingSecret()).to.throw();
     });
 
     it('should return env variable', () => {
-      const token = '1234abcd';
-      process.env.SITECORE_SECURITY_TOKEN = token;
-      const result = getSitecoreSecurityToken();
-      expect(result).to.equal(token);
+      const secret = '1234abcd';
+      process.env.JSS_EDITING_SECRET = secret;
+      const result = getJssEditingSecret();
+      expect(result).to.equal(secret);
     });
   });
 });

--- a/packages/sitecore-jss-nextjs/src/utils.ts
+++ b/packages/sitecore-jss-nextjs/src/utils.ts
@@ -20,10 +20,10 @@ export const getPublicUrl = (): string => {
   return url.toString().replace(/\/$/, '');
 };
 
-export const getSitecoreSecurityToken = (): string => {
-  const token = process.env.SITECORE_SECURITY_TOKEN;
-  if (!token || token.length === 0) {
-    throw new Error('The SITECORE_SECURITY_TOKEN environment variable is missing or invalid.');
+export const getJssEditingSecret = (): string => {
+  const secret = process.env.JSS_EDITING_SECRET;
+  if (!secret || secret.length === 0) {
+    throw new Error('The JSS_EDITING_SECRET environment variable is missing or invalid.');
   }
-  return token;
+  return secret;
 };

--- a/samples/nextjs/.env
+++ b/samples/nextjs/.env
@@ -11,5 +11,8 @@
 # See https://jss.sitecore.com/docs/fundamentals/services/view-engine
 PUBLIC_URL=http://localhost:3000
 
-# TODO: finalize after JSS.Server implementation complete
-SITECORE_SECURITY_TOKEN=
+# To secure the Experience Editor endpoint exposed by your Next.js app
+# (`/api/editing/render` by default), a secret token is used. This (client-side)
+# value must match your server-side value (see \sitecore\config\JssNextWeb.config).
+# We recommend an alphanumeric value of at least 16 characters.
+JSS_EDITING_SECRET=

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -23,10 +23,10 @@
         JSS EDITING SECRET
         To secure the Experience Editor endpoint exposed by your Next.js app (see `serverSideRenderingEngineEndpointUrl` below),
         a secret token is used. This is taken from an env variable by default, but could be patched and set directly by uncommenting.
-        This (server-side) value must match your client-side value, which is configured by the JSS_EDITING_SECRET env variable (see .env file).
+        This (server-side) value must match your client-side value, which is configured by the JSS_EDITING_SECRET env variable (see the Next.js .env file).
         We recommend an alphanumeric value of at least 16 characters.
 
-        <setting name="JavaScriptServices.ViewEngine.Http.JssEditingSecret" value="$(env:SITECORE_JSS_EDITING_SECRET)" />
+        <setting name="JavaScriptServices.ViewEngine.Http.JssEditingSecret" value="" />
      -->
     </settings>
     <sites>

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -18,6 +18,16 @@
         thus making analytics track the correct original client IP address.
       -->
       <setting name="Analytics.ForwardedRequestHttpHeader" set:value="X-Forwarded-For" />
+
+      <!--
+        JSS EDITING SECRET
+        To secure the Experience Editor endpoint exposed by your Next.js app (see `serverSideRenderingEngineEndpointUrl` below),
+        a secret token is used. This is taken from an env variable by default, but could be patched and set directly by uncommenting.
+        This (server-side) value must match your client-side value, which is configured by the JSS_EDITING_SECRET env variable (see .env file).
+        We recommend an alphanumeric value of at least 16 characters.
+
+        <setting name="JavaScriptServices.ViewEngine.Http.JssEditingSecret" value="$(env:SITECORE_JSS_EDITING_SECRET)" />
+     -->
     </settings>
     <sites>
       <!--


### PR DESCRIPTION
This is a follow-up to #529, which finalizes the editing secret now that JSS.Server implementation is complete. 
Updated names (SITECORE_SECURITY_TOKEN > JSS_EDITING_SECRET and SecurityToken > JssEditingSecret) and added doc comments.