### PR TITLE
Bug/472144

### DIFF
--- a/samples/node-headless-ssr-experience-edge/README.md
+++ b/samples/node-headless-ssr-experience-edge/README.md
@@ -36,6 +36,7 @@ The following environment variables can be set to configure the SSR sample inste
 | `SITECORE_API_KEY`                     | The API key provisioned on Sitecore Experience Edge. 																																																						|
 | `SITECORE_JSS_SERVER_BUNDLE`           | Path to the JSS app's `server.bundle.js` file.        																																									                          |
 | `SITECORE_EXPERIENCE_EDGE_ENDPOINT`    | Sitecore Experience Edge endpoint.																																																				                        |
+| `DEFAULT_LANGUAGE` | The JSS app's default language. Used to determine language context in case language is not specified in request URL.|
 | `PORT` 																 | Optional. Port which will be used when start sample. Default can be seen in [config.js](./config.js).                                                            |
 
 ## Build & run

--- a/samples/node-headless-ssr-experience-edge/config.js
+++ b/samples/node-headless-ssr-experience-edge/config.js
@@ -32,6 +32,11 @@ const config = {
    * Port which will be used when start sample
    */
   port: process.env.PORT || 3000,
+  /*
+  * The default language to use in case the context language cannot be determined (this happens
+  * on initial page load, if the language is not specified in the URL)
+  */
+  defaultLanguage: process.env.DEFAULT_LANGUAGE || serverBundle.defaultLanguage
 };
 
 module.exports = config;

--- a/samples/node-headless-ssr-experience-edge/index.js
+++ b/samples/node-headless-ssr-experience-edge/index.js
@@ -83,16 +83,12 @@ server.use(async (req, res) => {
       return;
     }
 
-    const layoutData = await layoutService.fetchLayoutData(route, lang);
-
-    // Take language provided by layout data in case if language is not provided in requested url
-    const language = lang || layoutData.sitecore.context.language;
+    // Language is required. In case it's not specified in the requested URL, fallback to the default language from the app configuration.
+    const layoutData = await layoutService.fetchLayoutData(route, lang || config.defaultLanguage);
 
     const viewBag = { dictionary: {} };
 
-    if (language) {
-      viewBag.dictionary = await dictionaryService.fetchDictionaryData(language);
-    }
+    viewBag.dictionary = await dictionaryService.fetchDictionaryData(layoutData.sitecore.context.language);
 
     renderView(
       (err, result) => {

--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -126,6 +126,7 @@ const config = {
       return {};
     }
 
+    // TODO: fallback language should come from app configuration
     const language = layoutServiceData.sitecore.context.language || 'en';
     const site =
       layoutServiceData.sitecore.context.site && layoutServiceData.sitecore.context.site.name;

--- a/samples/react/server/server.js
+++ b/samples/react/server/server.js
@@ -38,11 +38,10 @@ export const setUpDefaultAgents = (httpAgent, httpsAgent) => {
   https.globalAgent = httpsAgent;
 };
 
-/** Export the API key. This will be used by default in Headless mode, removing the need to manually configure the API key on the proxy. */
+// Export app configuration; this will be used when this app runs in Headless mode (ie node-headless-ssr-experience-edge or node-headless-ssr-proxy)
 export const apiKey = config.sitecoreApiKey;
-
-/** Export the app name. This will be used by default in Headless mode, removing the need to manually configure the app name on the proxy. */
 export const appName = config.jssAppName;
+export const defaultLanguage = config.defaultLanguage;
 
 /**
  * Main entry point to the application when run via Server-Side Rendering,


### PR DESCRIPTION
## Description / Motivation
Add default language for node-headless-ssr-experience-edge; default language is determined by property in package.json of the JSS app

## Testing Details
1. run jss build on react app
2. copy contents from build folder to node-headless-ssr-experience-edge/dist/<appName>/ folder
3. npm install in node-headless-ssr-experience-edge
4. npm run start
5. Go to localhost:3000/
