### PR TITLE
[JSS][angular] dk-DA language is not rendered in connected and disconnected mode 

### DIFF
--- a/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
+++ b/docs/data/routes/docs/nextjs/graphql/sample-app/en.md
@@ -4,3 +4,78 @@ routeTemplate: ./data/component-templates/article.yml
 title: Sitecore GraphQL in the sample app
 ---
 # Sitecore GraphQL in the sample app
+
+## Disconnected mode
+
+If you created the app using `jss create my-app nextjs --fetchWith GraphQL`, your services will use the Sitecore GraphQL endpoint. 
+
+Sitecore GraphQL does not come with a disconnected mock service, so it can only operate with a Next.js app in Connected mode. The disconnected server emulates the REST services only.
+
+Therefore, your service factories must return a REST service if you need to work in disconnected mode.
+
+To return a REST service for disconnected development from your service factories, leverage the `JSS_MODE` environment variable, as follows:
+
+1. Edit `src/lib/layout-service-factory.ts`:
+
+```js
+import {
+  LayoutService,
+  GraphQLLayoutService,
+  RestLayoutService,
+  JSS_MODE_DISCONNECTED,
+} from '@sitecore-jss/sitecore-jss-nextjs';
+import config from 'temp/config';
+
+export class LayoutServiceFactory {
+  create(): LayoutService {
+    // Switch to REST endpoint if we are in disconnected mode
+    if (process.env.JSS_MODE === JSS_MODE_DISCONNECTED) {
+      return new RestLayoutService({
+        apiHost: `http://localhost:${process.env.PROXY_PORT || 3042}`,
+        apiKey: config.sitecoreApiKey,
+        siteName: config.jssAppName,
+      });
+    }
+
+    return new GraphQLLayoutService({
+      endpoint: config.graphQLEndpoint,
+      apiKey: config.sitecoreApiKey,
+      siteName: config.jssAppName,
+    });
+  }
+}
+
+export const layoutServiceFactory = new LayoutServiceFactory();
+```
+
+2. Edit `src/lib/dictionary-service-factory.ts`:
+```js
+import {
+  DictionaryService,
+  RestDictionaryService,
+  GraphQLDictionaryService,
+  JSS_MODE_DISCONNECTED,
+} from '@sitecore-jss/sitecore-jss-nextjs';
+import config from 'temp/config';
+
+export class DictionaryServiceFactory {
+  create(): DictionaryService {
+    // Switch to REST endpoint if we are in disconnected mode
+    if (process.env.JSS_MODE === JSS_MODE_DISCONNECTED) {
+      return new RestDictionaryService({
+        apiHost: `http://localhost:${process.env.PROXY_PORT || 3042}`,
+        apiKey: config.sitecoreApiKey,
+        siteName: config.jssAppName,
+      });
+    }
+
+    return new GraphQLDictionaryService({
+      endpoint: config.graphQLEndpoint,
+      apiKey: config.sitecoreApiKey,
+      siteName: config.jssAppName,
+    });
+  }
+}
+
+export const dictionaryServiceFactory = new DictionaryServiceFactory();
+```

--- a/docs/src/app/components/Navigation/nextjs.js
+++ b/docs/src/app/components/Navigation/nextjs.js
@@ -128,10 +128,10 @@ export default {
         //  url: 'edge-schema-introduction',
         //  displayName: 'Introduction to the Edge Schema',
         //},
-        //{
-        //  url: 'sample-app',
-        //  displayName: 'Sitecore GraphQL in the sample app',
-        //},
+        {
+         url: 'sample-app',
+         displayName: 'Sitecore GraphQL in the sample app',
+        },
         {
           url: 'introspection',
           displayName: 'Introspecting the GraphQL schema'

--- a/samples/angular/src/index.html
+++ b/samples/angular/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <base href="/">
   <title>JSS Angular</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
Added `<base href="/">` to `index.html` of the Angular sample app as to solve error when navigating directly to the Danish styuleguide page in either connected or disconnected mode.
Reference: https://github.com/angular/angular-cli/issues/10325#issuecomment-399329033
<!--- Why is this change required? What problem does it solve? -->
bugfix
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
tested locally in connected and disconnected mode.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
