### PR TITLE
[Doc] [NextJS] GraphQL + Disconnected mode compatibility

### DIFF
--- a/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
+++ b/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
@@ -79,7 +79,3 @@ export class DictionaryServiceFactory {
 
 export const dictionaryServiceFactory = new DictionaryServiceFactory();
 ```
-
-
-export const dictionaryServiceFactory = new DictionaryServiceFactory();
-```

--- a/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
+++ b/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
@@ -7,11 +7,14 @@ title: Sitecore GraphQL in the sample app
 
 ## Disconnected mode
 
-If you created app using `jss create my-app nextjs --fetchWith GraphQL` your services will use Sitecore GraphQL endpoint. Sitecore GraphQL does not come with a disconnected mock service, so it can only operate with a Next.js app in Connected mode. The disconnected server emulates the REST services only.
+If you created the app using `jss create my-app nextjs --fetchWith GraphQL`, your services will use the Sitecore GraphQL endpoint. 
 
-If disconnected mode is required, you need to depend on `JSS_MODE` environment variable, and your service factories should return REST service.
+Sitecore GraphQL does not come with a disconnected mock service, so it can only operate with a Next.js app in Connected mode. The disconnected server emulates the REST services only.
 
-You need to apply changes to your factories:
+Therefore, your service factories must return a REST service if you need to work in disconnected mode.
+
+To return a REST service for disconnected development from your service factories, leverage the `JSS_MODE` environment variable, as follows:
+
 1. Edit `src/lib/layout-service-factory.ts`:
 
 ```js
@@ -73,6 +76,10 @@ export class DictionaryServiceFactory {
     });
   }
 }
+
+export const dictionaryServiceFactory = new DictionaryServiceFactory();
+```
+
 
 export const dictionaryServiceFactory = new DictionaryServiceFactory();
 ```

--- a/docs/src/app/components/Navigation/nextjs.js
+++ b/docs/src/app/components/Navigation/nextjs.js
@@ -128,10 +128,10 @@ export default {
         //  url: 'edge-schema-introduction',
         //  displayName: 'Introduction to the Edge Schema',
         //},
-        //{
-        //  url: 'sample-app',
-        //  displayName: 'Sitecore GraphQL in the sample app',
-        //},
+        {
+         url: 'sample-app',
+         displayName: 'Sitecore GraphQL in the sample app',
+        },
         {
           url: 'introspection',
           displayName: 'Introspecting the GraphQL schema'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A Next.js app using GraphQL for layout / dictionary data (e.g. `jss create my-app nextjs --fetchWith GraphQL`) will not be able to run in disconnected mode (i.e. `jss start`). This is because the disconnected proxies emulate the REST services only.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
