### PR TITLE
sitecore-jss - remove 'npm ci' from build steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,6 @@ variables:
 
 steps:
 - script: |
-    npm ci
-  displayName: 'npm ci'
-- script: |
     npm run bootstrap:ci
   displayName: 'bootstrapping packages'
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ variables:
 
 steps:
 - script: |
-    npm run bootstrap:ci
+    npx lerna bootstrap --ci
   displayName: 'bootstrapping packages'
 - script: |
     npm run build-packages


### PR DESCRIPTION
'npm ci' should not be necessary, as this is covered by 'npm bootsrap:ci'