### PR TITLE
[NextJs] [EE] Root server URL detection/handling for internal editing API calls (take 2)

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
@@ -72,12 +72,12 @@ describe('EditingRenderMiddleware', () => {
 
   beforeEach(() => {
     process.env.JSS_EDITING_SECRET = secret;
-    delete process.env.VERCEL_URL;
+    delete process.env.VERCEL;
   });
 
   after(() => {
     delete process.env.JSS_EDITING_SECRET;
-    delete process.env.VERCEL_URL;
+    delete process.env.VERCEL;
   });
 
   it('should handle request', async () => {
@@ -221,15 +221,15 @@ describe('EditingRenderMiddleware', () => {
     });
   });
 
-  it('should use VERCEL_URL with https for serverUrl', async () => {
+  it('should use https for serverUrl on Vercel', async () => {
     const html = '<html><body>Something amazing</body></html>';
     const fetcher = mockFetcher(html);
     const dataService = mockDataService();
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(EE_BODY, query);
+    const req = mockRequest(EE_BODY, query, undefined, 'vercel.com');
     const res = mockResponse();
-    process.env.VERCEL_URL = 'my-site-7q03y4pi5.vercel.app';
+    process.env.VERCEL = '1';
 
     const middleware = new EditingRenderMiddleware({
       dataFetcher: fetcher,
@@ -242,7 +242,7 @@ describe('EditingRenderMiddleware', () => {
     expect(fetcher.get).to.have.been.called.once.and.satisfies((args: any) => {
       const spy = args.__spy;
       const url = spy.calls[0][0] as string;
-      return url.startsWith('https://my-site-7q03y4pi5.vercel.app');
+      return url.startsWith('https://vercel.com');
     });
   });
 

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.test.ts
@@ -21,11 +21,12 @@ type Query = {
   [key: string]: string;
 };
 
-const mockRequest = (body?: any, query?: Query, method?: string) => {
+const mockRequest = (body?: any, query?: Query, method?: string, host?: string) => {
   return {
     body: body ?? {},
     method: method ?? 'POST',
     query: query ?? {},
+    headers: { host: host ?? 'localhost:3000' },
   } as NextApiRequest;
 };
 
@@ -71,10 +72,12 @@ describe('EditingRenderMiddleware', () => {
 
   beforeEach(() => {
     process.env.JSS_EDITING_SECRET = secret;
+    delete process.env.VERCEL_URL;
   });
 
   after(() => {
     delete process.env.JSS_EDITING_SECRET;
+    delete process.env.VERCEL_URL;
   });
 
   it('should handle request', async () => {
@@ -194,7 +197,56 @@ describe('EditingRenderMiddleware', () => {
     expect(res.json).to.have.been.called.once;
   });
 
-  it('should use custom resolvePageRoute', async () => {
+  it('should use host header with http for serverUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const dataService = mockDataService();
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(EE_BODY, query, undefined, 'testhostheader.com');
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware({
+      dataFetcher: fetcher,
+      editingDataService: dataService,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(fetcher.get).to.have.been.called.once.and.satisfies((args: any) => {
+      const spy = args.__spy;
+      const url = spy.calls[0][0] as string;
+      return url.startsWith('http://testhostheader.com');
+    });
+  });
+
+  it('should use VERCEL_URL with https for serverUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const dataService = mockDataService();
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(EE_BODY, query);
+    const res = mockResponse();
+    process.env.VERCEL_URL = 'my-site-7q03y4pi5.vercel.app';
+
+    const middleware = new EditingRenderMiddleware({
+      dataFetcher: fetcher,
+      editingDataService: dataService,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(fetcher.get).to.have.been.called.once.and.satisfies((args: any) => {
+      const spy = args.__spy;
+      const url = spy.calls[0][0] as string;
+      return url.startsWith('https://my-site-7q03y4pi5.vercel.app');
+    });
+  });
+
+  it('should use custom resolveServerUrl', async () => {
     const html = '<html><body>Something amazing</body></html>';
     const fetcher = mockFetcher(html);
     const dataService = mockDataService();
@@ -203,26 +255,59 @@ describe('EditingRenderMiddleware', () => {
     const req = mockRequest(EE_BODY, query);
     const res = mockResponse();
 
-    const expectedPageRoute = `/some/path${EE_PATH}`;
-    const resolvePageRoute = spy((itemPath: string) => {
-      return `/some/path${itemPath}`;
-    });
+    const serverUrl = 'https://test.com';
 
     const middleware = new EditingRenderMiddleware({
       dataFetcher: fetcher,
       editingDataService: dataService,
-      resolvePageRoute: resolvePageRoute,
+      resolveServerUrl: () => {
+        return serverUrl;
+      },
     });
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
-    expect(resolvePageRoute).to.have.been.called.once;
-    expect(resolvePageRoute).to.have.been.called.with(EE_PATH);
     expect(fetcher.get).to.have.been.called.once.and.satisfies((args: any) => {
       const spy = args.__spy;
       const url = spy.calls[0][0] as string;
-      return url.startsWith(expectedPageRoute);
+      return url.startsWith(serverUrl);
+    });
+  });
+
+  it('should use custom resolvePageUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const dataService = mockDataService();
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(EE_BODY, query);
+    const res = mockResponse();
+
+    const serverUrl = 'https://test.com';
+    const expectedPageUrl = `${serverUrl}/some/path${EE_PATH}`;
+    const resolvePageUrl = spy((serverUrl: string, itemPath: string) => {
+      return `${serverUrl}/some/path${itemPath}`;
+    });
+
+    const middleware = new EditingRenderMiddleware({
+      dataFetcher: fetcher,
+      editingDataService: dataService,
+      resolvePageUrl: resolvePageUrl,
+      resolveServerUrl: () => {
+        return serverUrl;
+      },
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(resolvePageUrl).to.have.been.called.once;
+    expect(resolvePageUrl).to.have.been.called.with(EE_PATH);
+    expect(fetcher.get).to.have.been.called.once.and.satisfies((args: any) => {
+      const spy = args.__spy;
+      const url = spy.calls[0][0] as string;
+      return url.startsWith(expectedPageUrl);
     });
   });
 

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
@@ -21,13 +21,23 @@ export interface EditingRenderMiddlewareConfig {
    */
   editingDataService?: EditingDataService;
   /**
-   * Function used to determine page/route to render.
+   * Function used to determine route/page URL to render.
    * This may be necessary for certain custom Next.js routing configurations.
+   * @param {string} serverUrl The root server URL e.g. 'http://localhost:3000'
    * @param {string} itemPath The Sitecore relative item path e.g. '/styleguide'
-   * @returns {string} The route to render
-   * @default itemPath
+   * @returns {string} The URL to render
+   * @default `${serverUrl}${itemPath}`
+   * @see resolveServerUrl
    */
-  resolvePageRoute?: (itemPath: string) => string;
+  resolvePageUrl?: (serverUrl: string, itemPath: string) => string;
+  /**
+   * Function used to determine the root server URL. This is used for the route/page and subsequent data API requests.
+   * By default, the host header is used, unless the VERCEL_URL environment variable is present (for Vercel hosting).
+   * @param {NextApiRequest} req The current request.
+   * @default process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://${req.headers.host}`;
+   * @see resolvePageUrl
+   */
+  resolveServerUrl?: (req: NextApiRequest) => string;
 }
 
 /**
@@ -37,7 +47,8 @@ export interface EditingRenderMiddlewareConfig {
 export class EditingRenderMiddleware {
   private editingDataService: EditingDataService;
   private dataFetcher: AxiosDataFetcher;
-  private resolvePageRoute: (itemPath: string) => string;
+  private resolvePageUrl: (serverUrl: string, itemPath: string) => string;
+  private resolveServerUrl: (req: NextApiRequest) => string;
 
   /**
    * @param {EditingRenderMiddlewareConfig} [config] Editing render middleware config
@@ -45,7 +56,8 @@ export class EditingRenderMiddleware {
   constructor(config?: EditingRenderMiddlewareConfig) {
     this.editingDataService = config?.editingDataService ?? editingDataService;
     this.dataFetcher = config?.dataFetcher ?? new AxiosDataFetcher();
-    this.resolvePageRoute = config?.resolvePageRoute ?? this.defaultResolvePageRoute;
+    this.resolvePageUrl = config?.resolvePageUrl ?? this.defaultResolvePageUrl;
+    this.resolveServerUrl = config?.resolveServerUrl ?? this.defaultResolveServerUrl;
   }
 
   /**
@@ -78,11 +90,14 @@ export class EditingRenderMiddleware {
       // Extract data from EE payload
       const editingData = extractEditingData(req);
 
+      // Resolve server URL
+      const serverUrl = this.resolveServerUrl(req);
+
       // Stash for use later on (i.e. within getStatic/ServerSideProps).
       // This ultimately gets stored on disk (using our EditingDataDiskCache) for compatibility with Vercel Serverless Functions.
       // Note we can't set this directly in setPreviewData since it's stored as a cookie (2KB limit)
       // https://nextjs.org/docs/advanced-features/preview-mode#previewdata-size-limits
-      const previewData = await this.editingDataService.setEditingData(editingData);
+      const previewData = await this.editingDataService.setEditingData(editingData, serverUrl);
 
       // Enable Next.js Preview Mode, passing our preview data (i.e. editingData cache key)
       res.setPreviewData(previewData);
@@ -92,7 +107,7 @@ export class EditingRenderMiddleware {
 
       // Make actual render request for page route, passing on preview cookies.
       // Note timestamp effectively disables caching the request in Axios (no amount of cache headers seemed to do it)
-      const requestUrl = this.resolvePageRoute(editingData.path);
+      const requestUrl = this.resolvePageUrl(serverUrl, editingData.path);
       const pageRes = await this.dataFetcher.get<string>(`${requestUrl}?timestamp=${Date.now()}`, {
         headers: {
           Cookie: cookies.join(';'),
@@ -107,14 +122,28 @@ export class EditingRenderMiddleware {
       res.status(200).json({ html });
     } catch (error) {
       console.error(error);
+
+      if (error.response || error.request) {
+        // Axios error, which could mean the server or page URL isn't quite right, so provide a more helpful hint
+        console.info(
+          // eslint-disable-next-line quotes
+          "Hint: for non-standard server or Next.js route configurations, you may need to override the 'resolveServerUrl' or 'resolvePageUrl' available on the 'EditingRenderMiddleware' config."
+        );
+      }
       res.status(500).json({
         html: `<html><body>${error}</body></html>`,
       });
     }
   };
 
-  private defaultResolvePageRoute = (itemPath: string) => {
-    return itemPath;
+  private defaultResolvePageUrl = (serverUrl: string, itemPath: string) => {
+    return `${serverUrl}${itemPath}`;
+  };
+
+  private defaultResolveServerUrl = (req: NextApiRequest) => {
+    return process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : `http://${req.headers.host}`;
   };
 }
 

--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
@@ -42,7 +42,8 @@ describe('EditingDataService', () => {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+      const serverUrl = 'https://test.com';
+      const expectedUrl = `${serverUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher();
 
@@ -51,7 +52,7 @@ describe('EditingDataService', () => {
         return key;
       });
 
-      return service.setEditingData(data).then((previewData) => {
+      return service.setEditingData(data, serverUrl).then((previewData) => {
         expect(previewData.key).to.equal(key);
         expect(fetcher.put).to.have.been.called.once;
         expect(fetcher.put).to.have.been.called.with.exactly(expectedUrl, data);
@@ -63,11 +64,12 @@ describe('EditingDataService', () => {
         layoutData: { sitecore: { route: { itemId: 'd6ac9d26-9474-51cf-982d-4f8d44951229' } } },
       } as EditingData;
       const fetcher = mockFetcher();
+      const serverUrl = 'https://test.com';
 
       const service = new EditingDataService({ dataFetcher: fetcher });
 
-      const previewData1 = await service.setEditingData(data);
-      const previewData2 = await service.setEditingData(data);
+      const previewData1 = await service.setEditingData(data, serverUrl);
+      const previewData2 = await service.setEditingData(data, serverUrl);
       expect(previewData1.key).to.not.equal(previewData2.key);
     });
 
@@ -76,7 +78,8 @@ describe('EditingDataService', () => {
         layoutData: { sitecore: { route: { itemId: 'd6ac9d26-9474-51cf-982d-4f8d44951229' } } },
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `/api/some/path/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+      const serverUrl = 'https://test.com';
+      const expectedUrl = `${serverUrl}/api/some/path/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher();
 
@@ -88,7 +91,7 @@ describe('EditingDataService', () => {
         return key;
       });
 
-      return service.setEditingData(data).then(() => {
+      return service.setEditingData(data, serverUrl).then(() => {
         expect(fetcher.put).to.have.been.called.once;
         expect(fetcher.put).to.have.been.called.with.exactly(expectedUrl, data);
       });
@@ -101,7 +104,8 @@ describe('EditingDataService', () => {
         layoutData: { sitecore: { route: { itemId: 'd6ac9d26-9474-51cf-982d-4f8d44951229' } } },
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${encodeURIComponent(
+      const serverUrl = 'https://test.com';
+      const expectedUrl = `${serverUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${encodeURIComponent(
         superSecret
       )}`;
 
@@ -112,7 +116,7 @@ describe('EditingDataService', () => {
         return key;
       });
 
-      return service.setEditingData(data).then(() => {
+      return service.setEditingData(data, serverUrl).then(() => {
         expect(fetcher.put).to.have.been.called.once;
         expect(fetcher.put).to.have.been.called.with.exactly(expectedUrl, data);
       });
@@ -125,7 +129,8 @@ describe('EditingDataService', () => {
         path: '/styleguide',
       } as EditingData;
       const key = '1234key';
-      const expectedUrl = `/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
+      const serverUrl = 'https://test.com';
+      const expectedUrl = `${serverUrl}/api/editing/data/${key}?${QUERY_PARAM_EDITING_SECRET}=${secret}`;
 
       const fetcher = mockFetcher(data);
 
@@ -134,7 +139,7 @@ describe('EditingDataService', () => {
         return key;
       });
 
-      const editingData = await service.getEditingData({ key });
+      const editingData = await service.getEditingData({ key, serverUrl });
       expect(editingData).to.equal(data);
       expect(fetcher.get).to.have.been.called.once;
       expect(fetcher.get).to.have.been.called.with(expectedUrl);

--- a/packages/sitecore-jss-nextjs/src/sharedTypes/editing-data.ts
+++ b/packages/sitecore-jss-nextjs/src/sharedTypes/editing-data.ts
@@ -27,4 +27,5 @@ export function isEditingData(data: EditingData | unknown): data is EditingData 
  */
 export interface EditingPreviewData {
   key: string;
+  serverUrl: string;
 }


### PR DESCRIPTION
Root server URL detection/handling for internal editing API calls. Server URL is determined based on original `/api/editing/render` request host header, and presence of `VERCEL` for https protocol usage (http otherwise). This is then used for all subsequent page and data API calls.

## Motivation
The previous 2 attempts (using PUBLIC_URL and then relative requests) failed to provide stability across all necessary environments, configurations, and platforms by default. This aims to cover our "planned" scenarios, with the ability to override if necessary.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
