### PR TITLE
Generate API reference documentation using typedoc (only for jss-sitecore package)

### DIFF
--- a/packages/sitecore-jss/docs/README.md
+++ b/packages/sitecore-jss/docs/README.md
@@ -1,0 +1,445 @@
+@sitecore-jss/sitecore-jss
+
+# @sitecore-jss/sitecore-jss
+
+## Table of contents
+
+### Namespaces
+
+- [constants](modules/constants.md)
+- [mediaApi](modules/mediaapi.md)
+
+### Enumerations
+
+- [LayoutServicePageState](enums/layoutservicepagestate.md)
+
+### Classes
+
+- [AxiosDataFetcher](classes/axiosdatafetcher.md)
+- [GraphQLDictionaryService](classes/graphqldictionaryservice.md)
+- [GraphQLLayoutService](classes/graphqllayoutservice.md)
+- [GraphQLRequestClient](classes/graphqlrequestclient.md)
+- [RestDictionaryService](classes/restdictionaryservice.md)
+- [RestLayoutService](classes/restlayoutservice.md)
+
+### Interfaces
+
+- [ComponentFields](interfaces/componentfields.md)
+- [ComponentParams](interfaces/componentparams.md)
+- [ComponentRendering](interfaces/componentrendering.md)
+- [DictionaryPhrases](interfaces/dictionaryphrases.md)
+- [DictionaryService](interfaces/dictionaryservice.md)
+- [Field](interfaces/field.md)
+- [GraphQLDictionaryServiceConfig](interfaces/graphqldictionaryserviceconfig.md)
+- [HtmlElementRendering](interfaces/htmlelementrendering.md)
+- [HttpResponse](interfaces/httpresponse.md)
+- [Item](interfaces/item.md)
+- [LayoutService](interfaces/layoutservice.md)
+- [LayoutServiceConfig](interfaces/layoutserviceconfig.md)
+- [LayoutServiceContext](interfaces/layoutservicecontext.md)
+- [LayoutServiceContextData](interfaces/layoutservicecontextdata.md)
+- [LayoutServiceData](interfaces/layoutservicedata.md)
+- [LayoutServiceRequestOptions](interfaces/layoutservicerequestoptions.md)
+- [PlaceholderData](interfaces/placeholderdata.md)
+- [RouteData](interfaces/routedata.md)
+
+### Type aliases
+
+- [AxiosDataFetcherConfig](README.md#axiosdatafetcherconfig)
+- [DataFetcherResolver](README.md#datafetcherresolver)
+- [Debugger](README.md#debugger)
+- [GraphQLLayoutServiceConfig](README.md#graphqllayoutserviceconfig)
+- [GraphQLRequestClientConfig](README.md#graphqlrequestclientconfig)
+- [HttpDataFetcher](README.md#httpdatafetcher)
+- [PlaceholdersData](README.md#placeholdersdata)
+- [RestDictionaryServiceConfig](README.md#restdictionaryserviceconfig)
+- [RestDictionaryServiceData](README.md#restdictionaryservicedata)
+- [RestLayoutServiceConfig](README.md#restlayoutserviceconfig)
+
+### Properties
+
+- [debug](README.md#debug)
+
+### Variables
+
+- [dataApi](README.md#dataapi)
+
+### Functions
+
+- [fetchData](README.md#fetchdata)
+- [getAppRootId](README.md#getapprootid)
+- [getChildPlaceholder](README.md#getchildplaceholder)
+- [getFieldValue](README.md#getfieldvalue)
+- [isExperienceEditorActive](README.md#isexperienceeditoractive)
+- [isServer](README.md#isserver)
+- [resetExperienceEditorChromes](README.md#resetexperienceeditorchromes)
+- [resolveUrl](README.md#resolveurl)
+
+## Type aliases
+
+### AxiosDataFetcherConfig
+
+Ƭ **AxiosDataFetcherConfig**: AxiosRequestConfig & AxiosDataFetcherOptions
+
+Defined in: [axios-fetcher.ts:35](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L35)
+
+___
+
+### DataFetcherResolver
+
+Ƭ **DataFetcherResolver**: <T\>(`req?`: IncomingMessage, `res?`: ServerResponse) => [*HttpDataFetcher*](README.md#httpdatafetcher)<T\>
+
+Data fetcher resolver in order to provide custom data fetcher
+
+**`param`** Request instance
+
+**`param`** Response instance
+
+#### Type declaration
+
+▸ <T\>(`req?`: IncomingMessage, `res?`: ServerResponse): [*HttpDataFetcher*](README.md#httpdatafetcher)<T\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req?` | IncomingMessage |
+| `res?` | ServerResponse |
+
+**Returns:** [*HttpDataFetcher*](README.md#httpdatafetcher)<T\>
+
+Defined in: [layout/rest-layout-service.ts:149](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L149)
+
+___
+
+### Debugger
+
+Ƭ **Debugger**: debug.Debugger
+
+Defined in: [debug.ts:6](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/debug.ts#L6)
+
+___
+
+### GraphQLLayoutServiceConfig
+
+Ƭ **GraphQLLayoutServiceConfig**: *object*
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `apiKey` | *string* | The API key to use for authentication |
+| `endpoint` | *string* | Your Graphql endpoint |
+| `formatLayoutQuery?` | (`siteName`: *string*, `itemPath`: *string*, `locale?`: *string*) => *string* | Override default layout query  **`param`**  **`param`**  **`param`**  **`returns`** custom layout query   **`default`** Layout query layout(site:"${siteName}", routePath:"${itemPath}", language:"${language}") |
+| `siteName` | *string* | The JSS application name |
+
+Defined in: [layout/graphql-layout-service.ts:6](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/graphql-layout-service.ts#L6)
+
+___
+
+### GraphQLRequestClientConfig
+
+Ƭ **GraphQLRequestClientConfig**: *object*
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `apiKey?` | *string* | The API key to use for authentication. This will be added as an 'sc_apikey' header. |
+| `debugger?` | [*Debugger*](README.md#debugger) | Override debugger for logging. Uses 'sitecore-jss:http' by default. |
+
+Defined in: [graphql-request-client.ts:5](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L5)
+
+___
+
+### HttpDataFetcher
+
+Ƭ **HttpDataFetcher**<T\>: (`url`: *string*, `data?`: { [key: string]: *unknown*;  }) => *Promise*<[*HttpResponse*](interfaces/httpresponse.md)<T\>\>
+
+Describes functions that fetch data asynchronously (i.e. from an API endpoint).
+This interface conforms to Axios' public API, but is adaptable to other HTTP libraries and
+fetch polyfills.
+The interface implementation must:
+- Support SSR
+- Comply with the rules of REST by returning appropriate response status codes when there is an error instead of throwing exceptions.
+- Send HTTP POST requests if `data` param is specified; GET is suggested but not required for data-less requests
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Type declaration
+
+▸ (`url`: *string*, `data?`: { [key: string]: *unknown*;  }): *Promise*<[*HttpResponse*](interfaces/httpresponse.md)<T\>\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | *string* |
+| `data?` | *object* |
+
+**Returns:** *Promise*<[*HttpResponse*](interfaces/httpresponse.md)<T\>\>
+
+Defined in: [data-fetcher.ts:26](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/data-fetcher.ts#L26)
+
+___
+
+### PlaceholdersData
+
+Ƭ **PlaceholdersData**<TYPEDNAME\>: { [P in TYPEDNAME]: (ComponentRendering \| HtmlElementRendering)[]}
+
+Placeholder contents data (name: placeholder name, then array of components within that placeholder name)
+Note: HtmlElementRendering is used by Sitecore Experience Editor
+
+#### Type parameters
+
+| Name | Type | Default |
+| :------ | :------ | :------ |
+| `TYPEDNAME` | *string* | *string* |
+
+Defined in: [layout/models.ts:64](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L64)
+
+___
+
+### RestDictionaryServiceConfig
+
+Ƭ **RestDictionaryServiceConfig**: CacheOptions & { `apiHost`: *string* ; `apiKey`: *string* ; `dataFetcher?`: [*HttpDataFetcher*](README.md#httpdatafetcher)<[*RestDictionaryServiceData*](README.md#restdictionaryservicedata)\> ; `siteName`: *string*  }
+
+Defined in: [i18n/rest-dictionary-service.ts:13](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L13)
+
+___
+
+### RestDictionaryServiceData
+
+Ƭ **RestDictionaryServiceData**: *object*
+
+A reply from the REST Sitecore Dictionary Service
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `phrases` | [*DictionaryPhrases*](interfaces/dictionaryphrases.md) |
+
+Defined in: [i18n/rest-dictionary-service.ts:9](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L9)
+
+___
+
+### RestLayoutServiceConfig
+
+Ƭ **RestLayoutServiceConfig**: *object*
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `apiHost` | *string* | Your Sitecore instance hostname that is the backend for JSS |
+| `apiKey` | *string* | The Sitecore SSC API key your app uses |
+| `dataFetcherResolver?` | [*DataFetcherResolver*](README.md#datafetcherresolver) | Function that handles fetching API data |
+| `siteName` | *string* | The JSS application name |
+| `tracking?` | *boolean* | Enables/disables analytics tracking for the Layout Service invocation (default is true). More than likely, this would be set to false for SSG/hybrid implementations, and the JSS tracker would instead be used on the client-side: [https://jss.sitecore.com/docs/fundamentals/services/tracking](https://jss.sitecore.com/docs/fundamentals/services/tracking)  **`default`** true |
+
+Defined in: [layout/rest-layout-service.ts:118](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L118)
+
+## Properties
+
+### debug
+
+• **debug**: *Readonly*<{ `dictionary`: Debugger ; `experienceEditor`: Debugger ; `http`: Debugger ; `layout`: Debugger ; `sitemap`: Debugger  }\>
+
+## Variables
+
+### dataApi
+
+• `Const` **dataApi**: *object*
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `fetchPlaceholderData` | (`placeholderName`: *string*, `itemPath`: *string*, `options`: [*LayoutServiceRequestOptions*](interfaces/layoutservicerequestoptions.md)<[*PlaceholderData*](interfaces/placeholderdata.md)\>) => *Promise*<[*PlaceholderData*](interfaces/placeholderdata.md)\> |
+| `fetchRouteData` | (`itemPath`: *string*, `options`: [*LayoutServiceRequestOptions*](interfaces/layoutservicerequestoptions.md)<[*LayoutServiceData*](interfaces/layoutservicedata.md)\>) => *Promise*<[*LayoutServiceData*](interfaces/layoutservicedata.md)\> |
+
+Defined in: [index.ts:13](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/index.ts#L13)
+
+## Functions
+
+### fetchData
+
+▸ **fetchData**<T\>(`url`: *string*, `fetcher`: [*HttpDataFetcher*](README.md#httpdatafetcher)<T\>, `params?`: querystring.ParsedUrlQueryInput): *Promise*<T\>
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `url` | *string* | - |
+| `fetcher` | [*HttpDataFetcher*](README.md#httpdatafetcher)<T\> | - |
+| `params` | querystring.ParsedUrlQueryInput | {} |
+
+**Returns:** *Promise*<T\>
+
+Defined in: [data-fetcher.ts:60](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/data-fetcher.ts#L60)
+
+___
+
+### getAppRootId
+
+▸ **getAppRootId**(`client`: [*GraphQLRequestClient*](classes/graphqlrequestclient.md), `siteName`: *string*, `language`: *string*): *Promise*<string\>
+
+Gets the ID of the JSS App root item from the Sitecore item tree.
+
+**`throws`** Error if the app root was not found for the specified site and language.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [*GraphQLRequestClient*](classes/graphqlrequestclient.md) | that fetches data from a GraphQL endpoint. |
+| `siteName` | *string* | the name of the Sitecore site. |
+| `language` | *string* | the item language version. |
+
+**Returns:** *Promise*<string\>
+
+the root item ID of the JSS App in Sitecore.
+
+Defined in: [utils/graphql-queries.ts:37](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/utils/graphql-queries.ts#L37)
+
+___
+
+### getChildPlaceholder
+
+▸ **getChildPlaceholder**(`rendering`: [*ComponentRendering*](interfaces/componentrendering.md), `placeholderName`: *string*): ([*ComponentRendering*](interfaces/componentrendering.md) \| [*HtmlElementRendering*](interfaces/htmlelementrendering.md))[]
+
+Gets rendering definitions in a given child placeholder under a current rendering.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `rendering` | [*ComponentRendering*](interfaces/componentrendering.md) |
+| `placeholderName` | *string* |
+
+**Returns:** ([*ComponentRendering*](interfaces/componentrendering.md) \| [*HtmlElementRendering*](interfaces/htmlelementrendering.md))[]
+
+child placeholder
+
+Defined in: [layout/utils.ts:56](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/utils.ts#L56)
+
+___
+
+### getFieldValue
+
+▸ **getFieldValue**<T\>(`renderingOrFields`: [*ComponentRendering*](interfaces/componentrendering.md) \| Fields, `fieldName`: *string*): T \| *undefined*
+
+Safely extracts a field value from a rendering or fields object.
+Null will be returned if the field is not defined.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `renderingOrFields` | [*ComponentRendering*](interfaces/componentrendering.md) \| Fields |
+| `fieldName` | *string* |
+
+**Returns:** T \| *undefined*
+
+Defined in: [layout/utils.ts:9](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/utils.ts#L9)
+
+▸ **getFieldValue**<T\>(`renderingOrFields`: [*ComponentRendering*](interfaces/componentrendering.md) \| Fields, `fieldName`: *string*, `defaultValue`: T): T
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `renderingOrFields` | [*ComponentRendering*](interfaces/componentrendering.md) \| Fields |
+| `fieldName` | *string* |
+| `defaultValue` | T |
+
+**Returns:** T
+
+Defined in: [layout/utils.ts:13](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/utils.ts#L13)
+
+___
+
+### isExperienceEditorActive
+
+▸ `Const` **isExperienceEditorActive**(): *boolean*
+
+**Returns:** *boolean*
+
+Defined in: [utils/experience-editor.ts:3](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/utils/experience-editor.ts#L3)
+
+___
+
+### isServer
+
+▸ **isServer**(): *boolean*
+
+Determines whether the current execution context is server-side
+
+**Returns:** *boolean*
+
+true if executing server-side
+
+Defined in: [utils/is-server.ts:5](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/utils/is-server.ts#L5)
+
+___
+
+### resetExperienceEditorChromes
+
+▸ `Const` **resetExperienceEditorChromes**(): *void*
+
+**Returns:** *void*
+
+Defined in: [utils/experience-editor.ts:12](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/utils/experience-editor.ts#L12)
+
+___
+
+### resolveUrl
+
+▸ **resolveUrl**(`urlBase`: *string*, `params?`: querystring.ParsedUrlQueryInput): *string*
+
+Resolves a base URL that may contain query string parameters and an additional set of query
+string parameters into a unified string representation.
+
+**`throws`** {RangeError} if the provided url is an empty string
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `urlBase` | *string* | - | the base URL that may contain query string parameters |
+| `params` | querystring.ParsedUrlQueryInput | {} | query string parameters |
+
+**Returns:** *string*
+
+a URL string
+
+Defined in: [utils/resolve-url.ts:24](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/utils/resolve-url.ts#L24)

--- a/packages/sitecore-jss/docs/classes/axiosdatafetcher.md
+++ b/packages/sitecore-jss/docs/classes/axiosdatafetcher.md
@@ -1,0 +1,186 @@
+[@sitecore-jss/sitecore-jss](../README.md) / AxiosDataFetcher
+
+# Class: AxiosDataFetcher
+
+## Table of contents
+
+### Constructors
+
+- [constructor](axiosdatafetcher.md#constructor)
+
+### Properties
+
+- [instance](axiosdatafetcher.md#instance)
+
+### Methods
+
+- [delete](axiosdatafetcher.md#delete)
+- [fetch](axiosdatafetcher.md#fetch)
+- [get](axiosdatafetcher.md#get)
+- [head](axiosdatafetcher.md#head)
+- [post](axiosdatafetcher.md#post)
+- [put](axiosdatafetcher.md#put)
+
+## Constructors
+
+### constructor
+
+\+ **new AxiosDataFetcher**(`dataFetcherConfig?`: [*AxiosDataFetcherConfig*](../README.md#axiosdatafetcherconfig)): [*AxiosDataFetcher*](axiosdatafetcher.md)
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `dataFetcherConfig` | [*AxiosDataFetcherConfig*](../README.md#axiosdatafetcherconfig) | {} | Axios data fetcher configuration. Note `withCredentials` is set to `true` by default in order for Sitecore cookies to be included in CORS requests (which is necessary for analytics and such). |
+
+**Returns:** [*AxiosDataFetcher*](axiosdatafetcher.md)
+
+Defined in: [axios-fetcher.ts:46](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L46)
+
+## Properties
+
+### instance
+
+• `Private` **instance**: AxiosInstance
+
+Defined in: [axios-fetcher.ts:46](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L46)
+
+## Methods
+
+### delete
+
+▸ **delete**(`url`: *string*, `config?`: AxiosRequestConfig): *Promise*<AxiosResponse<any\>\>
+
+Perform a DELETE request
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `config?` | AxiosRequestConfig | - |
+
+**Returns:** *Promise*<AxiosResponse<any\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:163](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L163)
+
+___
+
+### fetch
+
+▸ **fetch**<T\>(`url`: *string*, `data?`: *unknown*): *Promise*<AxiosResponse<T\>\>
+
+Implements a data fetcher. @see HttpDataFetcher<T> type for implementation details/notes.
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `data?` | *unknown* | - |
+
+**Returns:** *Promise*<AxiosResponse<T\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:107](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L107)
+
+___
+
+### get
+
+▸ **get**<T\>(`url`: *string*, `config?`: AxiosRequestConfig): *Promise*<AxiosResponse<T\>\>
+
+Perform a GET request
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `config?` | AxiosRequestConfig | - |
+
+**Returns:** *Promise*<AxiosResponse<T\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:121](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L121)
+
+___
+
+### head
+
+▸ **head**(`url`: *string*, `config?`: AxiosRequestConfig): *Promise*<AxiosResponse<any\>\>
+
+Perform a HEAD request
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `config?` | AxiosRequestConfig | - |
+
+**Returns:** *Promise*<AxiosResponse<any\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:131](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L131)
+
+___
+
+### post
+
+▸ **post**(`url`: *string*, `data?`: *unknown*, `config?`: AxiosRequestConfig): *Promise*<AxiosResponse<any\>\>
+
+Perform a POST request
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `data?` | *unknown* | - |
+| `config?` | AxiosRequestConfig | - |
+
+**Returns:** *Promise*<AxiosResponse<any\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:142](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L142)
+
+___
+
+### put
+
+▸ **put**(`url`: *string*, `data?`: *unknown*, `config?`: AxiosRequestConfig): *Promise*<AxiosResponse<any\>\>
+
+Perform a PUT request
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | *string* | The URL to request; may include query string |
+| `data?` | *unknown* | - |
+| `config?` | AxiosRequestConfig | - |
+
+**Returns:** *Promise*<AxiosResponse<any\>\>
+
+response
+
+Defined in: [axios-fetcher.ts:153](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/axios-fetcher.ts#L153)

--- a/packages/sitecore-jss/docs/classes/graphqldictionaryservice.md
+++ b/packages/sitecore-jss/docs/classes/graphqldictionaryservice.md
@@ -1,0 +1,171 @@
+[@sitecore-jss/sitecore-jss](../README.md) / GraphQLDictionaryService
+
+# Class: GraphQLDictionaryService
+
+Fetch dictionary data using  Sitecore's GraphQL API.
+Note: Uses graphql-request as the default library for fetching graphql data (@see GraphQLRequestClient).
+
+## Hierarchy
+
+- *DictionaryServiceBase*
+
+  ↳ **GraphQLDictionaryService**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](graphqldictionaryservice.md#constructor)
+
+### Properties
+
+- [options](graphqldictionaryservice.md#options)
+
+### Methods
+
+- [fetchDictionaryData](graphqldictionaryservice.md#fetchdictionarydata)
+- [getCacheValue](graphqldictionaryservice.md#getcachevalue)
+- [getDictionaryPhrases](graphqldictionaryservice.md#getdictionaryphrases)
+- [setCacheValue](graphqldictionaryservice.md#setcachevalue)
+
+## Constructors
+
+### constructor
+
+\+ **new GraphQLDictionaryService**(`options`: [*GraphQLDictionaryServiceConfig*](../interfaces/graphqldictionaryserviceconfig.md)): [*GraphQLDictionaryService*](graphqldictionaryservice.md)
+
+Creates an instance of graphQL dictionary service with the provided options
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | [*GraphQLDictionaryServiceConfig*](../interfaces/graphqldictionaryserviceconfig.md) | instance |
+
+**Returns:** [*GraphQLDictionaryService*](graphqldictionaryservice.md)
+
+Overrides: DictionaryServiceBase.constructor
+
+Defined in: [i18n/graphql-dictionary-service.ts:104](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L104)
+
+## Properties
+
+### options
+
+• **options**: [*GraphQLDictionaryServiceConfig*](../interfaces/graphqldictionaryserviceconfig.md)
+
+Inherited from: DictionaryServiceBase.options
+
+## Methods
+
+### fetchDictionaryData
+
+▸ **fetchDictionaryData**(`language`: *string*): *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+Fetches dictionary data for internalization.
+
+**`default`** Search query
+query DictionarySearch(
+$rootItemId: String!,
+$language: String!,
+$dictionaryEntryTemplateId: String!,
+$pageSize: Int = 10,
+$after: String
+) {
+search(
+where: {
+AND:[
+{ name: "_path",      value: $rootItemId },
+{ name: "_templates", value: $dictionaryEntryTemplateId },
+{ name: "_language",  value: $language }
+]
+}
+first: $pageSize
+after: $after
+orderBy: { name: "Title", direction: ASC }
+) {
+total
+pageInfo {
+endCursor
+hasNext
+}
+dictionaryPhrases: results {
+key: field(name: "key") {
+value
+},
+phrase: field(name: "phrase") {
+value
+}
+}
+}
+}
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `language` | *string* | the language to fetch |
+
+**Returns:** *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+Overrides: DictionaryServiceBase.fetchDictionaryData
+
+Defined in: [i18n/graphql-dictionary-service.ts:153](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L153)
+
+___
+
+### getCacheValue
+
+▸ `Protected` **getCacheValue**(`key`: *string*): ``null`` \| [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | *string* |
+
+**Returns:** ``null`` \| [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+Inherited from: DictionaryServiceBase.getCacheValue
+
+Defined in: [i18n/dictionary-service.ts:55](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L55)
+
+___
+
+### getDictionaryPhrases
+
+▸ **getDictionaryPhrases**(`client`: [*GraphQLRequestClient*](graphqlrequestclient.md), `language`: *string*): *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+Gets dictionary phrases
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `client` | [*GraphQLRequestClient*](graphqlrequestclient.md) | that fetches data from a GraphQL endpoint. |
+| `language` | *string* |  |
+
+**Returns:** *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+dictionary phrases
+
+Defined in: [i18n/graphql-dictionary-service.ts:182](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L182)
+
+___
+
+### setCacheValue
+
+▸ `Protected` **setCacheValue**(`key`: *string*, `value`: [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)): [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | *string* |
+| `value` | [*DictionaryPhrases*](../interfaces/dictionaryphrases.md) |
+
+**Returns:** [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+Inherited from: DictionaryServiceBase.setCacheValue
+
+Defined in: [i18n/dictionary-service.ts:59](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L59)

--- a/packages/sitecore-jss/docs/classes/graphqllayoutservice.md
+++ b/packages/sitecore-jss/docs/classes/graphqllayoutservice.md
@@ -1,0 +1,95 @@
+[@sitecore-jss/sitecore-jss](../README.md) / GraphQLLayoutService
+
+# Class: GraphQLLayoutService
+
+## Hierarchy
+
+- *LayoutServiceBase*
+
+  ↳ **GraphQLLayoutService**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](graphqllayoutservice.md#constructor)
+
+### Methods
+
+- [createClient](graphqllayoutservice.md#createclient)
+- [fetchLayoutData](graphqllayoutservice.md#fetchlayoutdata)
+- [getLayoutQuery](graphqllayoutservice.md#getlayoutquery)
+
+## Constructors
+
+### constructor
+
+\+ **new GraphQLLayoutService**(`serviceConfig`: [*GraphQLLayoutServiceConfig*](../README.md#graphqllayoutserviceconfig)): [*GraphQLLayoutService*](graphqllayoutservice.md)
+
+Fetch layout data using the Sitecore GraphQL endpoint.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serviceConfig` | [*GraphQLLayoutServiceConfig*](../README.md#graphqllayoutserviceconfig) |
+
+**Returns:** [*GraphQLLayoutService*](graphqllayoutservice.md)
+
+Overrides: LayoutServiceBase.constructor
+
+Defined in: [layout/graphql-layout-service.ts:33](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/graphql-layout-service.ts#L33)
+
+## Methods
+
+### createClient
+
+▸ `Private` **createClient**(): [*GraphQLRequestClient*](graphqlrequestclient.md)
+
+Returns new graphql client instance
+
+**Returns:** [*GraphQLRequestClient*](graphqlrequestclient.md)
+
+Defined in: [layout/graphql-layout-service.ts:72](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/graphql-layout-service.ts#L72)
+
+___
+
+### fetchLayoutData
+
+▸ **fetchLayoutData**(`itemPath`: *string*, `language?`: *string*): *Promise*<[*LayoutServiceData*](../interfaces/layoutservicedata.md)\>
+
+Fetch layout data for an item.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `itemPath` | *string* |
+| `language?` | *string* |
+
+**Returns:** *Promise*<[*LayoutServiceData*](../interfaces/layoutservicedata.md)\>
+
+layout service data
+
+Overrides: LayoutServiceBase.fetchLayoutData
+
+Defined in: [layout/graphql-layout-service.ts:48](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/graphql-layout-service.ts#L48)
+
+___
+
+### getLayoutQuery
+
+▸ `Private` **getLayoutQuery**(`itemPath`: *string*, `language?`: *string*): *string*
+
+Returns GraphQL Layout query
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `itemPath` | *string* | page route |
+| `language?` | *string* | - |
+
+**Returns:** *string*
+
+Defined in: [layout/graphql-layout-service.ts:83](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/graphql-layout-service.ts#L83)

--- a/packages/sitecore-jss/docs/classes/graphqlrequestclient.md
+++ b/packages/sitecore-jss/docs/classes/graphqlrequestclient.md
@@ -1,0 +1,87 @@
+[@sitecore-jss/sitecore-jss](../README.md) / GraphQLRequestClient
+
+# Class: GraphQLRequestClient
+
+## Table of contents
+
+### Constructors
+
+- [constructor](graphqlrequestclient.md#constructor)
+
+### Properties
+
+- [client](graphqlrequestclient.md#client)
+- [debug](graphqlrequestclient.md#debug)
+- [headers](graphqlrequestclient.md#headers)
+
+### Methods
+
+- [request](graphqlrequestclient.md#request)
+
+## Constructors
+
+### constructor
+
+\+ **new GraphQLRequestClient**(`endpoint`: *string*, `clientConfig?`: [*GraphQLRequestClientConfig*](../README.md#graphqlrequestclientconfig)): [*GraphQLRequestClient*](graphqlrequestclient.md)
+
+Provides ability to execute graphql query using given `endpoint`
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `endpoint` | *string* | - | The Graphql endpoint |
+| `clientConfig` | [*GraphQLRequestClientConfig*](../README.md#graphqlrequestclientconfig) | {} | - |
+
+**Returns:** [*GraphQLRequestClient*](graphqlrequestclient.md)
+
+Defined in: [graphql-request-client.ts:19](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L19)
+
+## Properties
+
+### client
+
+• `Private` **client**: *GraphQLClient*
+
+Defined in: [graphql-request-client.ts:17](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L17)
+
+___
+
+### debug
+
+• `Private` **debug**: Debugger
+
+Defined in: [graphql-request-client.ts:19](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L19)
+
+___
+
+### headers
+
+• `Private` **headers**: *Record*<string, string\>= {}
+
+Defined in: [graphql-request-client.ts:18](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L18)
+
+## Methods
+
+### request
+
+▸ **request**<T\>(`query`: *string* \| DocumentNode, `variables?`: { [key: string]: *unknown*;  }): *Promise*<T\>
+
+Execute graphql request
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `query` | *string* \| DocumentNode | graphql query |
+| `variables?` | *object* | graphql variables |
+
+**Returns:** *Promise*<T\>
+
+Defined in: [graphql-request-client.ts:39](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/graphql-request-client.ts#L39)

--- a/packages/sitecore-jss/docs/classes/restdictionaryservice.md
+++ b/packages/sitecore-jss/docs/classes/restdictionaryservice.md
@@ -1,0 +1,146 @@
+[@sitecore-jss/sitecore-jss](../README.md) / RestDictionaryService
+
+# Class: RestDictionaryService
+
+Fetch dictionary data using the Sitecore Dictionary Service REST API.
+Uses Axios as the default data fetcher (@see AxiosDataFetcher).
+
+## Hierarchy
+
+- *DictionaryServiceBase*
+
+  ↳ **RestDictionaryService**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](restdictionaryservice.md#constructor)
+
+### Properties
+
+- [options](restdictionaryservice.md#options)
+
+### Accessors
+
+- [defaultFetcher](restdictionaryservice.md#defaultfetcher)
+
+### Methods
+
+- [fetchDictionaryData](restdictionaryservice.md#fetchdictionarydata)
+- [getCacheValue](restdictionaryservice.md#getcachevalue)
+- [getUrl](restdictionaryservice.md#geturl)
+- [setCacheValue](restdictionaryservice.md#setcachevalue)
+
+## Constructors
+
+### constructor
+
+\+ **new RestDictionaryService**(`options`: [*RestDictionaryServiceConfig*](../README.md#restdictionaryserviceconfig)): [*RestDictionaryService*](restdictionaryservice.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `options` | [*RestDictionaryServiceConfig*](../README.md#restdictionaryserviceconfig) |
+
+**Returns:** [*RestDictionaryService*](restdictionaryservice.md)
+
+Overrides: DictionaryServiceBase.constructor
+
+Defined in: [i18n/rest-dictionary-service.ts:44](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L44)
+
+## Properties
+
+### options
+
+• **options**: [*RestDictionaryServiceConfig*](../README.md#restdictionaryserviceconfig)
+
+Inherited from: DictionaryServiceBase.options
+
+## Accessors
+
+### defaultFetcher
+
+• get **defaultFetcher**(): [*HttpDataFetcher*](../README.md#httpdatafetcher)<[*RestDictionaryServiceData*](../README.md#restdictionaryservicedata)\>
+
+Provides default @see AxiosDataFetcher data fetcher
+
+**Returns:** [*HttpDataFetcher*](../README.md#httpdatafetcher)<[*RestDictionaryServiceData*](../README.md#restdictionaryservicedata)\>
+
+Defined in: [i18n/rest-dictionary-service.ts:41](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L41)
+
+## Methods
+
+### fetchDictionaryData
+
+▸ **fetchDictionaryData**(`language`: *string*): *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+Fetch dictionary data for a language.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `language` | *string* |
+
+**Returns:** *Promise*<[*DictionaryPhrases*](../interfaces/dictionaryphrases.md)\>
+
+Overrides: DictionaryServiceBase.fetchDictionaryData
+
+Defined in: [i18n/rest-dictionary-service.ts:54](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L54)
+
+___
+
+### getCacheValue
+
+▸ `Protected` **getCacheValue**(`key`: *string*): ``null`` \| [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | *string* |
+
+**Returns:** ``null`` \| [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+Inherited from: DictionaryServiceBase.getCacheValue
+
+Defined in: [i18n/dictionary-service.ts:55](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L55)
+
+___
+
+### getUrl
+
+▸ `Private` **getUrl**(`language`: *string*): *string*
+
+Generate dictionary service url
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `language` | *string* |
+
+**Returns:** *string*
+
+Defined in: [i18n/rest-dictionary-service.ts:75](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L75)
+
+___
+
+### setCacheValue
+
+▸ `Protected` **setCacheValue**(`key`: *string*, `value`: [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)): [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `key` | *string* |
+| `value` | [*DictionaryPhrases*](../interfaces/dictionaryphrases.md) |
+
+**Returns:** [*DictionaryPhrases*](../interfaces/dictionaryphrases.md)
+
+Inherited from: DictionaryServiceBase.setCacheValue
+
+Defined in: [i18n/dictionary-service.ts:59](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L59)

--- a/packages/sitecore-jss/docs/classes/restlayoutservice.md
+++ b/packages/sitecore-jss/docs/classes/restlayoutservice.md
@@ -1,0 +1,183 @@
+[@sitecore-jss/sitecore-jss](../README.md) / RestLayoutService
+
+# Class: RestLayoutService
+
+Fetch layout data using the Sitecore Layout Service REST API.
+Uses Axios as the default data fetcher (@see AxiosDataFetcher).
+
+## Hierarchy
+
+- *LayoutServiceBase*
+
+  ↳ **RestLayoutService**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](restlayoutservice.md#constructor)
+
+### Methods
+
+- [fetchLayoutData](restlayoutservice.md#fetchlayoutdata)
+- [fetchPlaceholderData](restlayoutservice.md#fetchplaceholderdata)
+- [getDefaultFetcher](restlayoutservice.md#getdefaultfetcher)
+- [getFetchOptions](restlayoutservice.md#getfetchoptions)
+- [setupReqHeaders](restlayoutservice.md#setupreqheaders)
+- [setupResHeaders](restlayoutservice.md#setupresheaders)
+
+## Constructors
+
+### constructor
+
+\+ **new RestLayoutService**(`serviceConfig`: [*RestLayoutServiceConfig*](../README.md#restlayoutserviceconfig)): [*RestLayoutService*](restlayoutservice.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `serviceConfig` | [*RestLayoutServiceConfig*](../README.md#restlayoutserviceconfig) |
+
+**Returns:** [*RestLayoutService*](restlayoutservice.md)
+
+Overrides: LayoutServiceBase.constructor
+
+Defined in: [layout/rest-layout-service.ts:158](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L158)
+
+## Methods
+
+### fetchLayoutData
+
+▸ **fetchLayoutData**(`itemPath`: *string*, `language?`: *string*, `req?`: *IncomingMessage*, `res?`: *ServerResponse*): *Promise*<[*LayoutServiceData*](../interfaces/layoutservicedata.md)\>
+
+Fetch layout data for an item.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `itemPath` | *string* |
+| `language?` | *string* |
+| `req?` | *IncomingMessage* |
+| `res?` | *ServerResponse* |
+
+**Returns:** *Promise*<[*LayoutServiceData*](../interfaces/layoutservicedata.md)\>
+
+layout service data
+
+Overrides: LayoutServiceBase.fetchLayoutData
+
+Defined in: [layout/rest-layout-service.ts:171](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L171)
+
+___
+
+### fetchPlaceholderData
+
+▸ **fetchPlaceholderData**(`placeholderName`: *string*, `itemPath`: *string*, `language?`: *string*, `req?`: *IncomingMessage*, `res?`: *ServerResponse*): *Promise*<[*PlaceholderData*](../interfaces/placeholderdata.md)\>
+
+Fetch layout data for a particular placeholder.
+Makes a request to Sitecore Layout Service for the specified placeholder in
+a specific route item. Allows you to retrieve rendered data for individual placeholders instead of entire routes.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `placeholderName` | *string* |
+| `itemPath` | *string* |
+| `language?` | *string* |
+| `req?` | *IncomingMessage* |
+| `res?` | *ServerResponse* |
+
+**Returns:** *Promise*<[*PlaceholderData*](../interfaces/placeholderdata.md)\>
+
+placeholder data
+
+Defined in: [layout/rest-layout-service.ts:221](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L221)
+
+___
+
+### getDefaultFetcher
+
+▸ `Private` **getDefaultFetcher**<T\>(`req?`: *IncomingMessage*, `res?`: *ServerResponse*): *function*
+
+Provides default @see AxiosDataFetcher data fetcher
+
+#### Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req?` | *IncomingMessage* |
+| `res?` | *ServerResponse* |
+
+**Returns:** (`url`: *string*, `data?`: *unknown*) => *Promise*<AxiosResponse<T\>\>
+
+default fetcher
+
+Defined in: [layout/rest-layout-service.ts:271](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L271)
+
+___
+
+### getFetchOptions
+
+▸ `Private` **getFetchOptions**(`language?`: *string*): FetchOptions
+
+Provides fetch options in order to fetch data
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `language?` | *string* |
+
+**Returns:** FetchOptions
+
+fetch options
+
+Defined in: [layout/rest-layout-service.ts:249](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L249)
+
+___
+
+### setupReqHeaders
+
+▸ `Private` **setupReqHeaders**(`req`: *IncomingMessage*): *function*
+
+Setup request headers
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `req` | *IncomingMessage* |
+
+**Returns:** (`reqConfig`: AxiosRequestConfig) => AxiosRequestConfig
+
+axios request config
+
+Defined in: [layout/rest-layout-service.ts:293](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L293)
+
+___
+
+### setupResHeaders
+
+▸ `Private` **setupResHeaders**(`res`: *ServerResponse*): *function*
+
+Setup response headers based on response from layout service
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `res` | *ServerResponse* |
+
+**Returns:** (`serverRes`: *AxiosResponse*<any\>) => *AxiosResponse*<any\>
+
+response
+
+Defined in: [layout/rest-layout-service.ts:312](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L312)

--- a/packages/sitecore-jss/docs/enums/constants.sitecoretemplateid.md
+++ b/packages/sitecore-jss/docs/enums/constants.sitecoretemplateid.md
@@ -1,0 +1,28 @@
+[@sitecore-jss/sitecore-jss](../README.md) / [constants](../modules/constants.md) / SitecoreTemplateId
+
+# Enumeration: SitecoreTemplateId
+
+[constants](../modules/constants.md).SitecoreTemplateId
+
+## Table of contents
+
+### Enumeration members
+
+- [DictionaryEntry](constants.sitecoretemplateid.md#dictionaryentry)
+- [JssApp](constants.sitecoretemplateid.md#jssapp)
+
+## Enumeration members
+
+### DictionaryEntry
+
+• **DictionaryEntry**: = "6d1cd89719364a3aa511289a94c2a7b1"
+
+Defined in: [constants.ts:6](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/constants.ts#L6)
+
+___
+
+### JssApp
+
+• **JssApp**: = "061cba1554744b918a0617903b102b82"
+
+Defined in: [constants.ts:3](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/constants.ts#L3)

--- a/packages/sitecore-jss/docs/enums/layoutservicepagestate.md
+++ b/packages/sitecore-jss/docs/enums/layoutservicepagestate.md
@@ -1,0 +1,37 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServicePageState
+
+# Enumeration: LayoutServicePageState
+
+Layout Service page state enum
+
+## Table of contents
+
+### Enumeration members
+
+- [Edit](layoutservicepagestate.md#edit)
+- [Normal](layoutservicepagestate.md#normal)
+- [Preview](layoutservicepagestate.md#preview)
+
+## Enumeration members
+
+### Edit
+
+• **Edit**: = "edit"
+
+Defined in: [layout/models.ts:15](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L15)
+
+___
+
+### Normal
+
+• **Normal**: = "normal"
+
+Defined in: [layout/models.ts:16](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L16)
+
+___
+
+### Preview
+
+• **Preview**: = "preview"
+
+Defined in: [layout/models.ts:14](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L14)

--- a/packages/sitecore-jss/docs/interfaces/componentfields.md
+++ b/packages/sitecore-jss/docs/interfaces/componentfields.md
@@ -1,0 +1,11 @@
+[@sitecore-jss/sitecore-jss](../README.md) / ComponentFields
+
+# Interface: ComponentFields
+
+Content field data passed to a component
+
+## Indexable
+
+▪ [name: *string*]: [*Field*](field.md) \| [*Item*](item.md) \| [*Item*](item.md)[]
+
+Content field data passed to a component

--- a/packages/sitecore-jss/docs/interfaces/componentparams.md
+++ b/packages/sitecore-jss/docs/interfaces/componentparams.md
@@ -1,0 +1,11 @@
+[@sitecore-jss/sitecore-jss](../README.md) / ComponentParams
+
+# Interface: ComponentParams
+
+Component params
+
+## Indexable
+
+▪ [name: *string*]: *string*
+
+Component params

--- a/packages/sitecore-jss/docs/interfaces/componentrendering.md
+++ b/packages/sitecore-jss/docs/interfaces/componentrendering.md
@@ -1,0 +1,64 @@
+[@sitecore-jss/sitecore-jss](../README.md) / ComponentRendering
+
+# Interface: ComponentRendering
+
+Definition of a component instance within a placeholder on a route
+
+## Table of contents
+
+### Properties
+
+- [componentName](componentrendering.md#componentname)
+- [dataSource](componentrendering.md#datasource)
+- [fields](componentrendering.md#fields)
+- [params](componentrendering.md#params)
+- [placeholders](componentrendering.md#placeholders)
+- [uid](componentrendering.md#uid)
+
+## Properties
+
+### componentName
+
+• **componentName**: *string*
+
+Defined in: [layout/models.ts:86](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L86)
+
+___
+
+### dataSource
+
+• `Optional` **dataSource**: *string*
+
+Defined in: [layout/models.ts:87](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L87)
+
+___
+
+### fields
+
+• `Optional` **fields**: [*ComponentFields*](componentfields.md)
+
+Defined in: [layout/models.ts:90](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L90)
+
+___
+
+### params
+
+• `Optional` **params**: [*ComponentParams*](componentparams.md)
+
+Defined in: [layout/models.ts:91](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L91)
+
+___
+
+### placeholders
+
+• `Optional` **placeholders**: [*PlaceholdersData*](../README.md#placeholdersdata)<string\>
+
+Defined in: [layout/models.ts:89](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L89)
+
+___
+
+### uid
+
+• `Optional` **uid**: *string*
+
+Defined in: [layout/models.ts:88](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L88)

--- a/packages/sitecore-jss/docs/interfaces/dictionaryphrases.md
+++ b/packages/sitecore-jss/docs/interfaces/dictionaryphrases.md
@@ -1,0 +1,11 @@
+[@sitecore-jss/sitecore-jss](../README.md) / DictionaryPhrases
+
+# Interface: DictionaryPhrases
+
+Phrases from the Sitecore Dictionary Service
+
+## Indexable
+
+▪ [k: *string*]: *string*
+
+Phrases from the Sitecore Dictionary Service

--- a/packages/sitecore-jss/docs/interfaces/dictionaryservice.md
+++ b/packages/sitecore-jss/docs/interfaces/dictionaryservice.md
@@ -1,0 +1,29 @@
+[@sitecore-jss/sitecore-jss](../README.md) / DictionaryService
+
+# Interface: DictionaryService
+
+Dictionary data fetching service
+
+## Table of contents
+
+### Methods
+
+- [fetchDictionaryData](dictionaryservice.md#fetchdictionarydata)
+
+## Methods
+
+### fetchDictionaryData
+
+▸ **fetchDictionaryData**(`language`: *string*): *Promise*<[*DictionaryPhrases*](dictionaryphrases.md)\>
+
+Fetch dictionary data for a language.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `language` | *string* |
+
+**Returns:** *Promise*<[*DictionaryPhrases*](dictionaryphrases.md)\>
+
+Defined in: [i18n/dictionary-service.ts:39](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L39)

--- a/packages/sitecore-jss/docs/interfaces/field.md
+++ b/packages/sitecore-jss/docs/interfaces/field.md
@@ -1,0 +1,32 @@
+[@sitecore-jss/sitecore-jss](../README.md) / Field
+
+# Interface: Field<T\>
+
+## Type parameters
+
+| Name | Default |
+| :------ | :------ |
+| `T` | GenericFieldValue |
+
+## Table of contents
+
+### Properties
+
+- [editable](field.md#editable)
+- [value](field.md#value)
+
+## Properties
+
+### editable
+
+• `Optional` **editable**: *string*
+
+Defined in: [layout/models.ts:118](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L118)
+
+___
+
+### value
+
+• **value**: T
+
+Defined in: [layout/models.ts:117](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L117)

--- a/packages/sitecore-jss/docs/interfaces/graphqldictionaryserviceconfig.md
+++ b/packages/sitecore-jss/docs/interfaces/graphqldictionaryserviceconfig.md
@@ -1,0 +1,105 @@
+[@sitecore-jss/sitecore-jss](../README.md) / GraphQLDictionaryServiceConfig
+
+# Interface: GraphQLDictionaryServiceConfig
+
+Configuration options for @see GraphQLDictionaryService instances
+
+## Hierarchy
+
+- *CacheOptions*
+
+  ↳ **GraphQLDictionaryServiceConfig**
+
+## Table of contents
+
+### Properties
+
+- [apiKey](graphqldictionaryserviceconfig.md#apikey)
+- [cacheEnabled](graphqldictionaryserviceconfig.md#cacheenabled)
+- [cacheTimeout](graphqldictionaryserviceconfig.md#cachetimeout)
+- [endpoint](graphqldictionaryserviceconfig.md#endpoint)
+- [pageSize](graphqldictionaryserviceconfig.md#pagesize)
+- [rootItemId](graphqldictionaryserviceconfig.md#rootitemid)
+- [siteName](graphqldictionaryserviceconfig.md#sitename)
+
+## Properties
+
+### apiKey
+
+• **apiKey**: *string*
+
+The API key to use for authentication.
+
+Defined in: [i18n/graphql-dictionary-service.ts:77](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L77)
+
+___
+
+### cacheEnabled
+
+• `Optional` **cacheEnabled**: *boolean*
+
+Enable/disable caching mechanism
+
+**`default`** true
+
+Inherited from: CacheOptions.cacheEnabled
+
+Defined in: [i18n/dictionary-service.ts:23](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L23)
+
+___
+
+### cacheTimeout
+
+• `Optional` **cacheTimeout**: *number*
+
+Cache timeout (sec)
+
+**`default`** 60
+
+Inherited from: CacheOptions.cacheTimeout
+
+Defined in: [i18n/dictionary-service.ts:28](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/dictionary-service.ts#L28)
+
+___
+
+### endpoint
+
+• **endpoint**: *string*
+
+The URL of the graphQL endpoint.
+
+Defined in: [i18n/graphql-dictionary-service.ts:55](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L55)
+
+___
+
+### pageSize
+
+• `Optional` **pageSize**: *number*
+
+How many dictionary items to fetch in each GraphQL call. This is needed for pagination.
+
+**`default`** 10
+
+Defined in: [i18n/graphql-dictionary-service.ts:67](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L67)
+
+___
+
+### rootItemId
+
+• `Optional` **rootItemId**: *string*
+
+The GUID of the Sitecore item to use as the root for the dictionary service search.
+
+**`default`** The GUID of the root item of the specified Sitecore site.
+
+Defined in: [i18n/graphql-dictionary-service.ts:61](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L61)
+
+___
+
+### siteName
+
+• **siteName**: *string*
+
+The name of the current Sitecore site.
+
+Defined in: [i18n/graphql-dictionary-service.ts:72](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts#L72)

--- a/packages/sitecore-jss/docs/interfaces/htmlelementrendering.md
+++ b/packages/sitecore-jss/docs/interfaces/htmlelementrendering.md
@@ -1,0 +1,48 @@
+[@sitecore-jss/sitecore-jss](../README.md) / HtmlElementRendering
+
+# Interface: HtmlElementRendering
+
+HTML content used to support Sitecore Experience Editor
+
+## Table of contents
+
+### Properties
+
+- [attributes](htmlelementrendering.md#attributes)
+- [contents](htmlelementrendering.md#contents)
+- [name](htmlelementrendering.md#name)
+- [type](htmlelementrendering.md#type)
+
+## Properties
+
+### attributes
+
+• **attributes**: *object*
+
+#### Type declaration
+
+Defined in: [layout/models.ts:101](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L101)
+
+___
+
+### contents
+
+• **contents**: ``null`` \| *string*
+
+Defined in: [layout/models.ts:100](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L100)
+
+___
+
+### name
+
+• **name**: *string*
+
+Defined in: [layout/models.ts:98](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L98)
+
+___
+
+### type
+
+• `Optional` **type**: *string*
+
+Defined in: [layout/models.ts:99](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L99)

--- a/packages/sitecore-jss/docs/interfaces/httpresponse.md
+++ b/packages/sitecore-jss/docs/interfaces/httpresponse.md
@@ -1,0 +1,49 @@
+[@sitecore-jss/sitecore-jss](../README.md) / HttpResponse
+
+# Interface: HttpResponse<T\>
+
+Response data for an HTTP request sent to an API
+
+## Type parameters
+
+| Name | Description |
+| :------ | :------ |
+| `T` | the type of data model requested |
+
+## Table of contents
+
+### Properties
+
+- [data](httpresponse.md#data)
+- [status](httpresponse.md#status)
+- [statusText](httpresponse.md#statustext)
+
+## Properties
+
+### data
+
+• **data**: T
+
+Response content
+
+Defined in: [data-fetcher.ts:14](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/data-fetcher.ts#L14)
+
+___
+
+### status
+
+• **status**: *number*
+
+HTTP status code of the response (i.e. 200, 404)
+
+Defined in: [data-fetcher.ts:10](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/data-fetcher.ts#L10)
+
+___
+
+### statusText
+
+• **statusText**: *string*
+
+HTTP status text of the response (i.e. 'OK', 'Bad Request')
+
+Defined in: [data-fetcher.ts:12](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/data-fetcher.ts#L12)

--- a/packages/sitecore-jss/docs/interfaces/item.md
+++ b/packages/sitecore-jss/docs/interfaces/item.md
@@ -1,0 +1,39 @@
+[@sitecore-jss/sitecore-jss](../README.md) / Item
+
+# Interface: Item
+
+Content data returned from Content Service
+
+## Table of contents
+
+### Properties
+
+- [displayName](item.md#displayname)
+- [fields](item.md#fields)
+- [name](item.md#name)
+
+## Properties
+
+### displayName
+
+• `Optional` **displayName**: *string*
+
+Defined in: [layout/models.ts:126](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L126)
+
+___
+
+### fields
+
+• **fields**: *object*
+
+#### Type declaration
+
+Defined in: [layout/models.ts:127](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L127)
+
+___
+
+### name
+
+• **name**: *string*
+
+Defined in: [layout/models.ts:125](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L125)

--- a/packages/sitecore-jss/docs/interfaces/layoutservice.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutservice.md
@@ -1,0 +1,32 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutService
+
+# Interface: LayoutService
+
+## Table of contents
+
+### Methods
+
+- [fetchLayoutData](layoutservice.md#fetchlayoutdata)
+
+## Methods
+
+### fetchLayoutData
+
+▸ **fetchLayoutData**(`itemPath`: *string*, `language?`: *string*, `req?`: *IncomingMessage*, `res?`: *ServerResponse*): *Promise*<[*LayoutServiceData*](layoutservicedata.md)\>
+
+Fetch layout data for an item.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `itemPath` | *string* |
+| `language?` | *string* |
+| `req?` | *IncomingMessage* |
+| `res?` | *ServerResponse* |
+
+**Returns:** *Promise*<[*LayoutServiceData*](layoutservicedata.md)\>
+
+layout data
+
+Defined in: [layout/layout-service.ts:13](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/layout-service.ts#L13)

--- a/packages/sitecore-jss/docs/interfaces/layoutserviceconfig.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutserviceconfig.md
@@ -1,0 +1,42 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServiceConfig
+
+# Interface: LayoutServiceConfig
+
+## Table of contents
+
+### Properties
+
+- [configurationName](layoutserviceconfig.md#configurationname)
+- [host](layoutserviceconfig.md#host)
+- [serviceUrl](layoutserviceconfig.md#serviceurl)
+
+## Properties
+
+### configurationName
+
+• `Optional` **configurationName**: *string*
+
+Layout Service "named" configuration
+
+Defined in: [layout/rest-layout-service.ts:82](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L82)
+
+___
+
+### host
+
+• `Optional` **host**: *string*
+
+Host name of the Sitecore instance serving Layout Service requests.
+
+Defined in: [layout/rest-layout-service.ts:77](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L77)
+
+___
+
+### serviceUrl
+
+• `Optional` **serviceUrl**: *string*
+
+This value overrides the default layout service URL.
+Note: `host` and `configurationName` options are ignored if `layoutServiceUrl` is set.
+
+Defined in: [layout/rest-layout-service.ts:88](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L88)

--- a/packages/sitecore-jss/docs/interfaces/layoutservicecontext.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutservicecontext.md
@@ -1,0 +1,67 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServiceContext
+
+# Interface: LayoutServiceContext
+
+Shape of context data from the Sitecore Layout Service
+
+## Indexable
+
+▪ [key: *string*]: *unknown*
+
+Shape of context data from the Sitecore Layout Service
+
+## Table of contents
+
+### Properties
+
+- [language](layoutservicecontext.md#language)
+- [pageEditing](layoutservicecontext.md#pageediting)
+- [pageState](layoutservicecontext.md#pagestate)
+- [site](layoutservicecontext.md#site)
+- [visitorIdentificationTimestamp](layoutservicecontext.md#visitoridentificationtimestamp)
+
+## Properties
+
+### language
+
+• `Optional` **language**: *string*
+
+Defined in: [layout/models.ts:25](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L25)
+
+___
+
+### pageEditing
+
+• `Optional` **pageEditing**: *boolean*
+
+Defined in: [layout/models.ts:24](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L24)
+
+___
+
+### pageState
+
+• `Optional` **pageState**: [*Preview*](../enums/layoutservicepagestate.md#preview) \| [*Edit*](../enums/layoutservicepagestate.md#edit) \| [*Normal*](../enums/layoutservicepagestate.md#normal)
+
+Defined in: [layout/models.ts:26](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L26)
+
+___
+
+### site
+
+• `Optional` **site**: *object*
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `name?` | *string* |
+
+Defined in: [layout/models.ts:28](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L28)
+
+___
+
+### visitorIdentificationTimestamp
+
+• `Optional` **visitorIdentificationTimestamp**: *number*
+
+Defined in: [layout/models.ts:27](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L27)

--- a/packages/sitecore-jss/docs/interfaces/layoutservicecontextdata.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutservicecontextdata.md
@@ -1,0 +1,19 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServiceContextData
+
+# Interface: LayoutServiceContextData
+
+Context information from the Sitecore Layout Service
+
+## Table of contents
+
+### Properties
+
+- [context](layoutservicecontextdata.md#context)
+
+## Properties
+
+### context
+
+• **context**: [*LayoutServiceContext*](layoutservicecontext.md)
+
+Defined in: [layout/models.ts:37](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L37)

--- a/packages/sitecore-jss/docs/interfaces/layoutservicedata.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutservicedata.md
@@ -1,0 +1,19 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServiceData
+
+# Interface: LayoutServiceData
+
+A reply from the Sitecore Layout Service
+
+## Table of contents
+
+### Properties
+
+- [sitecore](layoutservicedata.md#sitecore)
+
+## Properties
+
+### sitecore
+
+• **sitecore**: [*LayoutServiceContextData*](layoutservicecontextdata.md) & { `route`: ``null`` \| [*RouteData*](routedata.md)  }
+
+Defined in: [layout/models.ts:5](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L5)

--- a/packages/sitecore-jss/docs/interfaces/layoutservicerequestoptions.md
+++ b/packages/sitecore-jss/docs/interfaces/layoutservicerequestoptions.md
@@ -1,0 +1,49 @@
+[@sitecore-jss/sitecore-jss](../README.md) / LayoutServiceRequestOptions
+
+# Interface: LayoutServiceRequestOptions<T\>
+
+## Type parameters
+
+| Name |
+| :------ |
+| `T` |
+
+## Table of contents
+
+### Properties
+
+- [fetcher](layoutservicerequestoptions.md#fetcher)
+- [layoutServiceConfig](layoutservicerequestoptions.md#layoutserviceconfig)
+- [querystringParams](layoutservicerequestoptions.md#querystringparams)
+
+## Properties
+
+### fetcher
+
+• **fetcher**: [*HttpDataFetcher*](../README.md#httpdatafetcher)<T\>
+
+The fetcher that performs the HTTP request and returns a promise to JSON
+
+Defined in: [layout/rest-layout-service.ts:102](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L102)
+
+___
+
+### layoutServiceConfig
+
+• `Optional` **layoutServiceConfig**: [*LayoutServiceConfig*](layoutserviceconfig.md)
+
+Configuration options for Layout Service requests.
+
+Defined in: [layout/rest-layout-service.ts:95](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L95)
+
+___
+
+### querystringParams
+
+• `Optional` **querystringParams**: *object*
+
+An object of key:value pairs to be stringified and used as querystring parameters.
+
+#### Type declaration
+
+Defined in: [layout/rest-layout-service.ts:99](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/rest-layout-service.ts#L99)

--- a/packages/sitecore-jss/docs/interfaces/placeholderdata.md
+++ b/packages/sitecore-jss/docs/interfaces/placeholderdata.md
@@ -1,0 +1,37 @@
+[@sitecore-jss/sitecore-jss](../README.md) / PlaceholderData
+
+# Interface: PlaceholderData
+
+Contents of a single placeholder returned from placeholder service
+
+## Table of contents
+
+### Properties
+
+- [elements](placeholderdata.md#elements)
+- [name](placeholderdata.md#name)
+- [path](placeholderdata.md#path)
+
+## Properties
+
+### elements
+
+• **elements**: ([*HtmlElementRendering*](htmlelementrendering.md) \| [*ComponentRendering*](componentrendering.md))[]
+
+Defined in: [layout/models.ts:138](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L138)
+
+___
+
+### name
+
+• **name**: *string*
+
+Defined in: [layout/models.ts:136](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L136)
+
+___
+
+### path
+
+• **path**: *string*
+
+Defined in: [layout/models.ts:137](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L137)

--- a/packages/sitecore-jss/docs/interfaces/routedata.md
+++ b/packages/sitecore-jss/docs/interfaces/routedata.md
@@ -1,0 +1,120 @@
+[@sitecore-jss/sitecore-jss](../README.md) / RouteData
+
+# Interface: RouteData
+
+Shape of route data returned from Sitecore Layout Service
+
+## Table of contents
+
+### Properties
+
+- [databaseName](routedata.md#databasename)
+- [deviceId](routedata.md#deviceid)
+- [displayName](routedata.md#displayname)
+- [fields](routedata.md#fields)
+- [itemId](routedata.md#itemid)
+- [itemLanguage](routedata.md#itemlanguage)
+- [itemVersion](routedata.md#itemversion)
+- [layoutId](routedata.md#layoutid)
+- [name](routedata.md#name)
+- [placeholders](routedata.md#placeholders)
+- [templateId](routedata.md#templateid)
+- [templateName](routedata.md#templatename)
+
+## Properties
+
+### databaseName
+
+• `Optional` **databaseName**: *string*
+
+Defined in: [layout/models.ts:49](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L49)
+
+___
+
+### deviceId
+
+• `Optional` **deviceId**: *string*
+
+Defined in: [layout/models.ts:50](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L50)
+
+___
+
+### displayName
+
+• `Optional` **displayName**: *string*
+
+Defined in: [layout/models.ts:45](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L45)
+
+___
+
+### fields
+
+• `Optional` **fields**: *object*
+
+#### Type declaration
+
+Defined in: [layout/models.ts:46](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L46)
+
+___
+
+### itemId
+
+• `Optional` **itemId**: *string*
+
+Defined in: [layout/models.ts:57](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L57)
+
+___
+
+### itemLanguage
+
+• `Optional` **itemLanguage**: *string*
+
+Defined in: [layout/models.ts:51](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L51)
+
+___
+
+### itemVersion
+
+• `Optional` **itemVersion**: *number*
+
+Defined in: [layout/models.ts:52](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L52)
+
+___
+
+### layoutId
+
+• `Optional` **layoutId**: *string*
+
+Defined in: [layout/models.ts:53](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L53)
+
+___
+
+### name
+
+• **name**: *string*
+
+Defined in: [layout/models.ts:44](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L44)
+
+___
+
+### placeholders
+
+• **placeholders**: [*PlaceholdersData*](../README.md#placeholdersdata)<string\>
+
+Defined in: [layout/models.ts:56](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L56)
+
+___
+
+### templateId
+
+• `Optional` **templateId**: *string*
+
+Defined in: [layout/models.ts:54](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L54)
+
+___
+
+### templateName
+
+• `Optional` **templateName**: *string*
+
+Defined in: [layout/models.ts:55](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/layout/models.ts#L55)

--- a/packages/sitecore-jss/docs/modules/constants.md
+++ b/packages/sitecore-jss/docs/modules/constants.md
@@ -1,0 +1,9 @@
+[@sitecore-jss/sitecore-jss](../README.md) / constants
+
+# Namespace: constants
+
+## Table of contents
+
+### Enumerations
+
+- [SitecoreTemplateId](../enums/constants.sitecoretemplateid.md)

--- a/packages/sitecore-jss/docs/modules/mediaapi.md
+++ b/packages/sitecore-jss/docs/modules/mediaapi.md
@@ -1,0 +1,117 @@
+[@sitecore-jss/sitecore-jss](../README.md) / mediaApi
+
+# Namespace: mediaApi
+
+## Table of contents
+
+### Functions
+
+- [findEditorImageTag](mediaapi.md#findeditorimagetag)
+- [getRequiredParams](mediaapi.md#getrequiredparams)
+- [getSrcSet](mediaapi.md#getsrcset)
+- [updateImageUrl](mediaapi.md#updateimageurl)
+
+## Functions
+
+### findEditorImageTag
+
+▸ `Const` **findEditorImageTag**(`editorMarkup`: *string*): ``null`` \| { `attrs`: { [key: string]: *string*;  } ; `imgTag`: *string*  }
+
+Makes a request to Sitecore Content Service for the specified item path.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `editorMarkup` | *string* |
+
+**Returns:** ``null`` \| { `attrs`: { [key: string]: *string*;  } ; `imgTag`: *string*  }
+
+found image tag
+
+Defined in: [media-api.ts:19](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/media-api.ts#L19)
+
+___
+
+### getRequiredParams
+
+▸ `Const` **getRequiredParams**(`qs`: { [key: string]: *string* \| *undefined*;  }): *object*
+
+Get required query string params which should be merged with user params
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `qs` | *object* | layout service parsed query string |
+
+**Returns:** *object*
+
+| Name | Type |
+| :------ | :------ |
+| `db` | *undefined* \| *string* |
+| `la` | *undefined* \| *string* |
+| `rev` | *undefined* \| *string* |
+| `ts` | *undefined* \| *string* |
+| `vs` | *undefined* \| *string* |
+
+requiredParams
+
+Defined in: [media-api.ts:45](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/media-api.ts#L45)
+
+___
+
+### getSrcSet
+
+▸ `Const` **getSrcSet**(`url`: *string*, `srcSet`: { [key: string]: *string* \| *number* \| *undefined*;  }[], `imageParams?`: { [key: string]: *string* \| *number* \| *undefined*;  }, `mediaUrlPrefix?`: *RegExp*): *string*
+
+Receives an array of `srcSet` parameters that are iterated and used as parameters to generate
+a corresponding set of updated Sitecore media URLs via @see updateImageUrl. The result is a comma-delimited
+list of media URLs with respective dimension parameters.
+
+**`example`**
+// returns '/ipsum.jpg?h=1000&w=1000 1000w, /ipsum.jpg?mh=250&mw=250 250w'
+getSrcSet('/ipsum.jpg', [{ h: 1000, w: 1000 }, { mh: 250, mw: 250 } ])
+
+More information about `srcSet`: [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | *string* |
+| `srcSet` | { [key: string]: *string* \| *number* \| *undefined*;  }[] |
+| `imageParams?` | *object* |
+| `mediaUrlPrefix?` | *RegExp* |
+
+**Returns:** *string*
+
+src set
+
+Defined in: [media-api.ts:116](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/media-api.ts#L116)
+
+___
+
+### updateImageUrl
+
+▸ `Const` **updateImageUrl**(`url`: *string*, `params?`: ``null`` \| { [key: string]: *string* \| *number* \| *undefined*;  }, `mediaUrlPrefix?`: *RegExp*): *string*
+
+Prepares a Sitecore media URL with `params` for use by the JSS media handler.
+This is done by replacing `/~/media` or `/-/media` with `/~/jssmedia` or `/-/jssmedia`, respectively.
+Provided `params` are used as the querystring parameters for the media URL.
+Can use `mediaUrlPrefix` in order to use a custom prefix.
+If no `params` are sent, the original media URL is returned.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `url` | *string* |
+| `params?` | ``null`` \| { [key: string]: *string* \| *number* \| *undefined*;  } |
+| `mediaUrlPrefix` | *RegExp* |
+
+**Returns:** *string*
+
+url
+
+Defined in: [media-api.ts:62](https://github.com/Sitecore/jss/blob/cea3ba4f/packages/sitecore-jss/src/media-api.ts#L62)

--- a/packages/sitecore-jss/package-lock.json
+++ b/packages/sitecore-jss/package-lock.json
@@ -3578,9 +3578,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "uri-js": {

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint ./src/**/*.ts",
     "test": "mocha --require ts-node/register \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
-    "coverage": "nyc --require ts-node/register npm test"
+    "coverage": "nyc --require ts-node/register npm test",
+    "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out docs ./src/index.ts"
   },
   "engines": {
     "node": ">=8.1"
@@ -48,7 +49,7 @@
     "sinon": "^7.5.0",
     "ts-node": "^8.4.1",
     "tslib": "^1.10.0",
-    "typescript": "^3.6.3"
+    "typescript": "~4.1.5"
   },
   "dependencies": {
     "axios": "^0.21.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As a POC, use TypeDoc to generate API reference in markdown
POC Started and requested by @anastasiya29 

## Description / Motivation
<!--- Describe your changes in detail -->
TypeScript needs to be at least version 3.7.x for typedoc to work. We are starting with the base package as a proof of concept, and will eventually have API reference for each package.
While there are technically no breaking changes between TS 3-4 (target version is 4.1.x), there are between some minor versions, so upgrades should be made with relative caution.
<!--- Why is this change required? What problem does it solve? -->
API reference documentation greatly improves the developer experience
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
ran test script in sitecore-jss package, all tests still passed after upgrading TypeScript
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
