### PR TITLE
[NextJs] Switch sample to ISG by default for production mode

### DIFF
--- a/docs/data/routes/docs/client-frameworks/nextjs/nextjs-static-export/en.md
+++ b/docs/data/routes/docs/client-frameworks/nextjs/nextjs-static-export/en.md
@@ -35,7 +35,7 @@ These instructions you should apply in order to run `next export`:
 	  };
 	}
 	```
-	> The `fallback: true` mode of `getStaticPaths` is not supported when using next export.
+	> The `fallback: true` and `fallback: 'blocking'` modes of `getStaticPaths` are not supported when using next export.
 1. Remove usage of `<VisitorIdentification />` component in `src/Layout.tsx`, since Visitor Identification not available.
 1. Define `PUBLIC_URL` in `.env`.
 1. Add script `"export": "npm-run-all --serial bootstrap next:build next:export"` in package.json.

--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -63,7 +63,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
 
     return {
       paths,
-      fallback: false,
+      fallback: 'blocking',
     };
   }
 


### PR DESCRIPTION
## Description
Allow ISG (incremental static generation) for production by default. 

## Motivation
This is helpful when sitemap generation returns empty results. i.e. it removes dependency on Sitecore/server-side GraphQL query stability. This is also currently necessary for Experience Editor support on Vercel due to an [open issue with Next.js Preview Mode compatibility (on Vercel only)](https://github.com/vercel/next.js/issues/16681). In general, this seems like a more sensible default for folks starting out vs the more restrictive `fallback: false`.

## How Has This Been Tested?
This change has been tested locally (using `npm run start:production`) and on Vercel.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
