### PR TITLE
[NextJS] Media should proxy through Next.js when using hosted Next

### DIFF
--- a/docs/data/routes/docs/client-frameworks/nextjs/nextjs-static-export/en.md
+++ b/docs/data/routes/docs/client-frameworks/nextjs/nextjs-static-export/en.md
@@ -17,10 +17,25 @@ These instructions you should apply in order to run `next export`:
 1. Remove `i18n`:
 	1. Delete i18n configuration in `next.config.js`.
 	1. Define language in `package.json` using `config.language` which will be used during export.
-1. Remove `rewrites` in `next.config.js`.
-1. Remove usage of `<VisitorIdentification />` component in `src/components/Layout.tsx`, since Visitor Identification not available.
-1. Define `PUBLIC_URL` in `.env`.
-1. Add scripts in `package.json`:
+2. Remove `rewrites` in `next.config.js`.
+3. Since `rewrites` are removed it's required to include Sitecore server URL as part of media requests. You should remove configuration patch from `JssNextWeb.config`:
+```xml
+<layoutService>
+	<configurations>
+		<config name="jss">
+			<rendering>
+				<renderingContentsResolver>
+					<IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
+				</renderingContentsResolver>
+			</rendering>
+		</config>
+	</configurations>
+</layoutService>
+```
+or setup `<IncludeServerUrlInMediaUrls>true</IncludeServerUrlInMediaUrls>`. Don't forget to run `jss deploy config`.
+4. Remove usage of `<VisitorIdentification />` component in `src/components/Layout.tsx`, since Visitor Identification not available.
+5. Define `PUBLIC_URL` in `.env`.
+6. Add scripts in `package.json`:
 	* `"next:export": "next export"`.
 	* For disconnected mode: 
 		* `"export": "cross-env-shell JSS_MODE=disconnected PORT=3042 EXPORT_MODE=true \"npm-run-all --serial bootstrap next:build next:export\""`,

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -93,7 +93,8 @@
     </javaScriptServices>
     <!--
       Media URLs resolving
-      Tells Sitecore to not include the Sitecore server URL as part of media requests.
+      Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
+      This eliminates exposing the Sitecore server publicly.
     -->
     <layoutService>
       <configurations>

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -92,9 +92,9 @@
       </allowedMediaParams>
     </javaScriptServices>
     <!--
-        Media URLs resolving
-        Tells Sitecore to not include the Sitecore server URL as part of media requests.
-     -->
+      Media URLs resolving
+      Tells Sitecore to not include the Sitecore server URL as part of media requests.
+    -->
     <layoutService>
       <configurations>
         <config name="jss">

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -91,5 +91,20 @@
         </styleguide-image-sample-adaptive>
       </allowedMediaParams>
     </javaScriptServices>
+    <!--
+        Media URLs resolving
+        Tells Sitecore to not include the Sitecore server URL as part of media requests.
+     -->
+    <layoutService>
+      <configurations>
+        <config name="jss">
+          <rendering>
+            <renderingContentsResolver>
+              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
+            </renderingContentsResolver>
+          </rendering>
+        </config>
+      </configurations>
+    </layoutService>
   </sitecore>
 </configuration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Media URLs currently target CM/CD directly. Our configuration patch should configure the Layout Service by default to not include server URLs in media output, like the headless proxy:
https://jss.sitecore.com/docs/techniques/ssr/headless-mode-ssr#media-urls-in-headless-mode

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
