### PR TITLE
[sitecore-jss-nextjs] Links inside RichText control cause page to be loaded twice

### DIFF
--- a/docs/data/routes/release-notes/en.md
+++ b/docs/data/routes/release-notes/en.md
@@ -26,6 +26,7 @@ There are [migration instructions](/upgrade-guides/18.0) from JSS 16-based appli
 
 ### Bug Fixes
 
+* [PR #659](https://github.com/Sitecore/jss/pull/659) [sitecore-jss-nextjs] Links inside RichText control cause page to be loaded twice
 * [PR #624](https://github.com/Sitecore/jss/pull/624):
 	* [sitecore-jss-react-native] [Image] Pass Object `style` type for `SvgUrI` instead of Array. 
 	* [sitecore-jss-react-native] [Date] Always render `<HtmlView/>` if `editable` is provided.

--- a/packages/sitecore-jss-nextjs/src/components/RichText.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.tsx
@@ -30,7 +30,7 @@ export const RichText = (props: RichTextProps): JSX.Element => {
     if (hasText && !isEditing) {
       initializeLinks();
     }
-  });
+  }, []);
 
   const routeHandler = (ev: MouseEvent) => {
     if (!ev.target) return;
@@ -56,7 +56,6 @@ export const RichText = (props: RichTextProps): JSX.Element => {
         prefetched[link.pathname] = true;
       }
 
-      link.removeEventListener('click', routeHandler, false);
       link.addEventListener('click', routeHandler, false);
     });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you click a link inside a RichText control, the target page will be loaded twice.
The cause of issue was that `useEffect` was called twice, because `dependencies` argument wasn't provided, so `removeEventListeners` can be removed.

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
