### PR TITLE
ensure that .next-container is ignored by git

### DIFF
--- a/samples/nextjs/.gitignore
+++ b/samples/nextjs/.gitignore
@@ -7,7 +7,7 @@
 /coverage
 
 # next.js
-/.next/
+/.next*/
 /out/
 
 # graphql code generation


### PR DESCRIPTION
## Description
Update .gitignore to include any .next* folder

## Motivation
We have an environment variable for altering this, specifically for containers, so e.g. `.next-container` should be ignored by default.

## How Has This Been Tested?
Made the same change in my solution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
