### PR TITLE
modified second point regarding deploying the nextjs app to sitecore

### DIFF
--- a/docs/data/routes/docs/nextjs/getting-started-nextjs/walkthrough-jsscreate/en.md
+++ b/docs/data/routes/docs/nextjs/getting-started-nextjs/walkthrough-jsscreate/en.md
@@ -63,7 +63,7 @@ Sitecore requires Windows, but the instance can be on a virtual machine or a rem
 To connect your application to Sitecore, you must:
 
 1. [Setup JSS Server Components](/docs/client-frameworks/getting-started/jss-server-install).
-2. Run jss deploy items
+2. Run `jss deploy items`.
 
 
 

--- a/docs/data/routes/docs/nextjs/getting-started-nextjs/walkthrough-jsscreate/en.md
+++ b/docs/data/routes/docs/nextjs/getting-started-nextjs/walkthrough-jsscreate/en.md
@@ -63,7 +63,7 @@ Sitecore requires Windows, but the instance can be on a virtual machine or a rem
 To connect your application to Sitecore, you must:
 
 1. [Setup JSS Server Components](/docs/client-frameworks/getting-started/jss-server-install).
-2. [Deploy the application to a Sitecore environment](/docs/client-frameworks/getting-started/app-deployment).
+2. Run jss deploy items
 
 
 


### PR DESCRIPTION
modified second point regarding deploying the nextjs app to site


## Description
It is confusing as on https://jss.sitecore.com/docs/nextjs/getting-started-nextjs/how-is-nextjs-different page, it says that you don't have to deploy next.js jss app to sitecore but on this page it is saying that you have to follow the same deployment approach as in react/angular app.

## Motivation
I was trying to setup nextjs and encountered this problem

## How Has This Been Tested?
documentation change only

## Types of changes
documentation change only

## Checklist:
documentation change only
