### PR TITLE
[NextJs] Fix issue with returning notFound: false from getServerSideProps in SSR example

### DIFF
--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -81,7 +81,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     // - When a request comes in
     // - At most once every 5 seconds
     revalidate: 5, // In seconds
-    notFound: props.notFound, // Returns custom 404 page with a status code of 404
+    notFound: props.notFound, // Returns custom 404 page with a status code of 404 when true
   };
 };
 

--- a/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
+++ b/samples/nextjs/src/pages_examples/[[...path]].SSR.tsx
@@ -45,9 +45,13 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const props = await sitecorePagePropsFactory.create(context);
 
+  // Returns custom 404 page with a status code of 404 when notFound: true
+  // Note we can't simply return props.notFound due to an issue in Next.js (https://github.com/vercel/next.js/issues/22472)
+  const notFound = props.notFound ? { notFound: true } : {};
+
   return {
     props,
-    notFound: props.notFound, // Returns custom 404 page with a status code of 404
+    ...notFound,
   };
 };
 


### PR DESCRIPTION
This fixes an issue with returning `notFound: false` from `getServerSideProps`, which is used in our SSR example route.
See related issue in Next.js [here](https://github.com/vercel/next.js/issues/22472).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
