### PR TITLE
[Horizon] Added wrapping div to ContentBlock component for all frameworks

### DIFF
--- a/samples/angular/src/app/components/content-block/content-block.component.html
+++ b/samples/angular/src/app/components/content-block/content-block.component.html
@@ -1,3 +1,4 @@
-<h2 class="display-4" *scText="rendering.fields.heading"></h2>
-<div *scRichText="rendering.fields.content"></div>
-
+<div class="contentBlock">
+  <h2 class="display-4" *scText="rendering.fields.heading"></h2>
+  <div class="contentDescription" *scRichText="rendering.fields.content"></div>
+</div>

--- a/samples/nextjs/src/components/ContentBlock.tsx
+++ b/samples/nextjs/src/components/ContentBlock.tsx
@@ -14,11 +14,11 @@ type ContentBlockProps = StyleguideComponentProps & {
  * JSS component that's useful.
  */
 const ContentBlock = ({ fields }: ContentBlockProps): JSX.Element => (
-  <>
+  <div className="contentBlock">
     <Text tag="h2" className="display-4" field={fields.heading} />
 
     <RichText className="contentDescription" field={fields.content} />
-  </>
+  </div>
 );
 
 export default withDatasourceCheck()(ContentBlock);

--- a/samples/react/src/components/ContentBlock/index.js
+++ b/samples/react/src/components/ContentBlock/index.js
@@ -7,11 +7,11 @@ import { Text, RichText } from '@sitecore-jss/sitecore-jss-react';
  * JSS component that's useful.
  */
 const ContentBlock = ({ fields }) => (
-  <React.Fragment>
+  <div className="contentBlock">
     <Text tag="h2" className="display-4" field={fields.heading} />
 
     <RichText className="contentDescription" field={fields.content} />
-  </React.Fragment>
+  </div>
 );
 
 export default ContentBlock;


### PR DESCRIPTION
Added wrapping div to ContentBlock component for all frameworks. This brings consistency (Vue already does this), but importantly this is required for Horizon editor compatibility.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
