### PR TITLE
[JSS] [React] - fix: type defs of React Placeholder render props

### DIFF
--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -9,17 +9,17 @@ export interface PlaceholderComponentProps extends PlaceholderProps {
    * Can be used to wrap the Sitecore EE empty placeholder markup in something that's visually correct
    */
   renderEmpty?: (
-    components: React.ReactNode[]
-  ) => React.ComponentClass<any> | React.SFC<any> | React.ReactNode;
+    components: React.ReactElement[]
+  ) => React.ReactNode;
   /**
    * Render props function that enables control over the rendering of the components in the placeholder.
    * Useful for techniques like wrapping each child in a wrapper component.
    */
   render?: (
-    components: React.ReactNode[],
+    components: React.ReactElement[],
     data: (ComponentRendering | HtmlElementRendering)[],
     props: PlaceholderProps
-  ) => React.ComponentClass<any> | React.SFC<any> | React.ReactNode;
+  ) => React.ReactNode;
 
   /**
    * Render props function that is called for each non-system component added to the placeholder.
@@ -28,7 +28,7 @@ export interface PlaceholderComponentProps extends PlaceholderProps {
   renderEach?: (
     component: React.ReactNode,
     index: number
-  ) => React.ComponentClass<any> | React.SFC<any> | React.ReactNode;
+  ) => React.ReactNode;
 }
 
 function isRawRendering(rendering: HtmlElementRendering | ComponentRendering): rendering is HtmlElementRendering {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -38,13 +38,13 @@ export interface PlaceholderProps {
    * A component that is rendered in place of any components that are in this placeholder,
    * but do not have a definition in the componentFactory (i.e. don't have a React implementation)
    */
-  missingComponentComponent?: React.ComponentClass<any> | React.SFC<any>;
+  missingComponentComponent?: React.ComponentType<any>;
 
   /**
    * A component that is rendered in place of the placeholder when an error occurs rendering
    * the placeholder
    */
-  errorComponent?: React.ComponentClass<any> | React.SFC<any>;
+  errorComponent?: React.ComponentType<any>;
 
   [key: string]: any;
 }
@@ -60,14 +60,8 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       PropTypes.object as Requireable<Item[]>
     ]).isRequired),
     params: PropTypes.objectOf(PropTypes.string.isRequired),
-    missingComponentComponent: PropTypes.oneOfType([
-      PropTypes.object as Requireable<React.ComponentClass<any>>,
-      PropTypes.object as Requireable<React.SFC<any>>
-    ]),
-    errorComponent: PropTypes.oneOfType([
-      PropTypes.object as Requireable<React.ComponentClass<any>>,
-      PropTypes.object as Requireable<React.SFC<any>>
-    ]),
+    missingComponentComponent: PropTypes.object as Requireable<React.ComponentType<any>>,
+    errorComponent: PropTypes.object as Requireable<React.ComponentType<any>>,
   };
 
   nodeRefs: any[];
@@ -132,16 +126,16 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         return this.createRawElement(rendering, commonProps);
       }
 
-      let component: React.ReactNode | null = this.getComponentForRendering(rendering);
-      if (!component) {
-        console.error(
-          `Placeholder ${name} contains unknown component ${
-          rendering.componentName
-          }. Ensure that a React component exists for it, and that it is registered in your componentFactory.js.`
-        );
+      const componentForRendering = this.getComponentForRendering(rendering);
 
-        component = missingComponentComponent || MissingComponent;
+      if (!componentForRendering) {
+        console.error(
+          `Placeholder ${name} contains unknown component ${rendering.componentName}. Ensure that a React component exists for it, and that it is registered in your componentFactory.js.`
+        );
       }
+
+      const component: React.ComponentType<any> =
+        componentForRendering || missingComponentComponent! || MissingComponent;
 
       const finalProps = {
         ...commonProps,
@@ -155,9 +149,9 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         rendering,
       };
 
-      return React.createElement(component as any, finalProps);
+      return React.createElement(component, finalProps);
     })
-      .filter((element: any) => element); // remove nulls
+    .filter(Boolean);
   }
 
   getComponentForRendering(renderingDefinition: { componentName: string }) {

--- a/packages/sitecore-jss-react/src/components/sharedTypes.ts
+++ b/packages/sitecore-jss-react/src/components/sharedTypes.ts
@@ -1,3 +1,3 @@
-import { Component } from 'react';
+import { ComponentType } from 'react';
 
-export type ComponentFactory = (componentName: string) => Component;
+export type ComponentFactory = (componentName: string) => ComponentType<any>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The type definitions of the React Placeholder component were not user-friendly/stable. I ensured only one type was used and returned (`React.ReactElement`).

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consistent types. No hacky type casting is done/required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Remove type casts and get TypeScript to test for you :+1: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [?] My code follows the code style of this project. -> This should be done automatically. I didn't see any code guidelines but free improvement remains free improvement. Feel free to adjust this mr to your liking.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
