### PR TITLE
Feature/475116

### DIFF
--- a/docs/data/routes/docs/nextjs/experience-edge/api/en.md
+++ b/docs/data/routes/docs/nextjs/experience-edge/api/en.md
@@ -1,0 +1,21 @@
+---
+name: edge-api
+routeTemplate: ./data/component-templates/article.yml
+title: Unified GraphQL Schema
+---
+# Unified GraphQL Schema
+
+Unified = serves data from multiple authoring sources through a single endpoint.
+
+## Queries
+
+### search
+Need to specify operator required  for the multi-value fields like _path and _templates.
+
+Ex.
+```
+
+```
+
+Even though _hasLayout should always be "true" in this query, using a variable is necessary for compatibility with Edge.
+TODO: Will there be a KB article that describes this known issue?

--- a/docs/data/routes/docs/nextjs/experience-edge/api/en.md
+++ b/docs/data/routes/docs/nextjs/experience-edge/api/en.md
@@ -12,10 +12,8 @@ Unified = serves data from multiple authoring sources through a single endpoint.
 ### search
 Need to specify operator required  for the multi-value fields like _path and _templates.
 
-Ex.
-```
-
-```
+Ex. [Dictionary search query](https://github.com/Sitecore/jss/blob/6a2f9497d9fa377ae4ce489d1e76bb341f385751/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L11)
 
 Even though _hasLayout should always be "true" in this query, using a variable is necessary for compatibility with Edge.
+
 TODO: Will there be a KB article that describes this known issue?

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
@@ -14,11 +14,13 @@ const DEFAULTS = Object.freeze({
   pageSize: 10,
 });
 
+// Event hough _hasLayout should always be "true" in this query, using a variable is necessary for compatibility with Edge
 const query = /* GraphQL */ `
   query SitePageQuery(
     $rootItemId: String!
     $language: String!
     $pageSize: Int = 10
+    $hasLayout: String = "true"
     $after: String
   ) {
     search(
@@ -26,7 +28,7 @@ const query = /* GraphQL */ `
         AND: [
           { name: "_path", value: $rootItemId }
           { name: "_language", value: $language }
-          { name: "_hasLayout", value: "true" }
+          { name: "_hasLayout", value: $hasLayout }
         ]
       }
       first: $pageSize

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
@@ -14,7 +14,7 @@ const DEFAULTS = Object.freeze({
   pageSize: 10,
 });
 
-// Event hough _hasLayout should always be "true" in this query, using a variable is necessary for compatibility with Edge
+// Even though _hasLayout should always be "true" in this query, using a variable is necessary for compatibility with Edge
 const query = /* GraphQL */ `
   query SitePageQuery(
     $rootItemId: String!
@@ -26,7 +26,7 @@ const query = /* GraphQL */ `
     search(
       where: {
         AND: [
-          { name: "_path", value: $rootItemId }
+          { name: "_path", value: $rootItemId, operator: CONTAINS }
           { name: "_language", value: $language }
           { name: "_hasLayout", value: $hasLayout }
         ]

--- a/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
+++ b/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
@@ -19,7 +19,7 @@ const query = /* GraphQL */ `
     search(
       where: {
         AND: [
-          { name: "_path", value: $rootItemId }
+          { name: "_path", value: $rootItemId, operator: CONTAINS }
           { name: "_templates", value: $dictionaryEntryTemplateId }
           { name: "_language", value: $language }
         ]


### PR DESCRIPTION
## Description / Motivation
Because of the known issue on the Delivery Edge side, when variables are used in predicates, the last predicate will error is the value is passed in directly. Additionally, the mirrored schema uses "contains" as the default operator, but for edge it should be specified explicitly. 

## Testing Details
tested by building all packages and building the sample next js app, which uses these queries.
