### PR TITLE
[node-headless-ssr-proxy + Angular sample] Error in console when refresh /graphql page

### DIFF
--- a/docs/data/routes/release-notes/en.md
+++ b/docs/data/routes/release-notes/en.md
@@ -26,6 +26,7 @@ There are [migration instructions](/upgrade-guides/18.0) from JSS 16-based appli
 
 ### Bug Fixes
 
+* [PR #680](https://github.com/Sitecore/jss/pull/680) [node-headless-ssr-proxy + Angular sample] Error in console when refresh /graphql page
 * [PR #659](https://github.com/Sitecore/jss/pull/659) [sitecore-jss-nextjs] Links inside RichText control cause page to be loaded twice
 * [PR #624](https://github.com/Sitecore/jss/pull/624):
 	* [sitecore-jss-react-native] [Image] Pass Object `style` type for `SvgUrI` instead of Array. 

--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -93,9 +93,6 @@ const config = {
     // This is a major security issue, so NEVER EVER set this to false
     // outside local development. Use a real CA-issued certificate.
 		secure: true,
-		headers: {
-			"accept-encoding": "gzip, deflate"
-		},
 		xfwd: true
 	},
 	/**

--- a/samples/node-headless-ssr-proxy/index.js
+++ b/samples/node-headless-ssr-proxy/index.js
@@ -27,6 +27,19 @@ server.use(
  */
 // server.use(cacheMiddleware());
 
+server.use((req, res, next) => {
+  // because this is a proxy, all headers are forwarded on to the Sitecore server
+  // but, if we SSR we only understand how to decompress gzip and deflate. Some
+  // modern browsers would send 'br' (brotli) as well, and if the Sitecore server
+  // supported that (maybe via CDN) it would fail SSR as we can't decode the Brotli
+  // response. So, we force the accept-encoding header to only include what we can understand.
+  if (req.headers['accept-encoding']) {
+    req.headers['accept-encoding'] = 'gzip, deflate';
+  }
+
+  next();
+})
+
 // For any other requests, we render app routes server-side and return them
 server.use('*', scProxy(config.serverBundle.renderView, config, config.serverBundle.parseRouteUrl));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
When you refresh /graphql page, angular sample doesn't provide `accept-encoding` header, but before fix we setup it on every request. If request contains `accept-encoding` we should setup it, if not - just skip.
Interesting that when you refresh another page, request will contain `accept-encoding` header with value `gzip, deflate, br`.

The issue is coming from PR #461, when we started to setup `accept-encoding` on every request

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
