### PR TITLE
[NextJs] [EE] Fix for "Cannot read property 'parent' of null" issues seen in the Sitecore Experience Editor

### DIFF
--- a/samples/nextjs/src/components/Layout.tsx
+++ b/samples/nextjs/src/components/Layout.tsx
@@ -1,10 +1,17 @@
 import Head from 'next/head';
 import Link from 'next/link';
+import { useEffect } from 'react';
 import { useI18n } from 'next-localization';
 import { getPublicUrl } from 'lib/util';
-import { Placeholder, RouteData, VisitorIdentification } from '@sitecore-jss/sitecore-jss-nextjs';
+import {
+  Placeholder,
+  LayoutServiceData,
+  VisitorIdentification,
+  useSitecoreContext,
+} from '@sitecore-jss/sitecore-jss-nextjs';
+import { StyleguideSitecoreContextValue } from 'lib/component-props';
 
-// Prefix public assets with a public URL to enable compaitibility with Sitecore Experience Editor.
+// Prefix public assets with a public URL to enable compatibility with Sitecore Experience Editor.
 // If you're not supporting the Experience Editor, you can remove this.
 const publicUrl = getPublicUrl();
 
@@ -43,10 +50,25 @@ const Navigation = () => {
 };
 
 type LayoutProps = {
-  route: RouteData;
+  layoutData: LayoutServiceData;
 };
 
-const Layout = ({ route }: LayoutProps): JSX.Element => {
+const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
+  const { updateSitecoreContext } = useSitecoreContext({ updatable: true });
+
+  // Update Sitecore Context if layoutData has changed (i.e. on client-side route change).
+  // Note the context object type here matches the initial value in [[...path]].tsx.
+  useEffect(() => {
+    updateSitecoreContext &&
+      updateSitecoreContext({
+        route: layoutData.sitecore.route,
+        itemId: layoutData.sitecore.route.itemId,
+        ...layoutData.sitecore.context,
+      } as StyleguideSitecoreContextValue);
+  }, [layoutData]);
+
+  const { route } = layoutData.sitecore;
+
   return (
     <>
       <Head>

--- a/samples/nextjs/src/components/Layout.tsx
+++ b/samples/nextjs/src/components/Layout.tsx
@@ -59,12 +59,12 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
   // Update Sitecore Context if layoutData has changed (i.e. on client-side route change).
   // Note the context object type here matches the initial value in [[...path]].tsx.
   useEffect(() => {
-    updateSitecoreContext &&
-      updateSitecoreContext({
-        route: layoutData.sitecore.route,
-        itemId: layoutData.sitecore.route.itemId,
-        ...layoutData.sitecore.context,
-      } as StyleguideSitecoreContextValue);
+    const context: StyleguideSitecoreContextValue = {
+      route: layoutData.sitecore.route,
+      itemId: layoutData.sitecore.route.itemId,
+      ...layoutData.sitecore.context,
+    };
+    updateSitecoreContext && updateSitecoreContext(context);
   }, [layoutData]);
 
   const { route } = layoutData.sitecore;

--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -30,20 +30,16 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     ...layoutData.sitecore.context,
   };
 
-  const routeData = layoutData.sitecore.route;
-
-  const PageLayout = () => (
+  return (
     <ComponentPropsContext value={componentProps}>
       <SitecoreContext<StyleguideSitecoreContextValue>
         componentFactory={componentFactory}
         context={context}
       >
-        <Layout route={routeData} />
+        <Layout layoutData={layoutData} />
       </SitecoreContext>
     </ComponentPropsContext>
   );
-
-  return <PageLayout />;
 };
 
 // This function gets called at build and export time to determine

--- a/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
+++ b/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
@@ -28,20 +28,16 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     ...layoutData.sitecore.context,
   };
 
-  const routeData = layoutData.sitecore.route;
-
-  const PageLayout = () => (
+  return (
     <ComponentPropsContext value={componentProps}>
       <SitecoreContext<StyleguideSitecoreContextValue>
         componentFactory={componentFactory}
         context={context}
       >
-        <Layout route={routeData} />
+        <Layout layoutData={layoutData} />
       </SitecoreContext>
     </ComponentPropsContext>
   );
-
-  return <PageLayout />;
 };
 
 // This function gets called at request time on server-side.


### PR DESCRIPTION
## Description
Switched (back) to direct return for `SitecorePage`, as opposed to intermediary `PageLayout` function component. This was originally the fix for an issue with the `SitecoreContext` not being properly updated (see PR #491, PBI 446949). To resolve this issue, the `Layout.tsx` is now responsible for calling `setSitecoreContext` when layout data changes (which is a similar approach that React sample app takes). 

## Motivation
These changes fix the "Cannot read property 'parent' of null" issues that are seen in the Sitecore Experience Editor.

## How Has This Been Tested?
Tested locally in JSS disconnected, connected modes, and Next.js dev and production modes - both in Experience Editor and out.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
