### PR TITLE
[Horizon] Empty placeholder / initial load issue

### DIFF
--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -225,7 +225,7 @@ describe('<Placeholder />', () => {
     const renderedComponent = mount(
       <Placeholder name={phKey} rendering={route} componentFactory={componentFactory} />
     );
-    expect(renderedComponent.html()).to.be.empty;
+    expect(renderedComponent.html()).to.equal('<div></div>');
   });
 
   it('should render error message on error', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -202,13 +202,8 @@ describe('<Placeholder />', () => {
       <Placeholder name={phKey} rendering={component} componentFactory={componentFactory} />
     );
 
-    const eeChrome = renderedComponent.find({
-      chrometype: 'placeholder',
-      kind: 'open',
-      id: phKey,
-    });
+    const eeChrome = renderedComponent.find({ chrometype: 'placeholder', kind: 'open', id: phKey });
     expect(eeChrome.length).to.eq(1);
-
     const keyAttribute = eeChrome.get(0).key;
     expect(keyAttribute).to.not.be.undefined;
     expect(keyAttribute).to.eq(`${phKey}`);
@@ -229,7 +224,7 @@ describe('<Placeholder />', () => {
     const renderedComponent = mount(
       <Placeholder name={phKey} rendering={route} componentFactory={componentFactory} />
     );
-    expect(renderedComponent.html()).to.equal('<div></div>');
+    expect(renderedComponent.html()).to.be.empty;
   });
 
   it('should render error message on error', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -202,10 +202,14 @@ describe('<Placeholder />', () => {
       <Placeholder name={phKey} rendering={component} componentFactory={componentFactory} />
     );
 
-    const eeChrome = renderedComponent.find({ chrometype: 'placeholder', kind: 'open', id: phKey });
+    const eeChrome = renderedComponent.find({
+      chrometype: 'placeholder',
+      kind: 'open',
+      id: phKey,
+    });
     expect(eeChrome.length).to.eq(1);
-    // getDOMNode() returns underlying DOM element: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement
-    const keyAttribute = eeChrome.getDOMNode().getAttribute('key');
+
+    const keyAttribute = eeChrome.get(0).key;
     expect(keyAttribute).to.not.be.undefined;
     expect(keyAttribute).to.eq(`${phKey}`);
   });

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -87,10 +87,16 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     }
   }
 
+  /**
+   * Insert empty placeholders in correct places.
+   * They were removed by React after first render,
+   * since LayoutData doesn't contain `empty placeholder` tag
+   */
   resetHorizonEmptyPlaceholders() {
     if (this.emptyPlaceholderTags && this.phKeys) {
       this.emptyPlaceholderTags.forEach((emptyPhTag, i) => {
         const emptyPlaceholder = this.placeholderRef.current?.querySelector(
+          // We are going throw all saved keys and trying to find `Placeholder open tag` related to current placeholder
           `:scope > code[kind="open"][class="scpm"][chrometype="placeholder"][key="${this.phKeys?.[i]}"]`
         );
 
@@ -100,10 +106,13 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
   }
 
   collectHorizonEmptyPlaceholders() {
+    // Grab all empty placeholders on the page, cause we can't search children and use `placeholderRef` before mount
     this.emptyPlaceholderTags = Array.prototype.slice.call(
       window.document.querySelectorAll('[class*="empty-placeholder"]')
     );
     this.phKeys = this.emptyPlaceholderTags.map(
+      // `Placeholder open tag` contains `key` attribute which we can store
+      // to identify position where we need to insert empty placeholder
       (el) => el.previousElementSibling?.getAttribute('key') || ''
     );
   }

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -131,7 +131,11 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     const components = this.getComponentsForRenderingData(placeholderData);
 
     if (isEmptyPlaceholder) {
-      if (HorizonEditor.isActive() && !this.placeholderRef.current) {
+      if (
+        typeof window !== 'undefined' &&
+        HorizonEditor.isActive() &&
+        !this.placeholderRef.current
+      ) {
         this.collectHorizonEmptyPlaceholders();
       }
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -1,8 +1,11 @@
 import React, { createRef } from 'react';
 import { PlaceholderCommon, PlaceholderProps } from './PlaceholderCommon';
 import { withComponentFactory } from '../enhancers/withComponentFactory';
-import { ComponentRendering, HtmlElementRendering } from '@sitecore-jss/sitecore-jss';
-
+import {
+  ComponentRendering,
+  HtmlElementRendering,
+  HorizonEditor,
+} from '@sitecore-jss/sitecore-jss';
 export interface PlaceholderComponentProps extends PlaceholderProps {
   /**
    * Render props function that is called when the placeholder contains no content components.
@@ -43,30 +46,6 @@ function isRawRendering(
   );
 }
 
-const isHorizonEditing = (): boolean => {
-  // Horizon canvas state is injected. Example:
-  // <script id="hrz-canvas-state" type="application/json">
-  // {
-  //   "type": "State",
-  //   "data": {
-  //     "itemId": "45be1451-fa83-5f80-9f0d-d7457b480b58",
-  //     "siteName": "JssNextWeb",
-  //     "language": "en",
-  //     "deviceId": "fe5d7fdf-89c0-4d99-9aa3-b5fbd009c9f3",
-  //     "pageMode": "EDIT"
-  //   }
-  // }
-  // </script>
-  if (typeof window === 'undefined') return false;
-
-  const stateEl = window.document.querySelector('#hrz-canvas-state');
-  if (!stateEl || stateEl.innerHTML === '') {
-    return false;
-  }
-  const state = JSON.parse(stateEl.innerHTML);
-  return state.data?.pageMode === 'EDIT';
-};
-
 class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> {
   static propTypes = PlaceholderCommon.propTypes;
   placeholderRef: React.RefObject<HTMLDivElement>;
@@ -81,7 +60,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
   }
 
   componentDidMount() {
-    if (isHorizonEditing()) {
+    if (HorizonEditor.isActive()) {
       this.resetHorizonEmptyPlaceholders();
     }
   }
@@ -152,7 +131,11 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     const components = this.getComponentsForRenderingData(placeholderData);
 
     if (isEmptyPlaceholder) {
-      if (typeof window !== 'undefined' && isHorizonEditing() && !this.placeholderRef.current) {
+      if (
+        typeof window !== 'undefined' &&
+        HorizonEditor.isActive() &&
+        !this.placeholderRef.current
+      ) {
         this.collectHorizonEmptyPlaceholders();
       }
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -131,11 +131,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     const components = this.getComponentsForRenderingData(placeholderData);
 
     if (isEmptyPlaceholder) {
-      if (
-        typeof window !== 'undefined' &&
-        HorizonEditor.isActive() &&
-        !this.placeholderRef.current
-      ) {
+      if (HorizonEditor.isActive() && !this.placeholderRef.current) {
         this.collectHorizonEmptyPlaceholders();
       }
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -97,12 +97,12 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
     }
 
     this.horizonEmptyPlaceholders.forEach((ph) => {
-      const emptyPlaceholder = this.placeholderRef.current?.querySelector(
+      const placeholderOpenTag = this.placeholderRef.current?.querySelector(
         // We are going throw all saved keys and trying to find `Placeholder open tag` related to current placeholder
         `:scope > code[kind="open"][class="scpm"][chrometype="placeholder"][key="${ph.key}"]`
       );
 
-      emptyPlaceholder && emptyPlaceholder.insertAdjacentElement('afterend', ph.element);
+      placeholderOpenTag && placeholderOpenTag.insertAdjacentElement('afterend', ph.element);
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The issue that markup doesn't contain empty placeholder tag.
How it's working:
**In Experience Editor:**
* On page load EE inserts empty placeholder tag
* React removes empty placeholder tag because our `<Placeholder />` component doesn't get data for empty placeholder (it contains only data for two `<code />` tags)
* When Sitecore scripts loaded, EE inserts empty placeholder tag second time

**In Horizon:**
* During initialization Horizon inserts empty placeholder tag.
* React removes empty placeholder tag because our <Placeholder /> component doesn't get data for empty placeholder (it contains only data for two `<code />` tags)
* As a result we have only two `<code />` tags under `<div class='container' >`, without empty placeholder tag

**Solution:**
Take empty placeholder tags and insert them in places where they were removed by React.
## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
