### PR TITLE
Specify buildArtifactsPath in samples/nextjs/package.json

### DIFF
--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -11,7 +11,8 @@
     "sitecoreDistPath": "/dist/JssNextWeb",
     "sitecoreConfigPath": "/App_Config/Include/zzz",
     "graphqlEndpointPath": "/api/jssnextweb",
-    "language": "en"
+    "language": "en",
+    "buildArtifactsPath": "./.next"
   },
   "engines": {
     "node": ">=8.1",


### PR DESCRIPTION
This var is needed for Sitecore import

## Description
Next.js doesn't use a 'dist' folder for build artifacts, so we need to specify the build output path. Otherwise, `jss deploy` fails.

## How Has This Been Tested?
Locally tested deploying next.js app to Sitecore with and without this variable.