### PR TITLE
Update Next.js sample config - layoutServiceConfiguration="default"

### DIFF
--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -81,8 +81,15 @@
           Defaults are defined in `/App_Config/Sitecore/JavaScriptServices/Sitecore.JavaScriptServices.Apps.config`
 
           NOTE: graphQLEndpoint enables _Integrated GraphQL_. If not using integrated GraphQL, it can be removed.
+
+          NOTE: layoutServiceConfiguration should be set to "default" when using Delivery Edge for
+          API endpoints. When using integrated GraphQL with Delivery Edge, a $language value is injected
+          since language is required in all Edge queries. XP does not do this (which is backwards
+          compatible with JSS versions < 18.0.0). Since GraphQL does not play nice with passing in
+          unused parameters to queries, we need to tell Sitecore type of GraphqL endpoint we are using.
         -->
         <app name="JssNextWeb"
+            layoutServiceConfiguration="default"
             sitecorePath="/sitecore/content/JssNextWeb"
             useLanguageSpecificLayout="true"
             graphQLEndpoint="/sitecore/api/graph/edge"

--- a/samples/nextjs/sitecore/config/JssNextWeb.config
+++ b/samples/nextjs/sitecore/config/JssNextWeb.config
@@ -82,11 +82,10 @@
 
           NOTE: graphQLEndpoint enables _Integrated GraphQL_. If not using integrated GraphQL, it can be removed.
 
-          NOTE: layoutServiceConfiguration should be set to "default" when using Delivery Edge for
-          API endpoints. When using integrated GraphQL with Delivery Edge, a $language value is injected
-          since language is required in all Edge queries. XP does not do this (which is backwards
-          compatible with JSS versions < 18.0.0). Since GraphQL does not play nice with passing in
-          unused parameters to queries, we need to tell Sitecore type of GraphqL endpoint we are using.
+          NOTE: layoutServiceConfiguration should be set to "default" when using GraphQL Edge schema.
+          When using integrated GraphQL with Edge schema, a $language value is injected
+          since language is required in all Edge queries. "jss" configuration does not do this (which is backwards
+          compatible with JSS versions < 18.0.0).
         -->
         <app name="JssNextWeb"
             layoutServiceConfiguration="default"


### PR DESCRIPTION
layoutServiceConfiguration should be set to "default" when using Delivery Edge for API endpoints. When using integrated GraphQL with Delivery Edge, a $language value is injected since language is required in all Edge queries. XP does not do this (which is backwards compatible with JSS versions < 18.0.0). Since GraphQL does not play nice with passing inunused parameters to queries, we need to tell Sitecore type of GraphqL endpoint we are using.