### PR TITLE
[NextJS] [Horizon] GraphqlConnectedDemo - not selectable before chromesReset is called

### DIFF
--- a/samples/nextjs/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
+++ b/samples/nextjs/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Text,
   Link,
@@ -8,6 +8,7 @@ import {
   constants,
   GraphQLRequestClient,
   withDatasourceCheck,
+  resetEditorChromes,
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import NextLink from 'next/link';
 import {
@@ -30,6 +31,10 @@ const GraphQLConnectedDemo = (props: StyleguideComponentProps): JSX.Element => {
   const data = props.rendering.uid
     ? useComponentProps<GraphQLConnectedDemoData>(props.rendering.uid)
     : undefined;
+
+  useEffect(() => {
+    resetEditorChromes();
+  }, []);
 
   return (
     <div data-e2e-id="graphql-connected">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Call `resetEditorChromes` on `mount` event
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
