### PR TITLE
[Next.js] Return notFound from getStatic/ServerSideProps

### DIFF
--- a/samples/nextjs/src/components/NotFound.tsx
+++ b/samples/nextjs/src/components/NotFound.tsx
@@ -1,14 +1,9 @@
-import { LayoutServiceContext } from '@sitecore-jss/sitecore-jss-nextjs';
 import Head from 'next/head';
-
-type NotFoundProps = {
-  context?: LayoutServiceContext;
-};
 
 /**
  * Rendered in case if we have 404 error
  */
-const NotFound = ({ context }: NotFoundProps): JSX.Element => (
+const NotFound = (): JSX.Element => (
   <>
     <Head>
       <title>404: NotFound</title>
@@ -16,13 +11,6 @@ const NotFound = ({ context }: NotFoundProps): JSX.Element => (
     <div style={{ padding: 10 }}>
       <h1>Page not found</h1>
       <p>This page does not exist.</p>
-      {context && (
-        <p>
-          Site: {context.site?.name}
-          <br />
-          Language: {context.language}
-        </p>
-      )}
       <a href="/">Go to the Home page</a>
     </div>
   </>

--- a/samples/nextjs/src/lib/page-props.ts
+++ b/samples/nextjs/src/lib/page-props.ts
@@ -4,9 +4,12 @@ import {
   ComponentPropsCollection,
 } from '@sitecore-jss/sitecore-jss-nextjs';
 
+/**
+ * Sitecore page props
+ */
 export type SitecorePageProps = {
   locale: string;
-  layoutData: LayoutServiceData;
+  layoutData: LayoutServiceData | null;
   dictionary: DictionaryPhrases;
   componentProps: ComponentPropsCollection;
   notFound: boolean;

--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -19,8 +19,9 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     handleExperienceEditorFastRefresh();
   }, []);
 
-  if (notFound) {
-    return <NotFound context={layoutData?.sitecore?.context} />;
+  if (notFound || !layoutData) {
+    // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
+    return <NotFound />;
   }
 
   const context: StyleguideSitecoreContextValue = {
@@ -80,6 +81,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     // - When a request comes in
     // - At most once every 5 seconds
     revalidate: 5, // In seconds
+    notFound: props.notFound, // Returns custom 404 page with a status code of 404
   };
 };
 

--- a/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
+++ b/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
@@ -18,8 +18,9 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     handleExperienceEditorFastRefresh();
   }, []);
 
-  if (notFound) {
-    return <NotFound context={layoutData?.sitecore?.context} />;
+  if (notFound || !layoutData) {
+    // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
+    return <NotFound />;
   }
 
   const context: StyleguideSitecoreContextValue = {
@@ -46,6 +47,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   return {
     props,
+    notFound: props.notFound, // Returns custom 404 page with a status code of 404
   };
 };
 


### PR DESCRIPTION
## Description
Return `notFound` from getStatic/ServerSideProps. This will use the custom 404 page. Since we're now always using the custom 404 page, there's no use sending along layoutData.sitecore.context to the `NotFound` component in `SitecorePagePropsFactory` (not to mention this won't be possible with GraphQL/Edge once implemented).

## Motivation
This is necessary to properly return 404 status codes and also required in SSG for Next.js to delete ISR cached pages. 

## How Has This Been Tested?
Locally in both dev and prod modes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
