### PR TITLE
[node-headless-ssr-proxy] Remove '/dist' path from 'pathRewriteExcludeRoutes' config property.

### DIFF
--- a/samples/node-headless-ssr-proxy/config.js
+++ b/samples/node-headless-ssr-proxy/config.js
@@ -68,7 +68,6 @@ const config = {
    * pathRewriteExcludePredicate function instead: (url) => boolean;
    */
   pathRewriteExcludeRoutes: [
-    '/dist',
     '/assets',
     '/sitecore/api',
     '/api',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove '/dist' path from `pathRewriteExcludeRoutes` in node-headless-ssr-proxy config because it is not needed, as the Express server is already set up to handle requests to '/dist'.

## Description / Motivation
<!--- Describe your changes in detail -->
Delete redundant/unused code
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
