### PR TITLE
next.js sample config - remove stuff relating to integrated mode

### DIFF
--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -79,13 +79,10 @@
 
           There are many available attributes, and they inherit the defaults if not explicitly specified here.
           Defaults are defined in `/App_Config/Sitecore/JavaScriptServices/Sitecore.JavaScriptServices.Apps.config`
-
-          NOTE: graphQLEndpoint enables _Integrated GraphQL_. If not using integrated GraphQL, it can be removed.
         -->
         <app name="JssNextWeb"
             sitecorePath="/sitecore/content/JssNextWeb"
             useLanguageSpecificLayout="true"
-            graphQLEndpoint="/sitecore/api/graph/edge"
             inherits="defaults"
             serverSideRenderingEngine="http"
             serverSideRenderingEngineEndpointUrl="http://localhost:3000/api/editing/render"


### PR DESCRIPTION
Integrated mode is not supported for Nextjs
