### PR TITLE
Rest Layout Service - Allow override of "named" JSS configuration

### DIFF
--- a/packages/sitecore-jss/src/layout/rest-layout-service.test.ts
+++ b/packages/sitecore-jss/src/layout/rest-layout-service.test.ts
@@ -165,6 +165,41 @@ describe('RestLayoutService', () => {
     });
   });
 
+  it('should fetch layout data using custom configuration name', () => {
+    mock.onGet().reply((config) => {
+      return [
+        200,
+        {
+          ...config,
+          data: { sitecore: { context: {}, route: { name: 'xxx' } } },
+        },
+        {
+          'set-cookie': 'test-set-cookie-value',
+        },
+      ];
+    });
+
+    const service = new RestLayoutService({
+      apiHost: 'http://sctest',
+      apiKey: '0FBFF61E-267A-43E3-9252-B77E71CEE4BA',
+      siteName: 'supersite',
+      configurationName: 'listen',
+      tracking: false,
+    });
+
+    return service.fetchLayoutData('/home', 'da-DK').then((layoutServiceData: any) => {
+      expect(layoutServiceData.url).to.equal(
+        'http://sctest/sitecore/api/layout/render/listen?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
+      );
+      expect(layoutServiceData.data).to.deep.equal({
+        sitecore: {
+          context: {},
+          route: { name: 'xxx' },
+        },
+      });
+    });
+  });
+
   it('should fetch layout data using custom fetcher resolver', () => {
     const fetcherSpy = spy((url: string) => {
       return new AxiosDataFetcher().fetch<any>(url);

--- a/packages/sitecore-jss/src/layout/rest-layout-service.ts
+++ b/packages/sitecore-jss/src/layout/rest-layout-service.ts
@@ -139,6 +139,11 @@ export type RestLayoutServiceConfig = {
    * Function that handles fetching API data
    */
   dataFetcherResolver?: DataFetcherResolver;
+
+  /**
+   * Layout Service "named" configuration
+   */
+  configurationName?: string;
 };
 
 /**
@@ -193,11 +198,11 @@ export class RestLayoutService extends LayoutServiceBase {
         // {
         //   sitecore: {
         //     context: {
-        //			   pageEditing: false,
-        //				 language
-        //		 },
-        //		 route: null
-        //	 },
+        //       pageEditing: false,
+        //       language
+        //     },
+        //     route: null
+        //   },
         // }
         //
         return error.response.data;
@@ -257,6 +262,7 @@ export class RestLayoutService extends LayoutServiceBase {
     return {
       layoutServiceConfig: {
         host: this.serviceConfig.apiHost,
+        configurationName: this.serviceConfig.configurationName,
       },
       querystringParams: { ...params },
     };

--- a/samples/nextjs/src/lib/layout-service-factory.rest.ts
+++ b/samples/nextjs/src/lib/layout-service-factory.rest.ts
@@ -7,6 +7,7 @@ export class LayoutServiceFactory {
       apiHost: config.sitecoreApiHost,
       apiKey: config.sitecoreApiKey,
       siteName: config.jssAppName,
+      configurationName: 'default',
     });
   }
 }


### PR DESCRIPTION
There are "jss" and "default" Layout Service configurations available in Sitecore. JSS's GraphQLLayoutService is fine using the "jss" configuration, which is the default. But for RestLayoutService, we need to be able to override the configuration to "default". This override is now possible by passing a "configurationName" arg in layout-service-factory

Tested locally with the following configurations
SSG/GraphQL
SSG/Rest
SSR/GraphQL
SSR/Rest

Docs - I'm adding mention of this new option to my branch on new services docs since it includes content on the new factories