### PR TITLE
[Feature/459416] [sitecore-jss-cli] implemented .env handling for CLI

### DIFF
--- a/docs/data/routes/docs/fundamentals/cli/en.md
+++ b/docs/data/routes/docs/fundamentals/cli/en.md
@@ -93,3 +93,25 @@ When using Sitecore-first/connected development methodology, this command scaffo
 > `jss deploy template` should never be used if code-first/disconnected development is in use as it does not update the disconnected manifest, only Sitecore items.
 
 > `jss deploy template` has options that enable modifying how the template is scaffolded, such as specifying template fields with `--fields` or setting a display name with `--displayName`. Run `jss deploy template --help` to see all the options with descriptions.
+
+## Env File Support
+The CLI supports loading environment variables from `.env` files. In particular, this can be used to populate environment variables such as `NODE_EXTRA_CA_CERTS` and `NODE_TLS_REJECT_UNAUTHORIZED` which you may have already configured in an `.env` file for communication with your Sitecore instance.
+
+Variables will be loaded from `.env` files with the following priority:
+
+* `.env.${NODE_ENV}.local`
+* `.env.local` (unless `NODE_ENV` is "test")
+* `.env.${NODE_ENV}`
+* `.env`
+
+The CLI will automatically expand variables (`$VAR`) inside of your `.env*` files. This allows you to reference other values. If you are attempting to use a `$` in a variable value, it needs to be escaped with a backslash (`\`).
+
+```
+PASSWORD=b
+
+# becomes 'adminb'
+EXPANDED=admin$PASSWORD
+
+# becomes 'admin$PASSWORD'
+ESCAPED=admin\$PASSWORD
+```

--- a/docs/data/routes/release-notes/en.md
+++ b/docs/data/routes/release-notes/en.md
@@ -13,6 +13,7 @@ title: Release Notes
 
 ### New Features & Improvements
 * [PR #508](https://github.com/Sitecore/jss/pull/508) [sitecore-jss-react] add useSitecoreContext hook
+* [PR #542](https://github.com/Sitecore/jss/pull/542) Added `.env` file support for the CLI
 
 ### Bug Fixes
 * [PR #506](https://github.com/Sitecore/jss/pull/506) [React sample] `Cannot read property 'sitecore' of null`, when 404 and routeData is null

--- a/packages/sitecore-jss-cli/package-lock.json
+++ b/packages/sitecore-jss-cli/package-lock.json
@@ -480,6 +480,15 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -721,6 +730,16 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -781,6 +800,7 @@
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
@@ -795,8 +815,79 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.2",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+              "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+              "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.9.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.3",
+                "string.prototype.trimstart": "^1.0.3"
+              },
+              "dependencies": {
+                "object.assign": {
+                  "version": "4.1.2",
+                  "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                  "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                  "requires": {
+                    "call-bind": "^1.0.0",
+                    "define-properties": "^1.1.3",
+                    "has-symbols": "^1.0.1",
+                    "object-keys": "^1.1.1"
+                  }
+                }
+              }
+            },
+            "object-inspect": {
+              "version": "1.9.0",
+              "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+              "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+            },
+            "object.assign": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+              "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+              "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+              }
+            },
+            "string.prototype.trimend": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+              "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+              "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+              }
+            },
+            "string.prototype.trimstart": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+              "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+              "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3"
+              }
+            }
           }
         }
       }
@@ -1240,6 +1331,16 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1483,6 +1584,11 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
       "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
       "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-number": {
       "version": "7.0.0",

--- a/packages/sitecore-jss-cli/package.json
+++ b/packages/sitecore-jss-cli/package.json
@@ -34,6 +34,8 @@
     "@sitecore-jss/sitecore-jss-manifest": "^16.0.0-canary.24",
     "chalk": "^2.4.2",
     "cross-spawn": "^7.0.0",
+    "dotenv": "^8.2.0",
+    "dotenv-expand": "^5.1.0",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.4",
     "jszip": "^3.2.2",

--- a/packages/sitecore-jss-cli/src/bin/jss.ts
+++ b/packages/sitecore-jss-cli/src/bin/jss.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import resolve from 'resolve';
+import processEnv from '../process-env';
 
 resolve('@sitecore-jss/sitecore-jss-cli', { basedir: process.cwd() }, (error, projectLocalCli) => {
   let cli;
@@ -18,6 +19,9 @@ resolve('@sitecore-jss/sitecore-jss-cli', { basedir: process.cwd() }, (error, pr
     // No error implies a projectLocalCli, which will load whatever
     // version of jss-cli you have installed in a local package.json
     cli = require(projectLocalCli as string).default;
+
+    // Since we are in context of a project, load its environment variables
+    processEnv(process.cwd());
   }
 
   cli();

--- a/packages/sitecore-jss-cli/src/process-env.test.ts
+++ b/packages/sitecore-jss-cli/src/process-env.test.ts
@@ -105,6 +105,13 @@ describe('processEnv', () => {
     });
   });
 
+  it('should default to development environment', () => {
+    const files = [{ name: '.env.development', value: 'FOO=foo' }];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+    });
+  });
+
   it('should expand variable values', () => {
     const files = [
       {

--- a/packages/sitecore-jss-cli/src/process-env.test.ts
+++ b/packages/sitecore-jss-cli/src/process-env.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import tmp from 'tmp';
+import processEnv from './process-env';
+
+interface EnvFile {
+  name: string;
+  value: string;
+}
+
+describe('processEnv', () => {
+  let nodeEnvOriginal: string | undefined;
+
+  const testTempEnv = (files: EnvFile[], callback: () => void) => {
+    const { name, removeCallback } = tmp.dirSync({ unsafeCleanup: true });
+
+    try {
+      for (const file of files) {
+        fs.writeFileSync(path.resolve(name, file.name), file.value);
+      }
+      processEnv(name);
+      callback();
+    } finally {
+      removeCallback();
+    }
+  };
+
+  before(() => {
+    // stash if set to Test
+    nodeEnvOriginal = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+  });
+
+  after(() => {
+    // restore original
+    process.env.NODE_ENV = nodeEnvOriginal;
+  });
+
+  beforeEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.FOO;
+    delete process.env.BAR;
+  });
+
+  it('should load environment values from the provided path', () => {
+    const files = [{ name: '.env', value: 'FOO=foo' }];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+    });
+  });
+
+  it('should merge environment local values', () => {
+    const files = [
+      { name: '.env', value: 'FOO=foo' },
+      { name: '.env.local', value: 'BAR=bar' },
+    ];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+      expect(process.env.BAR).to.equal('bar');
+    });
+  });
+
+  it('should override environment values from base file', () => {
+    const files = [
+      { name: '.env', value: 'FOO=foo' },
+      { name: '.env.local', value: 'FOO=bar' },
+    ];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('bar');
+    });
+  });
+
+  it('should not merge environment local values when testing', () => {
+    process.env.NODE_ENV = 'test';
+    const files = [{ name: '.env.local', value: 'BAR=bar' }];
+    testTempEnv(files, () => {
+      expect(process.env.BAR).to.be.undefined;
+    });
+  });
+
+  it('should merge environment values', () => {
+    process.env.NODE_ENV = 'production';
+    const files = [
+      { name: '.env', value: 'FOO=foo' },
+      { name: '.env.production', value: 'BAR=bar' },
+    ];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+      expect(process.env.BAR).to.equal('bar');
+    });
+  });
+
+  it('should merge environment local values', () => {
+    process.env.NODE_ENV = 'production';
+    const files = [
+      { name: '.env', value: 'FOO=foo' },
+      { name: '.env.production', value: 'BAR=bar' },
+      { name: '.env.production.local', value: 'BAR=baz' },
+    ];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+      expect(process.env.BAR).to.equal('baz');
+    });
+  });
+
+  it('should expand variable values', () => {
+    const files = [
+      {
+        name: '.env',
+        value: `FOO=foo
+BAR=\${FOO}bar`,
+      },
+    ];
+    testTempEnv(files, () => {
+      expect(process.env.FOO).to.equal('foo');
+      expect(process.env.BAR).to.equal('foobar');
+    });
+  });
+});

--- a/packages/sitecore-jss-cli/src/process-env.test.ts
+++ b/packages/sitecore-jss-cli/src/process-env.test.ts
@@ -105,10 +105,14 @@ describe('processEnv', () => {
     });
   });
 
-  it('should default to development environment', () => {
-    const files = [{ name: '.env.development', value: 'FOO=foo' }];
+  it('should not include environment files without NODE_ENV defined', () => {
+    const files = [
+        { name: '.env.development', value: 'FOO=foo' },
+        { name: '.env.development.local', value: 'BAR=bar' }
+    ];
     testTempEnv(files, () => {
-      expect(process.env.FOO).to.equal('foo');
+      expect(process.env.FOO).to.be.undefined;
+      expect(process.env.BAR).to.be.undefined;
     });
   });
 

--- a/packages/sitecore-jss-cli/src/process-env.ts
+++ b/packages/sitecore-jss-cli/src/process-env.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import * as dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
+
+/**
+ * @param {string} dir The directory containing the .env files to load.
+ */
+export default function processEnv(dir: string) {
+  // replicate Next.js handling/behavior
+  // https://github.com/vercel/next.js/blob/v10.0.5/packages/next-env/index.ts#L80-L90
+  const mode = process.env.NODE_ENV;
+  const dotenvFiles = [
+    `.env.${mode}.local`,
+    // Don't include `.env.local` for `test` environment
+    // since normally you expect tests to produce the same
+    // results for everyone
+    mode !== 'test' && '.env.local',
+    `.env.${mode}`,
+    '.env',
+  ].filter(Boolean) as string[];
+
+  // inspired by https://github.com/entropitor/dotenv-cli/blob/v4.0.0/cli.js#L53-L55
+  dotenvFiles.forEach(function(env) {
+    dotenvExpand(dotenv.config({ path: path.resolve(dir, env) }));
+  });
+}

--- a/packages/sitecore-jss-cli/src/process-env.ts
+++ b/packages/sitecore-jss-cli/src/process-env.ts
@@ -6,16 +6,16 @@ import dotenvExpand from 'dotenv-expand';
  * @param {string} dir The directory containing the .env files to load.
  */
 export default function processEnv(dir: string) {
-  // replicate Next.js handling/behavior
+  // replicate Next.js handling/behavior, but without a default NODE_ENV
   // https://github.com/vercel/next.js/blob/v10.0.5/packages/next-env/index.ts#L80-L90
-  const mode = process.env.NODE_ENV ?? 'development';
+  const mode = process.env.NODE_ENV;
   const dotenvFiles = [
-    `.env.${mode}.local`,
+    mode && `.env.${mode}.local`,
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone
     mode !== 'test' && '.env.local',
-    `.env.${mode}`,
+    mode && `.env.${mode}`,
     '.env',
   ].filter(Boolean) as string[];
 

--- a/packages/sitecore-jss-cli/src/process-env.ts
+++ b/packages/sitecore-jss-cli/src/process-env.ts
@@ -8,7 +8,7 @@ import dotenvExpand from 'dotenv-expand';
 export default function processEnv(dir: string) {
   // replicate Next.js handling/behavior
   // https://github.com/vercel/next.js/blob/v10.0.5/packages/next-env/index.ts#L80-L90
-  const mode = process.env.NODE_ENV;
+  const mode = process.env.NODE_ENV ?? 'development';
   const dotenvFiles = [
     `.env.${mode}.local`,
     // Don't include `.env.local` for `test` environment

--- a/packages/sitecore-jss-cli/src/scripts/environment.ts
+++ b/packages/sitecore-jss-cli/src/scripts/environment.ts
@@ -1,0 +1,27 @@
+/* eslint-disable prettier/prettier */
+/*
+ * Hidden testing/debugging command to print environment variable values.
+ */
+
+export const command = 'environment';
+
+export const describe = 'Prints an environment variable value';
+
+export const builder = {
+  name: {
+    requiresArg: true,
+    type: 'string',
+    describe: 'The name of the environment variable to print.',
+  },
+};
+
+/**
+ * Environment variable handler
+ * @param {any} argv
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function handler(argv: any) {
+  if (argv && argv.name) {
+    console.log(`process.env.${argv.name} = ${process.env[argv.name]}`);
+  }
+}

--- a/packages/sitecore-jss-cli/src/scripts/environment.ts
+++ b/packages/sitecore-jss-cli/src/scripts/environment.ts
@@ -5,7 +5,7 @@
 
 export const command = 'environment';
 
-export const describe = 'Prints an environment variable value';
+export const describe = false;
 
 export const builder = {
   name: {

--- a/packages/sitecore-jss-cli/src/scripts/index.ts
+++ b/packages/sitecore-jss-cli/src/scripts/index.ts
@@ -3,6 +3,7 @@
 
 import * as easterEgg from './easter-egg';
 import * as elephant from './elephant';
+import * as environment from './environment';
 
 import * as clean from './clean';
 import * as deploy from './deploy';
@@ -10,4 +11,4 @@ import * as manifest from './manifest';
 import * as pkg from './package';
 import * as setup from './setup';
 
-export { easterEgg, elephant, setup, deploy, pkg, manifest, clean };
+export { easterEgg, elephant, environment, setup, deploy, pkg, manifest, clean };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
* primarily to support NODE_EXTRA_CA_CERTS
* with behavior and capabilities close to those of Next.js
* includes hidden `jss environment --name FOO` command for debugging

## Motivation
Primarily to support NODE_EXTRA_CA_CERTS. In the Next.js getting started template, I want to populate this in `.env.local` with the mkcert root.

## How Has This Been Tested?
* Unit tests
* Newly added (hidden) CLI command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [X] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
