### PR TITLE
[NextJs] Unhelpful error message when GraphQL query fails

### DIFF
--- a/packages/sitecore-jss-nextjs/src/services/component-props-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/component-props-service.ts
@@ -1,4 +1,5 @@
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+import chalk from 'chalk';
 import {
   LayoutServiceData,
   ComponentRendering,
@@ -179,9 +180,13 @@ export class ComponentPropsService {
           componentProps[uid] = result;
         })
         .catch((error) => {
-          console.log(`Error during preload data for component ${uid}:`, error);
+          const errLog = `Error during preload data for component ${uid}: ${error.message ||
+            error}`;
+
+          console.error(chalk.red(errLog));
+
           componentProps[uid] = {
-            error,
+            error: error.message || errLog,
           };
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We should handle component props service errors correctly. Nextjs doesn't accept instance of Error in `getStaticProps`

1. Setup a Next.js environment with a deployed Styleguide app
1. Change the `url` on the GraphQL endpoint in Sitecore config, so that the URL which the app will request will be wrong
1. Deploy config
1. Attempt to load /graphql

**EXPECTED**
I see the ApolloError or other message indicating what's wrong with the GraphQL call

**ACTUAL**
I get a serialization error

![image](https://user-images.githubusercontent.com/23364749/106604615-8c502980-6568-11eb-95d9-ae1f7eb3fb71.png)


## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
