### PR TITLE
[JSS] [NextJs] Debug logging multi line toggle

### DIFF
--- a/docs/data/routes/docs/fundamentals/troubleshooting/debug-logging/en.md
+++ b/docs/data/routes/docs/fundamentals/troubleshooting/debug-logging/en.md
@@ -52,8 +52,10 @@ When running through Node.js, you can set a few additional environment variables
 | Name | Purpose |
 | --- | --- |
 | `DEBUG` |	Enables/disables specific debugging namespaces. |
+| `DEBUG_HIDE_DATE` | Hide date from debug output (non-TTY). Default is `false`. |
 | `DEBUG_COLORS` |	Whether or not to use colors in the debug output. Default is `true`. |
 | `DEBUG_DEPTH` |	Object inspection depth. Default is `2`. |
+| `DEBUG_MULTILINE` |	Pretty-print inspected objects on multiple lines. Default is `false` (single line). |
 | `DEBUG_SHOW_HIDDEN` |	Shows hidden properties on inspected objects. Default is `false`. |
 
 > To learn more about the `DEBUG_` environment variables, see [debug](https://www.npmjs.com/package/debug#environment-variables).

--- a/packages/sitecore-jss/src/debug.ts
+++ b/packages/sitecore-jss/src/debug.ts
@@ -1,8 +1,21 @@
 import debug from 'debug';
+import { isServer } from './util';
 
 const rootNamespace = 'sitecore-jss';
 
 export type Debugger = debug.Debugger;
+
+// On server/node side, allow switching from the built-in
+// `%o` (pretty-print single line) and `%O` (pretty-print multiple line)
+// with a `DEBUG_MULTILINE` environment variable.
+if (
+  isServer() &&
+  process?.env?.DEBUG_MULTILINE === 'true' &&
+  debug.formatters.o &&
+  debug.formatters.O
+) {
+  debug.formatters.o = debug.formatters.O;
+}
 
 /**
  * Default Sitecore JSS 'debug' module debuggers. Uses namespace prefix 'sitecore-jss:'.


### PR DESCRIPTION
## Description
Added `DEBUG_MULTILINE` environment variable to allow switching from our default `%o` (pretty-print single line) to `%O` (pretty-print multiple line) formatting.

This is a follow-up to #645.

## Motivation
In some cases it could be preferred to use multiline formatting. This provides that option.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
