### PR TITLE
[NextJs] [EE] Use relative URLs for internal editing API calls

### DIFF
--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
@@ -22,16 +22,13 @@ const mockFetcher = (data?: any) => {
 };
 
 describe('EditingDataService', () => {
-  const publicUrl = 'http://test.com';
   const secret = 'secret1234';
 
   beforeEach(() => {
-    process.env.PUBLIC_URL = publicUrl;
     process.env.JSS_EDITING_SECRET = secret;
   });
 
   after(() => {
-    delete process.env.PUBLIC_URL;
     delete process.env.JSS_EDITING_SECRET;
   });
 
@@ -45,7 +42,7 @@ describe('EditingDataService', () => {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher();
 
@@ -73,15 +70,62 @@ describe('EditingDataService', () => {
       const previewData2 = await service.setEditingData(data);
       expect(previewData1.key).to.not.equal(previewData2.key);
     });
+
+    it('should use custom apiRoute', async () => {
+      const data = {
+        layoutData: { sitecore: { route: { itemId: 'd6ac9d26-9474-51cf-982d-4f8d44951229' } } },
+      } as EditingData;
+      const key = '1234key';
+      const expectedUrl = `/api/some/path/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+
+      const fetcher = mockFetcher();
+
+      const service = new EditingDataService({
+        dataFetcher: fetcher,
+        apiRoute: '/api/some/path/[key]',
+      });
+      spy.on(service, 'generateKey', () => {
+        return key;
+      });
+
+      return service.setEditingData(data).then(() => {
+        expect(fetcher.put).to.have.been.called.once;
+        expect(fetcher.put).to.have.been.called.with.exactly(expectedUrl, data);
+      });
+    });
+
+    it('should URI encode secret', async () => {
+      const superSecret = ';,/?:@&=+$';
+      process.env.JSS_EDITING_SECRET = superSecret;
+      const data = {
+        layoutData: { sitecore: { route: { itemId: 'd6ac9d26-9474-51cf-982d-4f8d44951229' } } },
+      } as EditingData;
+      const key = '1234key';
+      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${encodeURIComponent(
+        superSecret
+      )}`;
+
+      const fetcher = mockFetcher();
+
+      const service = new EditingDataService({ dataFetcher: fetcher });
+      spy.on(service, 'generateKey', () => {
+        return key;
+      });
+
+      return service.setEditingData(data).then(() => {
+        expect(fetcher.put).to.have.been.called.once;
+        expect(fetcher.put).to.have.been.called.with.exactly(expectedUrl, data);
+      });
+    });
   });
 
   describe('getEditingData', () => {
-    it('should invoke GET request', () => {
+    it('should invoke GET request', async () => {
       const data = {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `${publicUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher(data);
 
@@ -90,11 +134,10 @@ describe('EditingDataService', () => {
         return key;
       });
 
-      return service.getEditingData({ key }).then((editingData) => {
-        expect(editingData).to.equal(data);
-        expect(fetcher.get).to.have.been.called.once;
-        expect(fetcher.get).to.have.been.called.with(expectedUrl);
-      });
+      const editingData = await service.getEditingData({ key });
+      expect(editingData).to.equal(data);
+      expect(fetcher.get).to.have.been.called.once;
+      expect(fetcher.get).to.have.been.called.with(expectedUrl);
     });
   });
 });

--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.ts
@@ -1,6 +1,6 @@
 import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { EditingData, EditingPreviewData } from '../sharedTypes/editing-data';
-import { getPublicUrl, getJssEditingSecret } from '../utils';
+import { getJssEditingSecret } from '../utils';
 
 export const QUERY_PARAM_EDITING_SECRET = 'secret';
 
@@ -78,12 +78,10 @@ export class EditingDataService {
 
   protected getUrl(key: string): string {
     // Example URL format:
-    //  http://localhost:3000/api/editing/data/52961eea-bafd-5287-a532-a72e36bd8a36-qkb4e3fv5x?secret=1234secret
-    const publicUrl = getPublicUrl();
+    //  /api/editing/data/52961eea-bafd-5287-a532-a72e36bd8a36-qkb4e3fv5x?secret=1234secret
     const apiRoute = this.apiRoute?.replace('[key]', key);
-    const url = new URL(apiRoute, publicUrl);
-    url.searchParams.append(QUERY_PARAM_EDITING_SECRET, getJssEditingSecret());
-    return url.toString();
+    const secret = getJssEditingSecret();
+    return `${apiRoute}?${QUERY_PARAM_EDITING_SECRET}=${encodeURIComponent(secret)}`;
   }
 }
 


### PR DESCRIPTION
Use relative URLs for internal editing API requests instead of PUBLIC_URL which isn't always resolvable within containerized environments.

## Description
<!--- Describe your changes in detail -->

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
