### PR TITLE
[JSS] Disallow file deploy for Next.js solutions

### DIFF
--- a/packages/sitecore-jss-cli/src/scripts/deploy.files.ts
+++ b/packages/sitecore-jss-cli/src/scripts/deploy.files.ts
@@ -68,7 +68,7 @@ export async function handler(argv: any) {
 
   const packageJson = await resolvePackage();
 
-  if (packageJson.config.serverSideRenderingEngine) {
+  if (!packageJson.config.sitecoreDistPath) {
     console.error(
       chalk.red(
         'The current project does not support file deployment into the Sitecore instance. You should use an HTTP POST based integration for Experience Editor support. See SDK documentation for details.'

--- a/packages/sitecore-jss-cli/src/scripts/deploy.files.ts
+++ b/packages/sitecore-jss-cli/src/scripts/deploy.files.ts
@@ -1,5 +1,6 @@
 /* eslint-disable prettier/prettier */
 import { deploy, verifySetup, resolveScJssConfig } from '@sitecore-jss/sitecore-jss-dev-tools';
+import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import resolvePackage from '../resolve-package';
@@ -65,6 +66,18 @@ export const builder = {
 export async function handler(argv: any) {
   verifySetup();
 
+  const packageJson = await resolvePackage();
+
+  if (packageJson.config.serverSideRenderingEngine) {
+    console.error(
+      chalk.red(
+        'The current project does not support file deployment into the Sitecore instance. You should use an HTTP POST based integration for Experience Editor support. See SDK documentation for details.'
+      )
+    );
+
+    return;
+  }
+
   if (!argv.skipBuild && argv.buildTaskName && argv.buildTaskName.length > 0) {
     runPackageScript([argv.buildTaskName]);
   }
@@ -77,8 +90,6 @@ export async function handler(argv: any) {
   };
 
   if (!options.sourcePath || !options.destinationPath) {
-    const packageJson = await resolvePackage();
-
     if (!options.sourcePath) {
       options.sourcePath = packageJson.config.buildArtifactsPath;
       if (!options.sourcePath) {
@@ -89,9 +100,13 @@ export async function handler(argv: any) {
           // /dist = non-CRA convention
           options.sourcePath = path.resolve('dist');
         } else {
-          throw new Error(
-            'No source path specified, conventional build paths missing, and buildArtifactsPath config is not defined in package.json!'
+          console.error(
+            chalk.red(
+              'No source path specified, conventional build paths missing, and buildArtifactsPath config is not defined in package.json!'
+            )
           );
+
+          return;
         }
       }
     }

--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -10,7 +10,6 @@
     ],
     "sitecoreConfigPath": "/App_Config/Include/zzz",
     "graphQLEndpointPath": "/sitecore/api/graph/edge",
-    "serverSideRenderingEngine": true,
     "language": "en"
   },
   "engines": {

--- a/samples/nextjs/package.json
+++ b/samples/nextjs/package.json
@@ -10,6 +10,7 @@
     ],
     "sitecoreConfigPath": "/App_Config/Include/zzz",
     "graphQLEndpointPath": "/sitecore/api/graph/edge",
+    "serverSideRenderingEngine": true,
     "language": "en"
   },
   "engines": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As a JSS developer, I'd like to know that `jss deploy files` and `jss deploy app` are not relevant for Next.js, so that I have the correct expectations about capabilities and behavior of the SDK.
Next.js SDK does not support the 'node' view engine of Integrated mode, you must use the HTTP view engine and the Next.js API endpoints.
* The CLI should output an error such as "The current project does not support file deployment into the Sitecore instance. You should use an HTTP POST based integration for Experience Editor support. See SDK documentation for details."
* `deploy config` should still be supported.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
