### PR TITLE
470753 Fix type errors related to Route | null type in the Next.js sample app

### DIFF
--- a/samples/nextjs/src/Layout.tsx
+++ b/samples/nextjs/src/Layout.tsx
@@ -5,7 +5,6 @@ import { useI18n } from 'next-localization';
 import { getPublicUrl } from 'lib/util';
 import {
   Placeholder,
-  LayoutServiceData,
   VisitorIdentification,
   useSitecoreContext,
 } from '@sitecore-jss/sitecore-jss-nextjs';
@@ -50,31 +49,24 @@ const Navigation = () => {
 };
 
 type LayoutProps = {
-  layoutData: LayoutServiceData;
+  context: StyleguideSitecoreContextValue;
 };
 
-const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
+const Layout = ({ context }: LayoutProps): JSX.Element => {
   const { updateSitecoreContext } = useSitecoreContext({ updatable: true });
 
   // Update Sitecore Context if layoutData has changed (i.e. on client-side route change).
   // Note the context object type here matches the initial value in [[...path]].tsx.
   useEffect(() => {
-    const context: StyleguideSitecoreContextValue = {
-      route: layoutData.sitecore.route,
-      itemId: layoutData.sitecore.route.itemId,
-      ...layoutData.sitecore.context,
-    };
     updateSitecoreContext && updateSitecoreContext(context);
-  }, [layoutData]);
+  }, [context]);
 
-  const { route } = layoutData.sitecore;
+  const { route } = context;
 
   return (
     <>
       <Head>
-        <title>
-          {(route.fields && route.fields.pageTitle && route.fields.pageTitle.value) || 'Page'}
-        </title>
+        <title>{route?.fields?.pageTitle?.value || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
 

--- a/samples/nextjs/src/pages/[[...path]].SSR.tsx
+++ b/samples/nextjs/src/pages/[[...path]].SSR.tsx
@@ -18,7 +18,7 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     handleExperienceEditorFastRefresh();
   }, []);
 
-  if (notFound || !layoutData) {
+  if (notFound || !layoutData?.sitecore?.route) {
     // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
     return <NotFound />;
   }
@@ -35,7 +35,7 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
         componentFactory={componentFactory}
         context={context}
       >
-        <Layout layoutData={layoutData} />
+        <Layout context={context} />
       </SitecoreContext>
     </ComponentPropsContext>
   );

--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -19,7 +19,7 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
     handleExperienceEditorFastRefresh();
   }, []);
 
-  if (notFound || !layoutData) {
+  if (notFound || !layoutData?.sitecore?.route) {
     // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
     return <NotFound />;
   }
@@ -36,7 +36,7 @@ const SitecorePage = ({ notFound, layoutData, componentProps }: SitecorePageProp
         componentFactory={componentFactory}
         context={context}
       >
-        <Layout layoutData={layoutData} />
+        <Layout context={context} />
       </SitecoreContext>
     </ComponentPropsContext>
   );


### PR DESCRIPTION
The type of `route` was recently changed from `RouteData` to `RouteData | null`

Even though we never tried to render <Layout> when route is null, the possibility of null made TypeScript complain. My workaround is to rely on [[...path]] to build the `context` object since it is aware of whether `route` is null or not