### PR TITLE
[NextJs] Added IncludeServerUrlInMediaUrls "default" configuration to sample config

### DIFF
--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -119,9 +119,19 @@
       Media URLs resolving
       Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
       This eliminates exposing the Sitecore server publicly.
+      
+      "default" configuration is used for Sitecore GraphQL Edge requests.
+      "jss" configuration is used for Sitecore Layout Service REST requests.
     -->
     <layoutService>
       <configurations>
+        <config name="default">
+          <rendering>
+            <renderingContentsResolver>
+              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
+            </renderingContentsResolver>
+          </rendering>
+        </config>
         <config name="jss">
           <rendering>
             <renderingContentsResolver>


### PR DESCRIPTION
Added IncludeServerUrlInMediaUrls "default" configuration to Next.js sample config (necessary for Sitecore GraphQL Edge requests).

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
