### PR TITLE
Fix a memory leak in the SSR Proxy

### DIFF
--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -93,6 +93,8 @@ const config = {
     // This is a major security issue, so NEVER EVER set this to false
     // outside local development. Use a real CA-issued certificate.
 		secure: true,
+    // setting ws to false will prevent the layoutservice call data being saved to memory
+    ws: false,
 		headers: {
 			"accept-encoding": "gzip, deflate"
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If ws: true, the details of the Layout service call will be saved to memory, this object is never cleared. By setting ws: false (as the layout service call is not a websocket call this is the correct config) the details of the call will not be saved to memory

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See before and after fix memory usage
![image](https://user-images.githubusercontent.com/4170885/111597643-ae2b0600-87ce-11eb-85f5-7bf16a200894.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Load testing on Azure, manual testing of the proxy. We have this fix in production.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the Contributing guide.
- [X] My code follows the code style of this project.
- [X] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
