### PR TITLE
[High priority packages + samples] Avoid use of 'any' for TypeScript definitions

### DIFF
--- a/packages/sitecore-jss-angular/.eslintrc
+++ b/packages/sitecore-jss-angular/.eslintrc
@@ -4,7 +4,6 @@
     "../../.eslintrc"
 	],
 	"rules": {
-		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/explicit-module-boundary-types": "off"
 	}
 }

--- a/packages/sitecore-jss-angular/src/components/date.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { textField as eeTextData } from '../testData/ee-data';
 import { DateDirective } from './date.directive';
+import { TextField } from './rendering-field';
 
 const testDate = new Date('2010-12-12T12:00Z');
 const testIsoDateValue = testDate.toISOString();
@@ -21,7 +22,7 @@ const defaultFormattedDate = formatDate(testIsoDateValue, testFormat, testLocale
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: TextField;
   @Input() editable = true;
   @Input() format = testFormat;
   @Input() locale = testLocale;

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -8,13 +8,13 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
-import { TextField } from './rendering-field';
+import { DateField } from './rendering-field';
 
 @Directive({
   selector: '[scDate]',
 })
 export class DateDirective implements OnChanges {
-  private viewRef: EmbeddedViewRef<any>;
+  private viewRef: EmbeddedViewRef<unknown>;
 
   @Input('scDateFormat') format?: string;
 
@@ -24,11 +24,11 @@ export class DateDirective implements OnChanges {
 
   @Input('scDateEditable') editable = true;
 
-  @Input('scDate') field: TextField;
+  @Input('scDate') field: DateField;
 
   constructor(
     private viewContainer: ViewContainerRef,
-    private templateRef: TemplateRef<any>,
+    private templateRef: TemplateRef<unknown>,
     private datePipe: DatePipe
   ) {}
 

--- a/packages/sitecore-jss-angular/src/components/file.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/file.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { FileDirective } from './file.directive';
+import { FileField } from './rendering-field';
 
 @Component({
   selector: 'test-file',
@@ -11,7 +12,7 @@ import { FileDirective } from './file.directive';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: FileField;
 }
 
 describe('<a *scFile />', () => {

--- a/packages/sitecore-jss-angular/src/components/file.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/file.directive.ts
@@ -14,11 +14,11 @@ import { FileField } from './rendering-field';
  */
 @Directive({ selector: '[scFile]' })
 export class FileDirective implements OnChanges {
-  private viewRef: EmbeddedViewRef<any>;
+  private viewRef: EmbeddedViewRef<unknown>;
 
   @Input('scFile') field: FileField;
 
-  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<any>) {}
+  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.field) {
@@ -40,6 +40,8 @@ export class FileDirective implements OnChanges {
 
     const file = field.src ? field : field.value;
     this.viewRef.rootNodes.forEach((node) => {
+      if (!file) return;
+
       node.href = file.src;
       if (node.innerHTML === '') {
         node.innerHTML = file.title || file.displayName;

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
@@ -6,6 +6,7 @@ import { generalLinkField as eeLinkData } from '../testData/ee-data';
 import { GenericLinkDirective } from './generic-link.directive';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
+import { LinkField } from './rendering-field';
 
 @Component({
   selector: 'test-router-link',
@@ -14,7 +15,7 @@ import { Router } from '@angular/router';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
   @Input() extras = {};
@@ -176,7 +177,7 @@ describe('<a *scGenericLink />', () => {
   `,
 })
 class TestWithChildrenComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
   @Input() extras = {};

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
@@ -14,7 +14,7 @@ import { LinkField } from './rendering-field';
 export class GenericLinkDirective extends LinkDirective {
   @Input('scGenericLinkEditable') editable = true;
 
-  @Input('scGenericLinkAttrs') attrs: any = {};
+  @Input('scGenericLinkAttrs') attrs: { [key: string]: string } = {};
 
   @Input('scGenericLink') field: LinkField;
 
@@ -22,7 +22,7 @@ export class GenericLinkDirective extends LinkDirective {
 
   constructor(
     viewContainer: ViewContainerRef,
-    templateRef: TemplateRef<any>,
+    templateRef: TemplateRef<unknown>,
     renderer: Renderer2,
     elementRef: ElementRef,
     private router: Router
@@ -30,11 +30,11 @@ export class GenericLinkDirective extends LinkDirective {
     super(viewContainer, templateRef, renderer, elementRef);
   }
 
-  protected renderTemplate(props: any, linkText: string) {
+  protected renderTemplate(props: { [key: string]: string }, linkText: string) {
     const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
 
     viewRef.rootNodes.forEach((node) => {
-      Object.entries(props).forEach(([key, propValue]: [string, any]) => {
+      Object.entries(props).forEach(([key, propValue]: [string, string]) => {
         if (key === 'href' && !this.isAbsoluteUrl(propValue)) {
           const urlTree = this.router.createUrlTree([propValue], this.extras);
           this.renderer.setAttribute(node, key, this.router.serializeUrl(urlTree));
@@ -53,7 +53,7 @@ export class GenericLinkDirective extends LinkDirective {
     });
   }
 
-  private isAbsoluteUrl(url?: string) {
+  private isAbsoluteUrl(url?: unknown) {
     if (url === null) {
       return false;
     }

--- a/packages/sitecore-jss-angular/src/components/image.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.spec.ts
@@ -4,6 +4,7 @@ import { By } from '@angular/platform-browser';
 
 import { imageField as eeImageData } from '../testData/ee-data';
 import { ImageDirective } from './image.directive';
+import { ImageField } from './rendering-field';
 
 @Component({
   selector: 'test-image',
@@ -12,7 +13,7 @@ import { ImageDirective } from './image.directive';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: ImageField | '';
   @Input() editable = true;
 }
 
@@ -33,10 +34,10 @@ class TestComponent {
   `,
 })
 class AnotherTestComponent {
-  @Input() field: any;
+  @Input() field: ImageField;
   @Input() editable = true;
-  @Input() params: any = {};
-  @Input() imageAttrs: any = {};
+  @Input() params: { [param: string]: string | number } = {};
+  @Input() imageAttrs: { [param: string]: unknown } = {};
   @Input() mediaUrlPrefix?: RegExp;
 }
 

--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -9,7 +9,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { mediaApi } from '@sitecore-jss/sitecore-jss';
-import { ImageField } from './rendering-field';
+import { ImageField, ImageFieldValue } from './rendering-field';
 
 @Directive({ selector: '[scImage]' })
 export class ImageDirective implements OnChanges {
@@ -28,13 +28,13 @@ export class ImageDirective implements OnChanges {
    */
   @Input('scImageMediaUrlPrefix') mediaUrlPrefix?: RegExp;
 
-  @Input('scImageUrlParams') urlParams = {};
+  @Input('scImageUrlParams') urlParams: { [param: string]: string | number } = {};
 
-  @Input('scImageAttrs') attrs = {};
+  @Input('scImageAttrs') attrs: { [param: string]: unknown } = {};
 
   constructor(
     private viewContainer: ViewContainerRef,
-    private templateRef: TemplateRef<any>,
+    private templateRef: TemplateRef<unknown>,
     private renderer: Renderer2,
     private elementRef: ElementRef
   ) {}
@@ -62,7 +62,7 @@ export class ImageDirective implements OnChanges {
       return;
     }
 
-    let attrs: any = {};
+    let attrs: { [attr: string]: string } | null = {};
 
     // we likely have an experience editor value, should be a string
     if (this.editable && media.editable) {
@@ -75,7 +75,7 @@ export class ImageDirective implements OnChanges {
         return this.renderInlineWrapper(media.editable);
       }
       const tempImg: HTMLImageElement = this.renderer.createElement('img');
-      Object.entries(attrs).forEach(([key, attrValue]: [string, any]) =>
+      Object.entries(attrs).forEach(([key, attrValue]: [string, string]) =>
         tempImg.setAttribute(key, attrValue)
       );
       const editableMarkup = media.editable.replace(foundImg.imgTag, tempImg.outerHTML);
@@ -94,7 +94,11 @@ export class ImageDirective implements OnChanges {
     }
   }
 
-  private getImageAttrs(fieldAttrs: any, parsedAttrs: any, imageParams: any): any {
+  private getImageAttrs(
+    fieldAttrs: ImageFieldValue,
+    parsedAttrs: { [attr: string]: unknown },
+    imageParams: { [param: string]: string | number }
+  ): { [attr: string]: string } | null {
     const combinedAttrs = {
       ...fieldAttrs,
       ...parsedAttrs,
@@ -104,8 +108,8 @@ export class ImageDirective implements OnChanges {
     if (!src) {
       return null;
     }
-    const newAttrs = {
-      ...otherAttrs,
+    const newAttrs: { [attr: string]: string } = {
+      ...(otherAttrs as { [key: string]: string }),
     };
     // update image URL for jss handler and image rendering params
     src = mediaApi.updateImageUrl(src, imageParams, this.mediaUrlPrefix);
@@ -118,22 +122,22 @@ export class ImageDirective implements OnChanges {
     return newAttrs;
   }
 
-  private renderTemplate(imageProps: any) {
+  private renderTemplate(imageProps: { [prop: string]: string }) {
     const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
     viewRef.rootNodes.forEach((node) => {
-      Object.entries(imageProps).forEach(([key, imgPropVal]: [string, any]) =>
+      Object.entries(imageProps).forEach(([key, imgPropVal]: [string, string]) =>
         this.renderer.setAttribute(node, key, imgPropVal)
       );
     });
   }
 
-  private getElementAttrs(): { [key: string]: any } {
+  private getElementAttrs(): { [key: string]: string } {
     const view = this.templateRef.createEmbeddedView(null);
     const element: Element = view.rootNodes[0];
     if (!element) {
       return {};
     }
-    const attrs: { [key: string]: any } = {};
+    const attrs: { [key: string]: string } = {};
     for (let i = 0; i < element.attributes.length; i++) {
       const attr = element.attributes.item(i);
       if (attr) {

--- a/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
@@ -4,6 +4,7 @@ import { By } from '@angular/platform-browser';
 
 import { generalLinkField as eeLinkData } from '../testData/ee-data';
 import { LinkDirective } from './link.directive';
+import { LinkField } from './rendering-field';
 
 @Component({
   selector: 'test-link',
@@ -12,7 +13,7 @@ import { LinkDirective } from './link.directive';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
 }
@@ -228,7 +229,7 @@ describe('<a *scLink />', () => {
   `,
 })
 class TestWithChildrenComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
 }

--- a/packages/sitecore-jss-angular/src/components/missing-component.component.ts
+++ b/packages/sitecore-jss-angular/src/components/missing-component.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { ComponentRendering } from '@sitecore-jss/sitecore-jss';
 
 @Component({
   selector: 'sc-missing-component',
@@ -12,5 +13,5 @@ import { Component, Input } from '@angular/core';
   `,
 })
 export class MissingComponentComponent {
-  @Input() rendering: any;
+  @Input() rendering: ComponentRendering;
 }

--- a/packages/sitecore-jss-angular/src/components/placeholder-loading.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder-loading.directive.ts
@@ -4,5 +4,5 @@ import { Directive, TemplateRef } from '@angular/core';
   selector: '[scPlaceholderLoading]',
 })
 export class PlaceholderLoadingDirective {
-  constructor(public templateRef: TemplateRef<any>) {}
+  constructor(public templateRef: TemplateRef<unknown>) {}
 }

--- a/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
@@ -108,6 +108,7 @@ describe('<sc-placeholder />', () => {
     { label: 'LayoutService data - EE on', data: eeData },
   ];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   testData.forEach((dataSet: any) => {
     describe(`with ${dataSet.label}`, () => {
       it('should render a placeholder with given key', async(() => {
@@ -159,7 +160,7 @@ describe('<sc-placeholder />', () => {
     const phKey = 'main';
 
     comp.name = phKey;
-    comp.rendering = component;
+    comp.rendering = (component as unknown) as ComponentRendering;
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
@@ -178,7 +179,7 @@ describe('<sc-placeholder />', () => {
     const component = nonEeDevData.sitecore.route;
     const phKey = 'main';
     comp.name = phKey;
-    comp.rendering = component;
+    comp.rendering = (component as unknown) as ComponentRendering;
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
@@ -219,7 +220,7 @@ describe('<sc-placeholder />', () => {
     };
 
     comp.name = phKey;
-    comp.rendering = route;
+    comp.rendering = (route as unknown) as ComponentRendering;
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
@@ -245,7 +246,7 @@ describe('<sc-placeholder />', () => {
     };
 
     comp.name = phKey;
-    comp.rendering = route;
+    comp.rendering = (route as unknown) as ComponentRendering;
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
@@ -334,7 +335,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
     const functionResult = 42;
     const changedMessage = 'ipsum';
 
-    comp.rendering = {
+    comp.rendering = ({
       placeholders: {
         children: [
           {
@@ -342,7 +343,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
           },
         ],
       },
-    };
+    } as unknown) as ComponentRendering;
     comp.name = 'children';
     comp.childMessage = expectedMessage;
     fixture.detectChanges();
@@ -361,7 +362,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
   it('should bind inputs to multiple', async(() => {
     const expectedMessage = 'lorem';
 
-    comp.rendering = {
+    comp.rendering = ({
       placeholders: {
         children: [
           {
@@ -375,7 +376,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
           },
         ],
       },
-    };
+    } as unknown) as ComponentRendering;
     comp.name = 'children';
     comp.childMessage = expectedMessage;
     fixture.detectChanges();
@@ -391,7 +392,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
   }));
 
   it('should bind outputs to children', async(() => {
-    comp.rendering = {
+    comp.rendering = ({
       placeholders: {
         children: [
           {
@@ -399,7 +400,7 @@ describe('<sc-placeholder /> with input/ouput binding', () => {
           },
         ],
       },
-    };
+    } as unknown) as ComponentRendering;
     comp.name = 'children';
     fixture.detectChanges();
     fixture.whenStable().then(() => {

--- a/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.component.spec.ts
@@ -7,6 +7,7 @@ import {
   Output,
 } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRendering } from '@sitecore-jss/sitecore-jss';
 import { By } from '@angular/platform-browser';
 import { SpyNgModuleFactoryLoader } from '@angular/router/testing';
 
@@ -27,7 +28,7 @@ import {
   `,
 })
 class TestPlaceholderComponent {
-  @Input() rendering: any;
+  @Input() rendering: ComponentRendering;
   @Input() name: string;
 }
 
@@ -38,7 +39,7 @@ class TestPlaceholderComponent {
   `,
 })
 class TestDownloadCalloutComponent {
-  @Input() rendering: any;
+  @Input() rendering: ComponentRendering;
 }
 
 @Component({
@@ -50,7 +51,7 @@ class TestDownloadCalloutComponent {
   `,
 })
 class TestHomeComponent {
-  @Input() rendering: any;
+  @Input() rendering: ComponentRendering;
 }
 
 @Component({
@@ -111,7 +112,7 @@ describe('<sc-placeholder />', () => {
     describe(`with ${dataSet.label}`, () => {
       it('should render a placeholder with given key', async(() => {
         const component = dataSet.data.sitecore.route.placeholders.main.find(
-          (c: any) => c.componentName
+          (c: ComponentRendering) => c.componentName
         );
         const phKey = 'page-content';
         comp.name = phKey;
@@ -270,7 +271,7 @@ describe('<sc-placeholder />', () => {
 })
 class TestParentComponent {
   clickMessage = '';
-  @Input() rendering: any;
+  @Input() rendering: ComponentRendering;
   @Input() name: string;
   @Input() set childMessage(message: string) {
     this.inputs.childMessage = message;

--- a/packages/sitecore-jss-angular/src/components/placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.component.ts
@@ -56,9 +56,9 @@ function getPlaceholder(rendering: ComponentRendering, name: string) {
   `,
 })
 export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
-  private _inputs: { [key: string]: any };
-  private _differ: KeyValueDiffer<string, any>;
-  private _componentInstances: any[] = [];
+  private _inputs: { [key: string]: unknown };
+  private _differ: KeyValueDiffer<string, unknown>;
+  private _componentInstances: { [prop: string]: unknown }[] = [];
   private destroyed = false;
   private parentStyleAttribute = '';
   public isLoading = true;
@@ -66,7 +66,7 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
   @Input() name?: string;
   @Input() rendering: ComponentRendering;
   @Input() renderings?: Array<ComponentRendering | HtmlElementRendering>;
-  @Input() outputs: { [k: string]: (eventType: any) => void };
+  @Input() outputs: { [k: string]: (eventType: unknown) => void };
 
   @Output()
   loaded = new EventEmitter<string | undefined>();
@@ -78,7 +78,7 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
   placeholderLoading?: PlaceholderLoadingDirective;
 
   @Input()
-  set inputs(value: { [key: string]: any }) {
+  set inputs(value: { [key: string]: unknown }) {
     this._inputs = value;
     if (!this._differ && value) {
       this._differ = this.differs.find(value).create();
@@ -92,7 +92,8 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
     private changeDetectorRef: ChangeDetectorRef,
     private elementRef: ElementRef,
     private renderer: Renderer2,
-    @Inject(PLACEHOLDER_MISSING_COMPONENT_COMPONENT) private missingComponentComponent: Type<any>
+    @Inject(PLACEHOLDER_MISSING_COMPONENT_COMPONENT)
+    private missingComponentComponent: Type<unknown>
   ) {}
 
   ngOnInit() {
@@ -130,7 +131,7 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
     if (!changes) {
       return;
     }
-    const updates: { [key: string]: any } = {};
+    const updates: { [key: string]: unknown } = {};
     changes.forEachRemovedItem((change) => (updates[change.key] = null));
     changes.forEachAddedItem((change) => (updates[change.key] = change.currentValue));
     changes.forEachChangedItem((change) => (updates[change.key] = change.currentValue));
@@ -139,22 +140,25 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
     );
   }
 
-  private _setComponentInputs(componentInstance: any, inputs: { [key: string]: any }) {
+  private _setComponentInputs(
+    componentInstance: { [key: string]: unknown },
+    inputs: { [key: string]: unknown }
+  ) {
     Object.entries(inputs).forEach(
       ([input, inputValue]) => (componentInstance[input] = inputValue)
     );
   }
 
   private _subscribeComponentOutputs(
-    componentInstance: any,
-    outputs: { [k: string]: (eventType: any) => void }
+    componentInstance: { [key: string]: unknown },
+    outputs: { [k: string]: (eventType: unknown) => void }
   ) {
     Object.keys(outputs)
       .filter(
         (output) => componentInstance[output] && componentInstance[output] instanceof Observable
       )
       .forEach((output) =>
-        (componentInstance[output] as Observable<any>)
+        (componentInstance[output] as Observable<unknown>)
           .pipe(takeWhile(() => !this.destroyed))
           .subscribe(outputs[output])
       );

--- a/packages/sitecore-jss-angular/src/components/placeholder.token.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.token.ts
@@ -3,7 +3,7 @@ import { InjectionToken, Type } from '@angular/core';
 /** Registers a statically loaded component */
 export class ComponentNameAndType {
   name: string;
-  type: Type<any>;
+  type: Type<unknown>;
 }
 
 /** Registers a lazily loaded component by name and module to lazy load when it's needed */
@@ -14,21 +14,23 @@ export interface ComponentNameAndModule {
    * Dynamic import of the component,
    * e.g. () => import('./path/to/lazyloadedcomponent.module').then(m => m.LazyLoadedComponentModuleExportName)
    */
-  loadChildren: () => Promise<any>;
+  loadChildren: () => Promise<Type<unknown>>;
 }
 
 /**
- * @param {any} object
+ * @param {unknown} object
  */
-export function instanceOfComponentNameAndType(object: any): object is ComponentNameAndType {
-  return 'type' in object;
+export function instanceOfComponentNameAndType(object: unknown): object is ComponentNameAndType {
+  return typeof object === 'object' && object !== null && 'type' in object;
 }
 
 /**
- * @param {any} object
+ * @param {unknown} object
  */
-export function instanceOfComponentNameAndModule(object: any): object is ComponentNameAndModule {
-  return 'module' in object;
+export function instanceOfComponentNameAndModule(
+  object: unknown
+): object is ComponentNameAndModule {
+  return typeof object === 'object' && object !== null && 'module' in object;
 }
 
 export const PLACEHOLDER_COMPONENTS = new InjectionToken<ComponentNameAndType[]>(
@@ -37,9 +39,9 @@ export const PLACEHOLDER_COMPONENTS = new InjectionToken<ComponentNameAndType[]>
 export const PLACEHOLDER_LAZY_COMPONENTS = new InjectionToken<ComponentNameAndType[]>(
   'Sc.placeholder.lazyComponents'
 );
-export const PLACEHOLDER_MISSING_COMPONENT_COMPONENT = new InjectionToken<Type<any>>(
+export const PLACEHOLDER_MISSING_COMPONENT_COMPONENT = new InjectionToken<Type<unknown>>(
   'Sc.placeholder.missingComponentComponent'
 );
-export const DYNAMIC_COMPONENT = new InjectionToken<Type<any> | { [s: string]: any }>(
+export const DYNAMIC_COMPONENT = new InjectionToken<Type<unknown> | { [s: string]: unknown }>(
   'Sc.placeholder.dynamicComponent'
 );

--- a/packages/sitecore-jss-angular/src/components/raw.component.ts
+++ b/packages/sitecore-jss-angular/src/components/raw.component.ts
@@ -16,7 +16,7 @@ export class RawComponent implements OnInit {
     const attributes = this.rendering.attributes;
     for (const attr in attributes) {
       // eslint-disable-next-line no-prototype-builtins
-      if ((attributes as any).hasOwnProperty(attr)) {
+      if (attributes.hasOwnProperty(attr)) {
         const value = attributes[attr];
         this.renderer.setAttribute(el, attr, value || '');
       }

--- a/packages/sitecore-jss-angular/src/components/render-component.component.ts
+++ b/packages/sitecore-jss-angular/src/components/render-component.component.ts
@@ -33,16 +33,16 @@ import { isRawRendering } from './rendering';
   `,
 })
 export class RenderComponentComponent implements OnChanges {
-  private _inputs: { [key: string]: any };
-  private _differ: KeyValueDiffer<string, any>;
+  private _inputs: { [key: string]: unknown };
+  private _differ: KeyValueDiffer<string, unknown>;
   private destroyed = false;
 
   @Input() rendering: ComponentRendering | HtmlElementRendering;
-  @Input() outputs: { [k: string]: (eventType: any) => void };
+  @Input() outputs: { [k: string]: (eventType: unknown) => void };
   @ViewChild('view', { read: ViewContainerRef, static: true }) private view: ViewContainerRef;
 
   @Input()
-  set inputs(value: { [key: string]: any }) {
+  set inputs(value: { [key: string]: unknown }) {
     this._inputs = value;
     if (!this._differ && value) {
       this._differ = this.differs.find(value).create();
@@ -53,7 +53,8 @@ export class RenderComponentComponent implements OnChanges {
     private componentFactoryResolver: ComponentFactoryResolver,
     private differs: KeyValueDiffers,
     private componentFactory: JssComponentFactoryService,
-    @Inject(PLACEHOLDER_MISSING_COMPONENT_COMPONENT) private missingComponentComponent: Type<any>
+    @Inject(PLACEHOLDER_MISSING_COMPONENT_COMPONENT)
+    private missingComponentComponent: Type<{ [key: string]: unknown }>
   ) {}
 
   ngOnChanges(changes: SimpleChanges) {
@@ -62,22 +63,26 @@ export class RenderComponentComponent implements OnChanges {
     }
   }
 
-  private _setComponentInputs(componentInstance: any, inputs: { [key: string]: any }) {
+  private _setComponentInputs(
+    componentInstance: { [key: string]: unknown },
+    inputs: { [key: string]: unknown }
+  ) {
     Object.entries(inputs).forEach(
-      ([input, inputValue]) => (componentInstance[input] = inputValue)
+      ([input, inputValue]) =>
+        ((componentInstance as { [prop: string]: unknown })[input] = inputValue)
     );
   }
 
   private _subscribeComponentOutputs(
-    componentInstance: any,
-    outputs: { [k: string]: (eventType: any) => void }
+    componentInstance: { [key: string]: unknown },
+    outputs: { [k: string]: (eventType: unknown) => void }
   ) {
     Object.keys(outputs)
       .filter(
         (output) => componentInstance[output] && componentInstance[output] instanceof Observable
       )
       .forEach((output) =>
-        (componentInstance[output] as Observable<any>)
+        (componentInstance[output] as Observable<unknown>)
           .pipe(takeWhile(() => !this.destroyed))
           .subscribe(outputs[output])
       );

--- a/packages/sitecore-jss-angular/src/components/render-each.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/render-each.directive.ts
@@ -4,5 +4,5 @@ import { Directive, TemplateRef } from '@angular/core';
   selector: '[renderEach]',
 })
 export class RenderEachDirective {
-  constructor(public templateRef: TemplateRef<any>) {}
+  constructor(public templateRef: TemplateRef<unknown>) {}
 }

--- a/packages/sitecore-jss-angular/src/components/render-empty.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/render-empty.directive.ts
@@ -4,5 +4,5 @@ import { Directive, TemplateRef } from '@angular/core';
   selector: '[renderEmpty]',
 })
 export class RenderEmptyDirective {
-  constructor(public templateRef: TemplateRef<any>) {}
+  constructor(public templateRef: TemplateRef<unknown>) {}
 }

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-export interface RenderingField {
-  value?: { [key: string]: unknown };
+export interface RenderingField<V = unknown> {
+  value?: V;
   editable?: string;
 }
 
@@ -9,10 +9,14 @@ export interface DateField {
   editable?: string;
 }
 
-export interface FileField extends RenderingField {
+export interface FileFieldValue {
   src?: string;
   title?: string;
   displayName?: string;
+}
+
+export interface FileField extends FileFieldValue, RenderingField {
+  value?: FileFieldValue;
 }
 
 export interface ImageFieldValue {
@@ -39,6 +43,6 @@ export interface LinkField extends LinkFieldValue, RenderingField {
   editableLastPart?: string;
 }
 
-export interface RichTextField extends RenderingField {}
+export interface RichTextField extends RenderingField<string> {}
 
-export interface TextField extends RenderingField {}
+export interface TextField extends RenderingField<string> {}

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -1,20 +1,40 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface RenderingField {
-  value?: any;
+  value?: { [key: string]: unknown };
+  editable?: string;
+}
+
+export interface DateField {
+  value?: string | number | Date;
   editable?: string;
 }
 
 export interface FileField extends RenderingField {
   src?: string;
+  title?: string;
+  displayName?: string;
 }
 
-export interface ImageField extends RenderingField {
+export interface ImageFieldValue {
+  [key: string]: unknown;
   src?: string;
+  srcSet?: {
+    [key: string]: string | number | undefined;
+  }[];
 }
 
-export interface LinkField extends RenderingField {
+export interface ImageField extends ImageFieldValue, RenderingField {
+  value?: ImageFieldValue;
+}
+
+export interface LinkFieldValue {
+  [key: string]: unknown;
   href?: string;
   text?: string;
+}
+
+export interface LinkField extends LinkFieldValue, RenderingField {
+  value?: LinkFieldValue;
   editableFirstPart?: string;
   editableLastPart?: string;
 }

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { richTextField as eeRichTextData } from '../testData/ee-data';
+import { RichTextField } from './rendering-field';
 import { RichTextDirective } from './rich-text.directive';
 
 @Component({
@@ -12,7 +13,7 @@ import { RichTextDirective } from './rich-text.directive';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: RichTextField;
   @Input() editable = true;
 }
 
@@ -47,7 +48,7 @@ describe('<div *scRichText />', () => {
   });
 
   it('should render editable with editable value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
       editable: 'editable',
     };
@@ -59,7 +60,7 @@ describe('<div *scRichText />', () => {
   });
 
   it('should render value with editing explicitly disabled', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
       editable: 'editable',
     };
@@ -72,7 +73,7 @@ describe('<div *scRichText />', () => {
   });
 
   it('should render value with with just a value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
     };
     comp.field = field;
@@ -83,7 +84,7 @@ describe('<div *scRichText />', () => {
   });
 
   it('should render embedded html as-is', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: '<input type="text">some crazy stuff<script code="whaaaat">uh oh</script>',
     };
     comp.field = field;

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -13,13 +13,13 @@ import { RichTextField } from './rendering-field';
   selector: '[scRichText]',
 })
 export class RichTextDirective implements OnChanges {
-  private viewRef: EmbeddedViewRef<any>;
+  private viewRef: EmbeddedViewRef<unknown>;
 
   @Input('scRichTextEditable') editable = true;
 
   @Input('scRichText') field: RichTextField;
 
-  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<any>) {}
+  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.field || changes.editable) {

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { generalLinkField as eeLinkData } from '../testData/ee-data';
 import { RouterLinkDirective } from './router-link.directive';
 import { RouterTestingModule } from '@angular/router/testing';
+import { LinkField } from './rendering-field';
 
 @Component({
   selector: 'test-router-link',
@@ -13,7 +14,7 @@ import { RouterTestingModule } from '@angular/router/testing';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
 }
@@ -174,7 +175,7 @@ describe('<a *scRouterLink />', () => {
   `,
 })
 class TestWithChildrenComponent {
-  @Input() field: any;
+  @Input() field: LinkField;
   @Input() editable = true;
   @Input() attrs = {};
 }

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.ts
@@ -14,13 +14,13 @@ import { LinkField } from './rendering-field';
 export class RouterLinkDirective extends LinkDirective {
   @Input('scRouterLinkEditable') editable = true;
 
-  @Input('scRouterLinkAttrs') attrs: any = {};
+  @Input('scRouterLinkAttrs') attrs: { [attr: string]: string } = {};
 
   @Input('scRouterLink') field: LinkField;
 
   constructor(
     viewContainer: ViewContainerRef,
-    templateRef: TemplateRef<any>,
+    templateRef: TemplateRef<unknown>,
     renderer: Renderer2,
     elementRef: ElementRef,
     private router: Router
@@ -28,11 +28,11 @@ export class RouterLinkDirective extends LinkDirective {
     super(viewContainer, templateRef, renderer, elementRef);
   }
 
-  protected renderTemplate(props: any, linkText: string) {
+  protected renderTemplate(props: { [prop: string]: string }, linkText: string) {
     const viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
 
     viewRef.rootNodes.forEach((node) => {
-      Object.entries(props).forEach(([key, propValue]: [string, any]) => {
+      Object.entries(props).forEach(([key, propValue]) => {
         this.renderer.setAttribute(node, key, propValue);
 
         if (key === 'href') {

--- a/packages/sitecore-jss-angular/src/components/text.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { textField as eeTextData } from '../testData/ee-data';
+import { TextField } from './rendering-field';
 import { TextDirective } from './text.directive';
 
 @Component({
@@ -12,7 +13,7 @@ import { TextDirective } from './text.directive';
   `,
 })
 class TestComponent {
-  @Input() field: any;
+  @Input() field: TextField;
   @Input() editable = true;
   @Input() encode = true;
 }
@@ -40,7 +41,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render nothing with missing editable and value', () => {
-    const field = {};
+    const field: { [prop: string]: unknown } = {};
     comp.field = field;
     fixture.detectChanges();
 
@@ -49,7 +50,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render nothing with empty value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: '',
     };
 
@@ -60,7 +61,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render editable with editable value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
       editable: 'editable',
     };
@@ -72,7 +73,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render value with editing explicitly disabled', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
       editable: 'editable',
     };
@@ -85,7 +86,7 @@ describe('<span *scText />', () => {
   });
 
   it('should encode values with editing explicitly disabled', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value < >',
     };
 
@@ -98,7 +99,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render value with with just a value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 'value',
     };
     comp.field = field;
@@ -109,7 +110,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render number value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 1.23,
     };
     comp.field = field;
@@ -120,7 +121,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render zero number value', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: 0,
     };
     comp.field = field;
@@ -131,7 +132,7 @@ describe('<span *scText />', () => {
   });
 
   it('should render embedded html as-is when encoding is disabled', () => {
-    const field = {
+    const field: { [prop: string]: unknown } = {
       value: '<input type="text">some crazy stuff<script code="whaaaat">uh oh</script>',
     };
     comp.field = field;

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -38,11 +38,7 @@ export class TextDirective implements OnChanges {
     const field = this.field;
     let editable = this.editable;
 
-    if (
-      !field ||
-      (!field.editable &&
-        (field.value === undefined || (typeof field.value === 'string' && field.value === '')))
-    ) {
+    if (!field || (!field.editable && (field.value === undefined || field.value === ''))) {
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -13,7 +13,7 @@ import { TextField } from './rendering-field';
   selector: '[scText]',
 })
 export class TextDirective implements OnChanges {
-  private viewRef: EmbeddedViewRef<any>;
+  private viewRef: EmbeddedViewRef<unknown>;
 
   @Input('scTextEditable') editable = true;
 
@@ -21,7 +21,7 @@ export class TextDirective implements OnChanges {
 
   @Input('scText') field: TextField;
 
-  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<any>) {}
+  constructor(private viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.field || changes.editable || changes.encode) {
@@ -38,7 +38,11 @@ export class TextDirective implements OnChanges {
     const field = this.field;
     let editable = this.editable;
 
-    if (!field || (!field.editable && (field.value === undefined || field.value === ''))) {
+    if (
+      !field ||
+      (!field.editable &&
+        (field.value === undefined || (typeof field.value === 'string' && field.value === '')))
+    ) {
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
+++ b/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
@@ -19,8 +19,10 @@ import { RawComponent } from './components/raw.component';
 import { isRawRendering } from './components/rendering';
 
 export interface ComponentFactoryResult {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   componentImplementation?: Type<any>;
   componentDefinition: ComponentRendering | HtmlElementRendering;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   componentFactory?: ComponentFactory<any>;
 }
 
@@ -81,6 +83,7 @@ export class JssComponentFactoryService {
         }
 
         if (component.componentName in dynamicComponentType) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           componentType = (dynamicComponentType as { [s: string]: any })[component.componentName];
         } else {
           if (typeof dynamicComponentType === 'function') {

--- a/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
+++ b/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
@@ -26,7 +26,7 @@ export interface ComponentFactoryResult {
 
 @Injectable()
 export class JssComponentFactoryService {
-  private componentMap: Map<string, Type<any>>;
+  private componentMap: Map<string, Type<unknown>>;
   private lazyComponentMap: Map<string, ComponentNameAndModule>;
 
   constructor(
@@ -45,7 +45,9 @@ export class JssComponentFactoryService {
     }
   }
 
-  private loadModuleFactory(lazyComponent: ComponentNameAndModule): Promise<NgModuleFactory<any>> {
+  private loadModuleFactory(
+    lazyComponent: ComponentNameAndModule
+  ): Promise<NgModuleFactory<unknown>> {
     return lazyComponent.loadChildren().then((loaded) => {
       if (loaded instanceof NgModuleFactory) {
         return loaded;

--- a/packages/sitecore-jss-angular/src/lib.module.ts
+++ b/packages/sitecore-jss-angular/src/lib.module.ts
@@ -1,5 +1,11 @@
 import { CommonModule, DatePipe } from '@angular/common';
-import { ANALYZE_FOR_ENTRY_COMPONENTS, ModuleWithProviders, NgModule, Type } from '@angular/core';
+import {
+  ANALYZE_FOR_ENTRY_COMPONENTS,
+  ModuleWithProviders,
+  NgModule,
+  Provider,
+  Type,
+} from '@angular/core';
 import { ROUTES } from '@angular/router';
 import { DateDirective } from './components/date.directive';
 import { FileDirective } from './components/file.directive';
@@ -77,10 +83,10 @@ export class JssModule {
 
   /**
    * Instantiates a module for a lazy-loaded JSS component
-   * @param {Type<any>} component
+   * @param {Type<unknown>} component
    * @returns {ModuleWithProviders<JssModule>} module
    */
-  static forChild(component: Type<any>): ModuleWithProviders<JssModule> {
+  static forChild(component: Type<unknown>): ModuleWithProviders<JssModule> {
     return {
       ngModule: JssModule,
       providers: [
@@ -114,7 +120,7 @@ export class JssModule {
         { provide: PLACEHOLDER_LAZY_COMPONENTS, useValue: lazyComponents || [] },
         { provide: ROUTES, useValue: lazyComponents || [], multi: true },
         { provide: PLACEHOLDER_MISSING_COMPONENT_COMPONENT, useValue: MissingComponentComponent },
-        ...(JssModule.forRoot().providers as any[]),
+        ...(JssModule.forRoot().providers as Provider[]),
       ],
     };
   }

--- a/packages/sitecore-jss-angular/tsconfig.json
+++ b/packages/sitecore-jss-angular/tsconfig.json
@@ -11,6 +11,7 @@
       "dom"
     ],
     "moduleResolution": "node",
+    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,

--- a/packages/sitecore-jss-forms/src/FormField.ts
+++ b/packages/sitecore-jss-forms/src/FormField.ts
@@ -1,16 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { HtmlFormField } from './HtmlFormField';
 import { InputViewModel, TitleFieldViewModel, ViewModel, FieldViewModel } from './ViewModel';
 
 export interface FormField<TViewModel extends ViewModel = ViewModel> {
+  [key: string]: unknown;
   model: TViewModel;
 }
 
 /**
- * @param {any} object
+ * @param {object} object
  */
-export function instanceOfFormField<T extends ViewModel>(object: any): object is FormField<T> {
+export function instanceOfFormField<T extends ViewModel>(object: {
+  [key: string]: unknown;
+}): object is FormField<T> {
   return 'model' in object;
 }
 
@@ -24,7 +25,9 @@ export interface ValueFormField<TViewModel extends InputViewModel = InputViewMod
 /**
  * @param {FormField} object
  */
-export function instanceOfValueFormField(object: FormField<any>): object is ValueFormField<any> {
+export function instanceOfValueFormField<T extends InputViewModel>(
+  object: FormField<ViewModel>
+): object is ValueFormField<T> {
   return 'indexField' in object;
 }
 

--- a/packages/sitecore-jss-forms/src/FormTracker.ts
+++ b/packages/sitecore-jss-forms/src/FormTracker.ts
@@ -19,8 +19,10 @@ enum EventIds {
   FieldError = 'ea27aca5-432f-424a-b000-26ba5f8ae60a',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TrackerFetcher = (formData: TrackingEvent[], endpoint: string) => Promise<any> | void;
+export type TrackerFetcher = (
+  formData: TrackingEvent[],
+  endpoint: string
+) => Promise<unknown> | void;
 
 export interface FormTrackerOptions {
   endpoint: string;

--- a/packages/sitecore-jss-forms/src/SitecoreForm.ts
+++ b/packages/sitecore-jss-forms/src/SitecoreForm.ts
@@ -11,6 +11,5 @@ export interface SitecoreForm {
   pageItemId: HtmlFormField;
   antiForgeryToken: HtmlFormField;
   metadata: FormModel;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Array<FormField<any>>;
+  fields: Array<FormField>;
 }

--- a/packages/sitecore-jss-forms/src/ViewModel.ts
+++ b/packages/sitecore-jss-forms/src/ViewModel.ts
@@ -7,6 +7,7 @@ export interface ValidationDataModel {
 }
 
 export interface ViewModel {
+  [key: string]: unknown;
   itemId: string;
   name: string;
   templateId: string;

--- a/packages/sitecore-jss-forms/src/serializeForm.ts
+++ b/packages/sitecore-jss-forms/src/serializeForm.ts
@@ -13,8 +13,7 @@ import { FileInputViewModel, instanceOfInputViewModel } from './ViewModel';
 
 export interface SerializeFormOptions {
   submitButtonName?: string | null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fieldValueParser?: (field: FormField<any>) => string | string[] | boolean;
+  fieldValueParser?: (field: FormField) => string | string[] | boolean;
 }
 
 /**
@@ -45,13 +44,12 @@ export function serializeForm(form: SitecoreForm, options?: SerializeFormOptions
 
 /**
  * @param {JssFormData} result
- * @param {Array<FormField<any>>} fields
+ * @param {Array<FormField>} fields
  * @param {SerializeFormOptions} options
  */
 function pushFields(
   result: JssFormData,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Array<FormField<any>>,
+  fields: ((TrackableValueFormField & FormField<FileInputViewModel>) | FormField)[],
   options: SerializeFormOptions
 ) {
   fields.forEach((field) => {

--- a/packages/sitecore-jss-forms/tsconfig.json
+++ b/packages/sitecore-jss-forms/tsconfig.json
@@ -23,7 +23,8 @@
     "declaration": true,
     "declarationDir": "./types",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noImplicitAny": true
   },
   "exclude": [
     "node_modules",

--- a/packages/sitecore-jss-nextjs/global.d.ts
+++ b/packages/sitecore-jss-nextjs/global.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module 'style-attr';
 
 declare module 'sync-disk-cache' {
@@ -9,15 +8,5 @@ declare module 'sync-disk-cache' {
     set(key: string, editingData: string): string;
     get(key: string): { value: string; isCached?: boolean };
     remove(key: string): void;
-  }
-}
-
-declare namespace NodeJS {
-  export interface Global {
-    requestAnimationFrame: any;
-    window: any;
-    document: any;
-    navigator: any;
-    HTMLElement: any;
   }
 }

--- a/packages/sitecore-jss-nextjs/global.d.ts
+++ b/packages/sitecore-jss-nextjs/global.d.ts
@@ -10,3 +10,14 @@ declare module 'sync-disk-cache' {
     remove(key: string): void;
   }
 }
+
+declare namespace NodeJS {
+  export interface Global {
+    [key: string]: unknown;
+    requestAnimationFrame: (callback: () => void) => void;
+    window: Window;
+    document: Document;
+    navigator: Navigator;
+    HTMLElement: HTMLElement;
+  }
+}

--- a/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-data-middleware.test.ts
@@ -14,7 +14,7 @@ type Query = {
   [key: string]: string;
 };
 
-const mockRequest = (method: string, query?: Query, body?: any) => {
+const mockRequest = (method: string, query?: Query, body?: unknown) => {
   return {
     method,
     query: query ?? {},
@@ -37,7 +37,7 @@ const mockResponse = () => {
   return res;
 };
 
-const mockCache = (data?: any) => {
+const mockCache = (data?: EditingData) => {
   const cache = {} as EditingDataCache;
   cache.set = spy();
   cache.get = spy(() => {

--- a/packages/sitecore-jss-nextjs/src/services/component-props-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/component-props-service.test.ts
@@ -4,7 +4,11 @@ import { expect, use, spy } from 'chai';
 import spies from 'chai-spies';
 import { IncomingMessage, ServerResponse } from 'http';
 import { ParsedUrlQuery } from 'querystring';
-import { Module } from '../sharedTypes/component-module';
+import { ComponentModule, Module } from '../sharedTypes/component-module';
+import {
+  GetServerSideComponentProps,
+  GetStaticComponentProps,
+} from '../sharedTypes/component-props';
 import { ComponentPropsService } from './component-props-service';
 
 use(spies);
@@ -68,8 +72,9 @@ describe('ComponentPropsService', () => {
     spy(() => (err ? Promise.reject(err) : Promise.resolve(expectedData)));
 
   it('fetchServerSideComponentProps', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ssrModules: { [componentName: string]: any } = {
+    const ssrModules: {
+      [componentName: string]: { getServerSideProps: GetServerSideComponentProps };
+    } = {
       namex11: {
         getServerSideProps: fetchFn('x11SSRData'),
       },
@@ -94,7 +99,7 @@ describe('ComponentPropsService', () => {
     const ssrComponentModule = (componentName: string) => ssrModules[componentName];
 
     const result = await service.fetchServerSideComponentProps({
-      componentModule: ssrComponentModule,
+      componentModule: ssrComponentModule as ComponentModule,
       context: ssrContext,
       layoutData,
     });
@@ -112,8 +117,9 @@ describe('ComponentPropsService', () => {
   });
 
   it('fetchServerSideComponentProps using lazy loading module', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ssrModules: { [componentName: string]: any } = {
+    const ssrModules: {
+      [componentName: string]: { getServerSideProps: GetServerSideComponentProps };
+    } = {
       namex11: {
         getServerSideProps: fetchFn('x11SSRData'),
       },
@@ -138,7 +144,7 @@ describe('ComponentPropsService', () => {
     const ssrComponentModule = (componentName: string) => {
       return new Promise<Module>((res) => {
         setTimeout(() => {
-          res(ssrModules[componentName]);
+          res(ssrModules[componentName] as Module);
         }, 200);
       });
     };
@@ -162,8 +168,7 @@ describe('ComponentPropsService', () => {
   });
 
   it('fetchStaticComponentProps using lazy loading module', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ssgModules: { [componentName: string]: any } = {
+    const ssgModules: { [componentName: string]: { getStaticProps: GetStaticComponentProps } } = {
       namex11: {
         getStaticProps: fetchFn('x11StaticData'),
       },
@@ -179,7 +184,7 @@ describe('ComponentPropsService', () => {
     };
 
     const ssgComponentModule = (componentName: string) => {
-      return new Promise<Module>((res) => {
+      return new Promise<{ getStaticProps: GetStaticComponentProps }>((res) => {
         setTimeout(() => {
           res(ssgModules[componentName]);
         }, 200);
@@ -187,7 +192,7 @@ describe('ComponentPropsService', () => {
     };
 
     const result = await service.fetchStaticComponentProps({
-      componentModule: ssgComponentModule,
+      componentModule: ssgComponentModule as ComponentModule,
       context,
       layoutData,
     });
@@ -205,8 +210,7 @@ describe('ComponentPropsService', () => {
   });
 
   it('fetchStaticComponentProps', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ssgModules: { [componentName: string]: any } = {
+    const ssgModules: { [componentName: string]: { getStaticProps: GetStaticComponentProps } } = {
       namex11: {
         getStaticProps: fetchFn('x11StaticData'),
       },
@@ -224,7 +228,7 @@ describe('ComponentPropsService', () => {
     const ssgComponentModule = (componentName: string) => ssgModules[componentName];
 
     const result = await service.fetchStaticComponentProps({
-      componentModule: ssgComponentModule,
+      componentModule: ssgComponentModule as ComponentModule,
       context,
       layoutData,
     });

--- a/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/editing-data-service.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, use, spy } from 'chai';
 import spies from 'chai-spies';
 import chaiAsPromised from 'chai-as-promised';
@@ -10,11 +9,13 @@ import { EditingDataService, QUERY_PARAM_EDITING_SECRET } from './editing-data-s
 use(spies);
 use(chaiAsPromised);
 
-const mockFetcher = (data?: any) => {
+const mockFetcher = (data?: unknown) => {
   const fetcher = {} as AxiosDataFetcher;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fetcher.get = spy<any>(() => {
     return Promise.resolve({ data });
   });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fetcher.put = spy<any>(() => {
     return Promise.resolve();
   });

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -11,8 +11,7 @@ import sitemapServiceResult from '../testData/sitemapServiceResult';
 import { GraphQLClient, GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
 
 class TestService extends GraphQLSitemapService {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public client: any;
+  public client: GraphQLClient;
   constructor(options: GraphQLSitemapServiceConfig) {
     super(options);
     this.client = this.getGraphQLClient();

--- a/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
@@ -2,21 +2,12 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
 
-/// <reference path="../../global.d.ts" />
+/// <reference types="../../global" />
 
 declare module 'style-attr';
 
-export interface Global {
-  [key: string]: unknown;
-  requestAnimationFrame: (callback: () => void) => void;
-  window: Window;
-  document: Document;
-  navigator: Navigator;
-  HTMLElement: HTMLElement;
-}
-
 // eslint-disable-next-line no-var
-declare var global: Global;
+declare var global: NodeJS.Global;
 
 const { JSDOM } = require('jsdom');
 

--- a/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
@@ -1,10 +1,22 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable spaced-comment */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
+
+/// <reference path="../../global.d.ts" />
 
 declare module 'style-attr';
 
+export interface Global {
+  [key: string]: unknown;
+  requestAnimationFrame: (callback: () => void) => void;
+  window: Window;
+  document: Document;
+  navigator: Navigator;
+  HTMLElement: HTMLElement;
+}
+
 // eslint-disable-next-line no-var
-declare var global: any;
+declare var global: Global;
 
 const { JSDOM } = require('jsdom');
 
@@ -12,10 +24,10 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const jsDomWindow = jsdom.window;
 
 /**
- * @param {any} src
- * @param {any} target
+ * @param {unknown} src
+ * @param {unknown} target
  */
-function copyProps(src: any, target: any) {
+function copyProps(src: unknown, target: { [key: string]: unknown }) {
   const props = Object.getOwnPropertyNames(src)
     .filter((prop) => typeof target[prop] === 'undefined')
     .reduce(
@@ -33,7 +45,7 @@ global.window = jsDomWindow;
 global.document = jsDomWindow.document;
 global.navigator = {
   userAgent: 'node.js',
-};
+} as Navigator;
 
 global.HTMLElement = jsDomWindow.HTMLElement; // makes chai "happy" https://github.com/chaijs/chai/issues/1029
 copyProps(jsDomWindow, global);

--- a/packages/sitecore-jss-nextjs/src/tests/shim.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/shim.ts
@@ -1,11 +1,12 @@
+/* eslint-disable spaced-comment */
 // React 16 depends on requestAnimationFrame, need a shim for node.js
 // eslint-disable-next-line spaced-comment
 // https://github.com/facebook/jest/issues/4545
 
-import { Global } from './jsdom-setup';
+/// <reference types="../../global" />
 
 // eslint-disable-next-line no-var
-declare var global: Global;
+declare var global: NodeJS.Global;
 
 global.requestAnimationFrame = (callback: () => void) => {
   setTimeout(callback, 0);

--- a/packages/sitecore-jss-nextjs/src/tests/shim.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/shim.ts
@@ -1,10 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // React 16 depends on requestAnimationFrame, need a shim for node.js
+// eslint-disable-next-line spaced-comment
 // https://github.com/facebook/jest/issues/4545
 
-// eslint-disable-next-line no-var
-declare var global: any;
+import { Global } from './jsdom-setup';
 
-global.requestAnimationFrame = (callback: any) => {
+// eslint-disable-next-line no-var
+declare var global: Global;
+
+global.requestAnimationFrame = (callback: () => void) => {
   setTimeout(callback, 0);
 };

--- a/packages/sitecore-jss-nextjs/tsconfig.json
+++ b/packages/sitecore-jss-nextjs/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitAny": true,
     "strict": true,
     "typeRoots": ["node_modules/@types"],
     "outDir": "dist/cjs",

--- a/packages/sitecore-jss-proxy/.eslintrc
+++ b/packages/sitecore-jss-proxy/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": "../../.eslintrc",
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off"
   }
 }

--- a/packages/sitecore-jss-proxy/src/AppRenderer.ts
+++ b/packages/sitecore-jss-proxy/src/AppRenderer.ts
@@ -6,6 +6,6 @@ export type AppRenderer = (
   /**
    * Data returned by Layout Service. If the route does not exist, null.
    */
-  data: any,
-  viewBag: any
+  data: { [key: string]: unknown },
+  viewBag: { [key: string]: unknown }
 ) => void;

--- a/packages/sitecore-jss-proxy/src/ProxyConfig.ts
+++ b/packages/sitecore-jss-proxy/src/ProxyConfig.ts
@@ -42,7 +42,7 @@ export interface ProxyConfig {
     request: IncomingMessage,
     response: ServerResponse,
     proxyResponse: IncomingMessage,
-    layoutServiceData: any
+    layoutServiceData: { [key: string]: unknown }
   ) => // eslint-disable-next-line @typescript-eslint/ban-types
   Promise<object>;
   /** Hook to alter HTTP headers in a custom way. */

--- a/packages/sitecore-jss-proxy/src/index.test.ts
+++ b/packages/sitecore-jss-proxy/src/index.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { removeEmptyAnalyticsCookie, rewriteRequestPath } from './';
+import { IncomingMessage } from 'http';
+import { ProxyIncomingMessage, removeEmptyAnalyticsCookie, rewriteRequestPath } from './';
 import config from './test/config.test';
 
 describe('removeEmptyAnalyticsCookie', () => {
@@ -18,7 +19,7 @@ describe('removeEmptyAnalyticsCookie', () => {
       },
     };
 
-    removeEmptyAnalyticsCookie(mockResponse);
+    removeEmptyAnalyticsCookie(mockResponse as IncomingMessage);
 
     expect(mockResponse).to.eql(expected);
   });
@@ -29,11 +30,11 @@ describe('rewriteRequestPath', () => {
     it('should return original url', () => {
       const url = '/sitecore/layoutsvc/render/jss?item=/&sc_apikey={GUID}';
       const expected = url;
-      const mockRequest = {
+      const mockRequest = ({
         headers: {
           'accept-encoding': 'gzip or whatever',
         },
-      };
+      } as unknown) as IncomingMessage;
 
       const actual = rewriteRequestPath(url, mockRequest, config);
       expect(actual).to.equal(expected);
@@ -43,11 +44,11 @@ describe('rewriteRequestPath', () => {
     it('should return original url', () => {
       const url = '/sitecore%20modules/foo.txt';
       const expected = '/sitecore%20modules/foo.txt';
-      const mockRequest = {
+      const mockRequest = ({
         headers: {
           'accept-encoding': 'gzip or whatever',
         },
-      };
+      } as unknown) as IncomingMessage;
 
       const actual = rewriteRequestPath(url, mockRequest, config);
       expect(actual).to.equal(expected);
@@ -57,11 +58,11 @@ describe('rewriteRequestPath', () => {
     it('should return route prefixed with layout service route', () => {
       const url = '/about';
       const expected = '/sitecore/layoutsvc/render/jss?item=%2Fabout&sc_apikey={GUID}';
-      const mockRequest = {
+      const mockRequest = ({
         headers: {
           'accept-encoding': 'gzip or whatever',
         },
-      };
+      } as unknown) as IncomingMessage;
 
       const actual = rewriteRequestPath(url, mockRequest, config);
       expect(actual).to.equal(expected);
@@ -69,11 +70,11 @@ describe('rewriteRequestPath', () => {
     it('should return route prefixed with layout service route when encoded chars are part of route', () => {
       const url = '/about%20us';
       const expected = '/sitecore/layoutsvc/render/jss?item=%2Fabout%20us&sc_apikey={GUID}';
-      const mockRequest = {
+      const mockRequest = ({
         headers: {
           'accept-encoding': 'gzip or whatever',
         },
-      };
+      } as unknown) as IncomingMessage;
 
       const actual = rewriteRequestPath(url, mockRequest, config);
       expect(actual).to.equal(expected);
@@ -84,12 +85,12 @@ describe('rewriteRequestPath', () => {
         const expected =
           '/sitecore/layoutsvc/render/jss?item=%2Fabout&sc_apikey={GUID}&sc_camp=123456%2078';
 
-        const req = {
+        const req = ({
           query: { sc_camp: '123456 78' },
           headers: {
             'accept-encoding': 'gzip or whatever',
           },
-        };
+        } as unknown) as IncomingMessage;
 
         const actual = rewriteRequestPath(url, req, config);
 
@@ -100,7 +101,7 @@ describe('rewriteRequestPath', () => {
         const url = '/styleguide?x=%25';
         const expected =
           '/sitecore/layoutsvc/render/jss?item=%2Fstyleguide&sc_apikey={GUID}&x=%25&y=test';
-        const mockRequest = {
+        const mockRequest = ({
           query: {
             x: '%',
             y: 'test',
@@ -108,7 +109,7 @@ describe('rewriteRequestPath', () => {
           headers: {
             'accept-encoding': 'gzip or whatever',
           },
-        };
+        } as unknown) as IncomingMessage;
 
         const actual = rewriteRequestPath(url, mockRequest, config);
         expect(actual).to.equal(expected);
@@ -120,12 +121,12 @@ describe('rewriteRequestPath', () => {
         const expected =
           '/sitecore/layoutsvc/render/jss?item=%2Fipsum%2Fdolor&sc_apikey={GUID}&sc_lang=zz-ZZ&sc_camp=123456';
 
-        const req = {
+        const req = ({
           query: { sc_camp: '123456' },
           headers: {
             'accept-encoding': 'gzip or whatever',
           },
-        };
+        } as unknown) as IncomingMessage;
         const parseRouteUrl = () => ({
           sitecoreRoute: 'ipsum/dolor',
           lang: 'zz-ZZ',
@@ -138,12 +139,12 @@ describe('rewriteRequestPath', () => {
         const expected =
           '/sitecore/layoutsvc/render/jss?item=%2Florem%20ipsum%2Fdolor&sc_apikey={GUID}&sc_lang=zz-ZZ&sc_camp=123456%2078';
 
-        const req = {
+        const req = ({
           query: { sc_camp: '123456 78' },
           headers: {
             'accept-encoding': 'gzip or whatever',
           },
-        };
+        } as unknown) as IncomingMessage;
         const parseRouteUrl = (incomingUrl: string) => ({
           sitecoreRoute: `${incomingUrl}/dolor`,
           lang: 'zz-ZZ',
@@ -158,11 +159,11 @@ describe('rewriteRequestPath', () => {
         const expected =
           '/sitecore/layoutsvc/render/jss?item=%2Fabout&sc_apikey={GUID}&sc_site=mysite';
         const qsParamsConfig = { ...config, qsParams: 'sc_site=mysite' };
-        const req = {
+        const req = ({
           headers: {
             'accept-encoding': 'gzip or whatever',
           },
-        };
+        } as unknown) as IncomingMessage;
 
         const actual = rewriteRequestPath(url, req, qsParamsConfig);
 
@@ -180,7 +181,11 @@ describe('rewriteRequestPath', () => {
           },
         };
 
-        const actual = rewriteRequestPath(url, req, qsParamsConfig);
+        const actual = rewriteRequestPath(
+          url,
+          (req as unknown) as ProxyIncomingMessage,
+          qsParamsConfig
+        );
 
         expect(actual).to.equal(expected);
       });

--- a/packages/sitecore-jss-proxy/src/util.ts
+++ b/packages/sitecore-jss-proxy/src/util.ts
@@ -12,7 +12,7 @@ export const tryParseJson = (jsonString: string) => {
   return null;
 };
 
-export const buildQueryString = (params: any) =>
+export const buildQueryString = (params: { [key: string]: string | number | boolean }) =>
   Object.keys(params)
     .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
     .join('&');

--- a/packages/sitecore-jss-proxy/tsconfig.json
+++ b/packages/sitecore-jss-proxy/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "noImplicitAny": true,
     "noUnusedParameters": false,
     "strict": true,
     "typeRoots": ["node_modules/@types"],

--- a/packages/sitecore-jss-react-forms/global.d.ts
+++ b/packages/sitecore-jss-react-forms/global.d.ts
@@ -1,1 +1,12 @@
 declare module 'style-attr';
+
+declare namespace NodeJS {
+  export interface Global {
+    [key: string]: unknown;
+    requestAnimationFrame: (callback: () => void) => void;
+    window: Window;
+    document: Document;
+    navigator: Navigator;
+    HTMLElement: HTMLElement;
+  }
+}

--- a/packages/sitecore-jss-react-forms/global.d.ts
+++ b/packages/sitecore-jss-react-forms/global.d.ts
@@ -1,11 +1,1 @@
 declare module 'style-attr';
-
-declare namespace NodeJS {
-  export interface Global {
-    requestAnimationFrame: any;
-    window: any;
-    document: any;
-    navigator: any;
-    HTMLElement: any;
-  }
-}

--- a/packages/sitecore-jss-react-forms/src/FieldProps.ts
+++ b/packages/sitecore-jss-react-forms/src/FieldProps.ts
@@ -51,7 +51,7 @@ export interface FieldWithValueProps<
 
 export type FieldChangeCallback = (
   fieldName: string,
-  newValue: string | string[] | File[],
+  newValue: string | string[] | File[] | boolean,
   isValid: boolean,
   errorMessages: string[]
 ) => void;
@@ -66,6 +66,5 @@ export type ValueFieldProps<
 
 export type LabelProps<TViewModel extends InputViewModel = InputViewModel> = FieldWithValueProps<
   ValueFormField<TViewModel>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  any
+  string | string[]
 >;

--- a/packages/sitecore-jss-react-forms/src/components/field-templates/checkbox.tsx
+++ b/packages/sitecore-jss-react-forms/src/components/field-templates/checkbox.tsx
@@ -33,8 +33,7 @@ const Checkbox: React.FunctionComponent<ValueFieldProps> = (props) => {
  */
 function handleOnChange(field: ValueFormField, fieldValue: boolean, callback: FieldChangeCallback) {
   // (fieldName, fieldValue, isValid, validationErrors)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  callback(field.valueField.name, fieldValue as any, true, []);
+  callback(field.valueField.name, fieldValue, true, []);
 }
 
 export default Checkbox;

--- a/packages/sitecore-jss-react-forms/src/components/form.tsx
+++ b/packages/sitecore-jss-react-forms/src/components/form.tsx
@@ -28,8 +28,7 @@ export interface FormProps {
   sitecoreApiKey: string;
   onRedirect?: (url: string) => void;
   errorComponent?: ComponentType<ErrorComponentProps>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fieldWrapperComponent?: ComponentType<FieldWithValueProps<any>>;
+  fieldWrapperComponent?: ComponentType<FieldWithValueProps>;
 
   /** Optionally override the label component for any field components that render a label */
   labelComponent?: ComponentType<LabelProps>;
@@ -66,15 +65,14 @@ export class Form extends Component<FormProps, FormState & FieldStateCollection>
   constructor(props: FormProps) {
     super(props);
 
-    this.state = {
+    this.state = ({
       errors: [],
       // in a multistep form the server can reset the form schema
       // to display further steps; this state property overrides
       // the form passed in from props if present
       nextForm: null,
       submitButton: null,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any; // workaround index type limitations in TS
+    } as unknown) as FieldStateCollection & FormState;
 
     this.createFieldComponent = this.createFieldComponent.bind(this);
     this.getCurrentFieldState = this.getCurrentFieldState.bind(this);

--- a/packages/sitecore-jss-react-forms/src/field-factory.tsx
+++ b/packages/sitecore-jss-react-forms/src/field-factory.tsx
@@ -12,8 +12,7 @@ export type FormFieldComponent<TProps extends FieldProps> = React.ComponentType<
  * but it maps form element components instead of layout components
  */
 class FieldFactory {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _fieldMap = new Map<string, React.ComponentType<any>>();
+  private _fieldMap = new Map<string, React.ComponentType<unknown>>();
   private _defaultComponent: React.ComponentType<FormField>;
 
   constructor() {
@@ -30,7 +29,7 @@ class FieldFactory {
   }
 
   setComponent<TProps extends FieldProps>(type: FieldTypes, component: FormFieldComponent<TProps>) {
-    this._fieldMap.set(type, component);
+    this._fieldMap.set(type, component as React.ComponentType<unknown>);
   }
 
   get(field: FormField, props: FieldProps): React.ReactNode {

--- a/packages/sitecore-jss-react-forms/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-react-forms/src/tests/jsdom-setup.ts
@@ -1,8 +1,21 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/* eslint-disable spaced-comment */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
 
+/// <reference path="../../global.d.ts" />
+
 declare module 'style-attr';
-declare let global: any;
+
+export interface Global {
+  [key: string]: unknown;
+  requestAnimationFrame: (callback: () => void) => void;
+  window: Window;
+  document: Document;
+  navigator: Navigator;
+  HTMLElement: HTMLElement;
+}
+
+declare let global: Global;
 
 const { JSDOM } = require('jsdom');
 
@@ -10,10 +23,10 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const jsDomWindow = jsdom.window;
 
 /**
- * @param {any} src
- * @param {any} target
+ * @param {unknown} src
+ * @param {object} target
  */
-function copyProps(src: any, target: any) {
+function copyProps(src: unknown, target: { [key: string]: unknown }) {
   const props = Object.getOwnPropertyNames(src)
     .filter((prop) => typeof target[prop] === 'undefined')
     .reduce(
@@ -31,7 +44,7 @@ global.window = jsDomWindow;
 global.document = jsDomWindow.document;
 global.navigator = {
   userAgent: 'node.js',
-};
+} as Navigator;
 
 global.HTMLElement = jsDomWindow.HTMLElement; // makes chai "happy" https://github.com/chaijs/chai/issues/1029
 copyProps(jsDomWindow, global);

--- a/packages/sitecore-jss-react-forms/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-react-forms/src/tests/jsdom-setup.ts
@@ -2,20 +2,11 @@
 /* eslint-disable spaced-comment */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
 
-/// <reference path="../../global.d.ts" />
+/// <reference types="../../global" />
 
 declare module 'style-attr';
 
-export interface Global {
-  [key: string]: unknown;
-  requestAnimationFrame: (callback: () => void) => void;
-  window: Window;
-  document: Document;
-  navigator: Navigator;
-  HTMLElement: HTMLElement;
-}
-
-declare let global: Global;
+declare let global: NodeJS.Global;
 
 const { JSDOM } = require('jsdom');
 

--- a/packages/sitecore-jss-react-forms/src/tests/shim.ts
+++ b/packages/sitecore-jss-react-forms/src/tests/shim.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // React 16 depends on requestAnimationFrame, need a shim for node.js
 // https://github.com/facebook/jest/issues/4545
 
-declare let global: any;
+import { Global } from './jsdom-setup';
 
-global.requestAnimationFrame = (callback: any) => {
+declare let global: Global;
+
+global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);
 };

--- a/packages/sitecore-jss-react-forms/src/tests/shim.ts
+++ b/packages/sitecore-jss-react-forms/src/tests/shim.ts
@@ -1,9 +1,10 @@
+/* eslint-disable spaced-comment */
 // React 16 depends on requestAnimationFrame, need a shim for node.js
 // https://github.com/facebook/jest/issues/4545
 
-import { Global } from './jsdom-setup';
+/// <reference types="../../global" />
 
-declare let global: Global;
+declare let global: NodeJS.Global;
 
 global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);

--- a/packages/sitecore-jss-react-forms/tsconfig.json
+++ b/packages/sitecore-jss-react-forms/tsconfig.json
@@ -15,6 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": false,
+    "noImplicitAny": true,
     "noUnusedParameters": true,
     "strict": true,
     "typeRoots": [

--- a/packages/sitecore-jss-react/global.d.ts
+++ b/packages/sitecore-jss-react/global.d.ts
@@ -1,1 +1,12 @@
 declare module 'style-attr';
+
+declare namespace NodeJS {
+  export interface Global {
+    [key: string]: unknown;
+    requestAnimationFrame: (callback: () => void) => void;
+    window: Window;
+    document: Document;
+    navigator: Navigator;
+    HTMLElement: HTMLElement;
+  }
+}

--- a/packages/sitecore-jss-react/global.d.ts
+++ b/packages/sitecore-jss-react/global.d.ts
@@ -1,11 +1,1 @@
 declare module 'style-attr';
-
-declare namespace NodeJS {
-  export interface Global {
-    requestAnimationFrame: any;
-    window: any;
-    document: any;
-    navigator: any;
-    HTMLElement: any;
-  }
-}

--- a/packages/sitecore-jss-react/src/components/Date.tsx
+++ b/packages/sitecore-jss-react/src/components/Date.tsx
@@ -62,7 +62,7 @@ export const DateField: React.SFC<DateFieldProps> = ({
 
 DateField.propTypes = {
   field: PropTypes.shape({
-    value: PropTypes.any,
+    value: PropTypes.string,
     editable: PropTypes.string,
   }).isRequired,
   tag: PropTypes.string,

--- a/packages/sitecore-jss-react/src/components/File.test.tsx
+++ b/packages/sitecore-jss-react/src/components/File.test.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import React from 'react';
-import { File } from './File';
+import { File, FileField } from './File';
 
 describe('<File />', () => {
   it('should render nothing with missing field', () => {
-    const field: any = null;
+    const field = null as FileField;
     const rendered = mount(<File field={field} />).children();
     expect(rendered).to.have.length(0);
   });

--- a/packages/sitecore-jss-react/src/components/Image.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.test.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-unused-expressions */
 import chai from 'chai';
 import chaiString from 'chai-string';
 import { mount } from 'enzyme';
 import React from 'react';
 import { imageField as eeImageData } from '../testData/ee-data';
-import { Image } from './Image';
+import { Image, ImageField } from './Image';
 
 const expect = chai.use(chaiString).expect;
 
@@ -264,7 +263,7 @@ describe('<Image />', () => {
   });
 
   it('should render no <img /> when media prop is empty', () => {
-    const img: any = '';
+    const img = '' as ImageField;
     const rendered = mount(<Image media={img} />);
     expect(rendered.find('img')).to.have.length(0);
   });

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { Link } from './Link';
+import { Link, LinkField } from './Link';
 import { generalLinkField as eeLinkData } from '../testData/ee-data';
 
 describe('<Link />', () => {
   it('should render nothing with missing field', () => {
-    const field: any = null;
+    const field = null as LinkField;
     const rendered = mount(<Link field={field} />).children();
     expect(rendered).to.have.length(0);
   });

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable react/prop-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -5,6 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
+import { ComponentRendering, Field, Item, RouteData } from '@sitecore-jss/sitecore-jss';
 import { ComponentFactory } from './sharedTypes';
 import { Placeholder } from './Placeholder';
 import { SitecoreContext } from './SitecoreContext';
@@ -19,8 +21,14 @@ const componentFactory: ComponentFactory = (componentName: string) => {
   const components = new Map<string, React.FC>();
 
   // pass otherProps to page-content to test property cascading through the Placeholder
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const Home: React.FC<any> = ({ rendering, render, renderEach, renderEmpty, ...otherProps }) => (
+
+  const Home: React.FC<{ [prop: string]: unknown; rendering?: RouteData | ComponentRendering }> = ({
+    rendering,
+    render,
+    renderEach,
+    renderEmpty,
+    ...otherProps
+  }) => (
     <div className="home-mock">
       <Placeholder name="page-header" rendering={rendering} />
       <Placeholder name="page-content" rendering={rendering} {...otherProps} />
@@ -32,15 +40,20 @@ const componentFactory: ComponentFactory = (componentName: string) => {
 
   components.set('Home', Home);
 
-  const DownloadCallout: React.FC<any> = (props) => (
+  const DownloadCallout: React.FC<{
+    [prop: string]: unknown;
+    fields?: { message?: { value?: string } };
+  }> = (props) => (
     <div className="download-callout-mock">
       {props.fields.message ? props.fields.message.value : ''}
     </div>
   );
   DownloadCallout.propTypes = {
     fields: PropTypes.shape({
-      message: PropTypes.object,
-    }),
+      message: PropTypes.shape({
+        value: PropTypes.string,
+      }),
+    }).isRequired,
   };
 
   components.set('DownloadCallout', DownloadCallout);
@@ -51,8 +64,9 @@ const componentFactory: ComponentFactory = (componentName: string) => {
 
 describe('<Placeholder />', () => {
   it('should render without required props', () => {
-    const key: any = null;
-    const renderedComponent = shallow(<Placeholder name={key} rendering={key} />);
+    const key: string = null;
+    const rendering: RouteData = null;
+    const renderedComponent = shallow(<Placeholder name={key} rendering={rendering} />);
     expect(renderedComponent.length).to.eql(1);
   });
 
@@ -65,9 +79,10 @@ describe('<Placeholder />', () => {
   testData.forEach((dataSet) => {
     describe(`with ${dataSet.label}`, () => {
       it('should render a placeholder with given key', () => {
-        const component = (dataSet.data.sitecore.route.placeholders.main as any[]).find(
-          (c) => c.componentName
-        );
+        const component = (dataSet.data.sitecore.route.placeholders.main as (
+          | ComponentRendering
+          | RouteData
+        )[]).find((c) => (c as ComponentRendering).componentName);
         const phKey = 'page-content';
 
         const renderedComponent = mount(
@@ -78,7 +93,7 @@ describe('<Placeholder />', () => {
       });
 
       it('should render nested placeholders', () => {
-        const component: any = dataSet.data.sitecore.route;
+        const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = mount(
@@ -91,7 +106,7 @@ describe('<Placeholder />', () => {
       });
 
       it('should render components based on the rendereach function', () => {
-        const component: any = dataSet.data.sitecore.route;
+        const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = mount(
@@ -108,7 +123,7 @@ describe('<Placeholder />', () => {
       });
 
       it('should render components based on the render function', () => {
-        const component: any = dataSet.data.sitecore.route;
+        const component = dataSet.data.sitecore.route as RouteData;
         const phKey = 'main';
 
         const renderedComponent = mount(
@@ -126,7 +141,7 @@ describe('<Placeholder />', () => {
 
       it('when null passed to render function', () => {
         it('should render empty placeholder', () => {
-          const component: any = dataSet.data.sitecore.route;
+          const component = dataSet.data.sitecore.route as RouteData;
           const phKey = 'main';
 
           const renderedComponent = mount(
@@ -142,9 +157,9 @@ describe('<Placeholder />', () => {
       });
 
       it('should render output based on the renderEmpty function in case of no renderings', () => {
-        const component: any = dataSet.data.sitecore.route;
+        const component = dataSet.data.sitecore.route as RouteData;
         const renderings = component.placeholders.main.filter(
-          ({ componentName }: any) => !componentName
+          (c) => !(c as ComponentRendering).componentName
         );
         const myComponent = {
           ...component,
@@ -210,7 +225,7 @@ describe('<Placeholder />', () => {
   });
 
   it('should render null for unknown placeholder', () => {
-    const route: any = {
+    const route = ({
       placeholders: {
         main: [
           {
@@ -218,7 +233,7 @@ describe('<Placeholder />', () => {
           },
         ],
       },
-    };
+    } as unknown) as RouteData;
     const phKey = 'unknown';
 
     const renderedComponent = mount(
@@ -231,14 +246,11 @@ describe('<Placeholder />', () => {
     const componentFactory: ComponentFactory = (componentName: string) => {
       const components = new Map<string, React.FC>();
 
-      const Home: React.FC<any> = ({ rendering }) => (
+      const Home: React.FC<{ rendering?: RouteData }> = ({ rendering }) => (
         <div className="home-mock">
           <Placeholder name="main" rendering={rendering} />
         </div>
       );
-      Home.propTypes = {
-        placeholders: PropTypes.object,
-      };
 
       components.set('Home', Home);
       components.set('ThrowError', () => {
@@ -247,7 +259,7 @@ describe('<Placeholder />', () => {
       return components.get(componentName) || null;
     };
 
-    const route: any = {
+    const route = ({
       placeholders: {
         main: [
           {
@@ -255,7 +267,7 @@ describe('<Placeholder />', () => {
           },
         ],
       },
-    };
+    } as unknown) as RouteData;
     const phKey = 'main';
 
     const renderedComponent = mount(
@@ -266,16 +278,13 @@ describe('<Placeholder />', () => {
 
   it('should render custom errorComponent on error, if provided', () => {
     const componentFactory: ComponentFactory = (componentName: string) => {
-      const components = new Map<string, React.FC>();
+      const components = new Map<string, React.FC<{ [key: string]: unknown }>>();
 
-      const Home: React.FC<any> = ({ rendering }) => (
+      const Home: React.FC<{ rendering?: RouteData }> = ({ rendering }) => (
         <div className="home-mock">
           <Placeholder name="main" rendering={rendering} />
         </div>
       );
-      Home.propTypes = {
-        placeholders: PropTypes.object,
-      };
 
       components.set('Home', Home);
       components.set('ThrowError', () => {
@@ -284,9 +293,9 @@ describe('<Placeholder />', () => {
       return components.get(componentName) || null;
     };
 
-    const CustomError: React.FC<any> = () => <div className="custom-error">Custom Error</div>;
+    const CustomError: React.FC = () => <div className="custom-error">Custom Error</div>;
 
-    const route: any = {
+    const route = ({
       placeholders: {
         main: [
           {
@@ -294,7 +303,7 @@ describe('<Placeholder />', () => {
           },
         ],
       },
-    };
+    } as unknown) as RouteData;
     const phKey = 'main';
 
     const renderedComponent = mount(

--- a/packages/sitecore-jss-react/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.test.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { RichText } from './RichText';
+import { RichText, RichTextField } from './RichText';
 import { richTextField as eeRichTextData } from '../testData/ee-data';
 
 describe('<RichText />', () => {
   it('should render nothing with missing field', () => {
-    const field: any = null;
+    const field: RichTextField = null;
     const rendered = mount(<RichText field={field} />).find('div');
     expect(rendered).to.have.length(0);
   });

--- a/packages/sitecore-jss-react/src/components/RichText.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.tsx
@@ -1,13 +1,15 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
+export interface RichTextField {
+  value?: string;
+  editable?: string;
+}
+
 export interface RichTextProps {
   [htmlAttributes: string]: unknown;
   /** The rich text field data. */
-  field?: {
-    value?: string;
-    editable?: string;
-  };
+  field?: RichTextField;
   /**
    * The HTML element that will wrap the contents of the field.
    * @default <div />

--- a/packages/sitecore-jss-react/src/components/Text.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Text.test.tsx
@@ -1,15 +1,14 @@
 /* eslint-disable no-unused-expressions */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { Text } from './Text';
+import { Text, TextField } from './Text';
 import { textField as eeTextData } from '../testData/ee-data';
 
 describe('<Text />', () => {
   it('should render nothing with missing field', () => {
-    const field: any = null;
+    const field: TextField = null;
     const rendered = mount(<Text field={field} />);
     expect(rendered).to.have.length(1);
     expect(rendered.html()).to.be.null;

--- a/packages/sitecore-jss-react/src/components/Text.tsx
+++ b/packages/sitecore-jss-react/src/components/Text.tsx
@@ -1,13 +1,15 @@
 import React, { ReactElement, FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
 
+export interface TextField {
+  value?: string | number;
+  editable?: string;
+}
+
 export interface TextProps {
   [htmlAttributes: string]: unknown;
   /** The text field data. */
-  field?: {
-    value?: string | number;
-    editable?: string;
-  };
+  field?: TextField;
   /**
    * The HTML element that will wrap the contents of the field.
    */

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { expect, use, spy } from 'chai';
 import spies from 'chai-spies';
@@ -52,7 +51,7 @@ describe('withDatasourceCheck', () => {
 
   it('should return null if rendering missing in normal mode', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
-    const props = {} as any;
+    const props = {} as WithDatasourceCheckProps;
 
     const wrapper = mount(
       <SitecoreContextReactContext.Provider value={mockContext(false)}>

--- a/packages/sitecore-jss-react/src/enhancers/withPlaceholder.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withPlaceholder.tsx
@@ -42,8 +42,11 @@ export function withPlaceholder(
   placeholders: WithPlaceholderSpec,
   options?: WithPlaceholderOptions
 ) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (WrappedComponent: React.ComponentClass<any> | React.SFC<any>) => {
+  return (
+    WrappedComponent:
+      | React.ComponentClass<{ [prop: string]: unknown }>
+      | React.FunctionComponent<{ [prop: string]: unknown }>
+  ) => {
     class WithPlaceholder extends PlaceholderCommon<PlaceholderProps> {
       static propTypes = PlaceholderCommon.propTypes;
 

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -27,8 +27,8 @@ export {
 export { ComponentFactory } from './components/sharedTypes';
 export { Placeholder } from './components/Placeholder';
 export { Image, ImageField } from './components/Image';
-export { RichText, RichTextProps, RichTextPropTypes } from './components/RichText';
-export { Text } from './components/Text';
+export { RichText, RichTextProps, RichTextPropTypes, RichTextField } from './components/RichText';
+export { Text, TextField } from './components/Text';
 export { DateField } from './components/Date';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';

--- a/packages/sitecore-jss-react/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-react/src/tests/jsdom-setup.ts
@@ -1,9 +1,22 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable spaced-comment */
+/* eslint-disable @typescript-eslint/triple-slash-reference */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
 
+/// <reference path="../../global.d.ts" />
+
 declare module 'style-attr';
+
+export interface Global {
+  [key: string]: unknown;
+  requestAnimationFrame: (callback: () => void) => void;
+  window: Window;
+  document: Document;
+  navigator: Navigator;
+  HTMLElement: HTMLElement;
+}
+
 // eslint-disable-next-line no-var
-declare var global: any;
+declare var global: Global;
 
 const { JSDOM } = require('jsdom');
 
@@ -11,10 +24,10 @@ const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
 const jsDomWindow = jsdom.window;
 
 /**
- * @param {any} src
- * @param {any} target
+ * @param {unknown} src
+ * @param {unknown} target
  */
-function copyProps(src: any, target: any) {
+function copyProps(src: unknown, target: { [key: string]: unknown }) {
   const props = Object.getOwnPropertyNames(src)
     .filter((prop) => typeof target[prop] === 'undefined')
     .reduce(
@@ -32,7 +45,7 @@ global.window = jsDomWindow;
 global.document = jsDomWindow.document;
 global.navigator = {
   userAgent: 'node.js',
-};
+} as Navigator;
 
 global.HTMLElement = jsDomWindow.HTMLElement; // makes chai "happy" https://github.com/chaijs/chai/issues/1029
 copyProps(jsDomWindow, global);

--- a/packages/sitecore-jss-react/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-react/src/tests/jsdom-setup.ts
@@ -1,22 +1,12 @@
 /* eslint-disable spaced-comment */
-/* eslint-disable @typescript-eslint/triple-slash-reference */
 // https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
 
-/// <reference path="../../global.d.ts" />
+/// <reference types="../../global" />
 
 declare module 'style-attr';
 
-export interface Global {
-  [key: string]: unknown;
-  requestAnimationFrame: (callback: () => void) => void;
-  window: Window;
-  document: Document;
-  navigator: Navigator;
-  HTMLElement: HTMLElement;
-}
-
 // eslint-disable-next-line no-var
-declare var global: Global;
+declare var global: NodeJS.Global;
 
 const { JSDOM } = require('jsdom');
 

--- a/packages/sitecore-jss-react/src/tests/shim.ts
+++ b/packages/sitecore-jss-react/src/tests/shim.ts
@@ -1,10 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // React 16 depends on requestAnimationFrame, need a shim for node.js
 // https://github.com/facebook/jest/issues/4545
 
-// eslint-disable-next-line no-var
-declare var global: any;
+import { Global } from './jsdom-setup';
 
-global.requestAnimationFrame = (callback: any) => {
+// eslint-disable-next-line no-var
+declare var global: Global;
+
+global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);
 };

--- a/packages/sitecore-jss-react/src/tests/shim.ts
+++ b/packages/sitecore-jss-react/src/tests/shim.ts
@@ -1,10 +1,11 @@
+/* eslint-disable spaced-comment */
 // React 16 depends on requestAnimationFrame, need a shim for node.js
 // https://github.com/facebook/jest/issues/4545
 
-import { Global } from './jsdom-setup';
+/// <reference types="../../global" />
 
 // eslint-disable-next-line no-var
-declare var global: Global;
+declare var global: NodeJS.Global;
 
 global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);

--- a/packages/sitecore-jss-react/tsconfig.json
+++ b/packages/sitecore-jss-react/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noImplicitAny": true,
     "noUnusedLocals": false,
     "noUnusedParameters": true,
     "strict": true,

--- a/packages/sitecore-jss-rendering-host/.eslintrc
+++ b/packages/sitecore-jss-rendering-host/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": "../../.eslintrc",
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off"
   }
 }

--- a/packages/sitecore-jss-rendering-host/src/defaultAppInvocationInfoResolver.ts
+++ b/packages/sitecore-jss-rendering-host/src/defaultAppInvocationInfoResolver.ts
@@ -1,6 +1,6 @@
 import importFresh from 'import-fresh';
 import path from 'path';
-import { AppInvocationInfoResolver } from './ssrMiddleware';
+import { AppInvocationInfoResolver, JsonObject } from './ssrMiddleware';
 
 /**
  * Returns the default AppInvocationInfoResolver, which is responsible for resolving the function, within your app bundle,
@@ -17,19 +17,19 @@ import { AppInvocationInfoResolver } from './ssrMiddleware';
  * @returns {AppInvocationInfoResolver} resolver
  */
 export function getDefaultAppInvocationInfoResolver({
-  appPathResolver = (requestJson: any) => {
+  appPathResolver = (requestJson: JsonObject) => {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return path.resolve(baseAppPath, requestJson.id, serverBundleName);
   },
   baseAppPath = './dist',
   serverBundleName = 'server.bundle',
 }) {
-  const resolver: AppInvocationInfoResolver = (requestJson: any) => {
+  const resolver: AppInvocationInfoResolver = (requestJson) => {
     // default resolution assumes folder structure of:
     // ./dist/{JSSAppName}/{ServerBundleName}.js
-    const modulePath = appPathResolver(requestJson); // path.resolve(baseAppPath, requestJson.id, serverBundleName);
+    const modulePath = appPathResolver(requestJson as JsonObject);
     const resolvedModule = importFresh(modulePath);
-    const resolvedRenderFunctionName = requestJson.functionName || 'renderView';
+    const resolvedRenderFunctionName = (requestJson as JsonObject).functionName || 'renderView';
     const renderFunction = resolvedModule[resolvedRenderFunctionName];
 
     if (!renderFunction) {
@@ -39,7 +39,7 @@ export function getDefaultAppInvocationInfoResolver({
         named "${resolvedRenderFunctionName}".`);
     }
 
-    const renderFunctionArgs = requestJson.args;
+    const renderFunctionArgs = (requestJson as JsonObject).args;
 
     return {
       renderFunction: (...args) => {

--- a/packages/sitecore-jss-rendering-host/src/devServer.ts
+++ b/packages/sitecore-jss-rendering-host/src/devServer.ts
@@ -71,7 +71,7 @@ export interface DevServerOptions {
 }
 
 /**
- * @param {any} config
+ * @param {DevServerOptions} config
  */
 export function startDevServer({
   port = 0,
@@ -258,10 +258,10 @@ export function startDevServer({
 
 /**
  * @param {Function | undefined} hook
- * @param {...any} args
+ * @param {unknown[]} args
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-function invokeHook(hook: Function | undefined, ...args: any[]) {
+function invokeHook(hook: Function | undefined, ...args: unknown[]) {
   if (hook && typeof hook === 'function') {
     hook(...args);
   }

--- a/packages/sitecore-jss-rendering-host/src/devServer.ts
+++ b/packages/sitecore-jss-rendering-host/src/devServer.ts
@@ -258,7 +258,7 @@ export function startDevServer({
 
 /**
  * @param {Function | undefined} hook
- * @param {unknown[]} args
+ * @param {...unknown} args
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 function invokeHook(hook: Function | undefined, ...args: unknown[]) {

--- a/packages/sitecore-jss-rendering-host/src/renderingHostServer.ts
+++ b/packages/sitecore-jss-rendering-host/src/renderingHostServer.ts
@@ -42,7 +42,7 @@ export interface RenderingHostServerOptions {
 }
 
 /**
- * @param {any} config
+ * @param {RenderingHostServerOptions} config
  */
 export function startRenderingHostServer({
   port = 0,
@@ -100,10 +100,10 @@ export function startRenderingHostServer({
 
 /**
  * @param {Function | undefined} hook
- * @param {...any} args
+ * @param {...unknown} args
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-function invokeHook(hook: Function | undefined, ...args: any[]) {
+function invokeHook(hook: Function | undefined, ...args: unknown[]) {
   if (hook && typeof hook === 'function') {
     hook(...args);
   }

--- a/packages/sitecore-jss-rendering-host/tsconfig.json
+++ b/packages/sitecore-jss-rendering-host/tsconfig.json
@@ -11,6 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "noImplicitAny": true,
     "noUnusedParameters": false,
     "strict": true,
     "typeRoots": ["node_modules/@types"],

--- a/packages/sitecore-jss-tracking/src/trackingApi.test.ts
+++ b/packages/sitecore-jss-tracking/src/trackingApi.test.ts
@@ -44,8 +44,7 @@ describe('trackEvent', () => {
       fetcher: axiosFetcher,
     }).then((data) => {
       // testData should contain the 'config' object from the mock request
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const testData = data as any;
+      const testData = (data as unknown) as { [key: string]: unknown };
       expect(testData.url).to.equal(expectedUrl);
       expect(testData.withCredentials, 'with credentials is not true').to.be.true;
     });
@@ -67,8 +66,7 @@ describe('trackEvent', () => {
       fetcher: axiosFetcher,
     }).then((data) => {
       // testData should contain the 'config' object from the mock request
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const testData = data as any;
+      const testData = (data as unknown) as { [key: string]: unknown };
       expect(testData.url).to.equal(expectedUrl);
       expect(testData.withCredentials, 'with credentials is not true').to.be.true;
     });

--- a/packages/sitecore-jss-tracking/src/trackingApi.ts
+++ b/packages/sitecore-jss-tracking/src/trackingApi.ts
@@ -36,14 +36,13 @@ function checkStatus<T>(response: HttpResponse<T>) {
  * Note: axios needs to use `withCredentials: true` in order for Sitecore cookies to be included in CORS requests
  * which is necessary for analytics and such
  * @param {string} url
- * @param {any} data
+ * @param {unknown} data
  * @param {HttpDataFetcher<T>} fetcher
  * @param {Object} params
  */
 function fetchData<T>(
   url: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any,
+  data: unknown[],
   fetcher: HttpDataFetcher<T>,
   params: querystring.ParsedUrlQueryInput = {}
 ) {

--- a/packages/sitecore-jss-tracking/src/trackingApi.ts
+++ b/packages/sitecore-jss-tracking/src/trackingApi.ts
@@ -36,7 +36,7 @@ function checkStatus<T>(response: HttpResponse<T>) {
  * Note: axios needs to use `withCredentials: true` in order for Sitecore cookies to be included in CORS requests
  * which is necessary for analytics and such
  * @param {string} url
- * @param {unknown} data
+ * @param {unknown[]} data
  * @param {HttpDataFetcher<T>} fetcher
  * @param {Object} params
  */

--- a/packages/sitecore-jss-tracking/tsconfig.json
+++ b/packages/sitecore-jss-tracking/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,

--- a/packages/sitecore-jss/src/axios-fetcher.ts
+++ b/packages/sitecore-jss/src/axios-fetcher.ts
@@ -101,7 +101,7 @@ export class AxiosDataFetcher {
   /**
    * Implements a data fetcher. @see HttpDataFetcher<T> type for implementation details/notes.
    * @param {string} url The URL to request; may include query string
-   * @param {any} [data] Optional data to POST with the request.
+   * @param {unknown} [data] Optional data to POST with the request.
    * @returns {Promise<AxiosResponse<T>>} response
    */
   fetch<T>(url: string, data?: unknown): Promise<AxiosResponse<T>> {
@@ -135,7 +135,7 @@ export class AxiosDataFetcher {
   /**
    * Perform a POST request
    * @param {string} url The URL to request; may include query string
-   * @param {any} [data] Data to POST with the request.
+   * @param {unknown} [data] Data to POST with the request.
    * @param {AxiosRequestConfig} [config] Axios config
    * @returns {Promise<AxiosResponse>} response
    */
@@ -146,7 +146,7 @@ export class AxiosDataFetcher {
   /**
    * Perform a PUT request
    * @param {string} url The URL to request; may include query string
-   * @param {any} [data] Data to PUT with the request.
+   * @param {unknown} [data] Data to PUT with the request.
    * @param {AxiosRequestConfig} [config] Axios config
    * @returns {Promise<AxiosResponse>} response
    */

--- a/packages/sitecore-jss/src/data-fetcher.ts
+++ b/packages/sitecore-jss/src/data-fetcher.ts
@@ -23,10 +23,7 @@ export interface HttpResponse<T> {
  * - Comply with the rules of REST by returning appropriate response status codes when there is an error instead of throwing exceptions.
  * - Send HTTP POST requests if `data` param is specified; GET is suggested but not required for data-less requests
  */
-export type HttpDataFetcher<T> = (
-  url: string,
-  data?: { [key: string]: unknown }
-) => Promise<HttpResponse<T>>;
+export type HttpDataFetcher<T> = (url: string, data?: unknown) => Promise<HttpResponse<T>>;
 
 class ResponseError extends Error {
   response: HttpResponse<unknown>;

--- a/packages/sitecore-jss/src/i18n/graphql-dictionary-service.test.ts
+++ b/packages/sitecore-jss/src/i18n/graphql-dictionary-service.test.ts
@@ -8,8 +8,7 @@ import dictionaryQueryResponse from '../testData/mockDictionaryQueryResponse.jso
 import appRootQueryResponse from '../testData/mockAppRootQueryResponse.json';
 
 class TestService extends GraphQLDictionaryService {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public client: any;
+  public client: GraphQLClient;
   constructor(options: GraphQLDictionaryServiceConfig) {
     super(options);
     this.client = this.getGraphQLClient();

--- a/packages/sitecore-jss/src/layout/rest-layout-service.test.ts
+++ b/packages/sitecore-jss/src/layout/rest-layout-service.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable no-unused-expressions */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, spy, use } from 'chai';
 import spies from 'chai-spies';
 import { IncomingMessage, ServerResponse } from 'http';
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { AxiosDataFetcher } from '../axios-fetcher';
 import { RestLayoutService } from './rest-layout-service';
@@ -13,6 +12,8 @@ use(spies);
 
 describe('RestLayoutService', () => {
   let mock: MockAdapter;
+
+  type SetHeader = (name: string, value: unknown) => void;
 
   before(() => {
     mock = new MockAdapter(axios);
@@ -37,17 +38,19 @@ describe('RestLayoutService', () => {
       siteName: 'supersite',
     });
 
-    return service.fetchLayoutData('/styleguide', 'en').then((layoutServiceData: any) => {
-      expect(layoutServiceData.url).to.equal(
-        'http://sctest/sitecore/api/layout/render/jss?item=%2Fstyleguide&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=en&tracking=true'
-      );
-      expect(layoutServiceData.data).to.deep.equal({
-        sitecore: {
-          context: {},
-          route: { name: 'xxx' },
-        },
+    return service
+      .fetchLayoutData('/styleguide', 'en')
+      .then((layoutServiceData: LayoutServiceData & AxiosRequestConfig) => {
+        expect(layoutServiceData.url).to.equal(
+          'http://sctest/sitecore/api/layout/render/jss?item=%2Fstyleguide&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=en&tracking=true'
+        );
+        expect(layoutServiceData.data).to.deep.equal({
+          sitecore: {
+            context: {},
+            route: { name: 'xxx' },
+          },
+        });
       });
-    });
   });
 
   it('should fetch layout data and invoke callbacks', () => {
@@ -75,7 +78,7 @@ describe('RestLayoutService', () => {
       },
     } as IncomingMessage;
 
-    const setHeaderSpy: any = spy();
+    const setHeaderSpy: SetHeader = spy();
 
     const res = {
       setHeader: setHeaderSpy,
@@ -88,23 +91,25 @@ describe('RestLayoutService', () => {
       tracking: false,
     });
 
-    return service.fetchLayoutData('/home', 'da-DK', req, res).then((layoutServiceData: any) => {
-      expect(layoutServiceData.headers.cookie).to.equal('test-cookie-value');
-      expect(layoutServiceData.headers.referer).to.equal('http://sctest');
-      expect(layoutServiceData.headers['user-agent']).to.equal('test-user-agent-value');
-      expect(layoutServiceData.headers['X-Forwarded-For']).to.equal('192.168.1.10');
+    return service
+      .fetchLayoutData('/home', 'da-DK', req, res)
+      .then((layoutServiceData: LayoutServiceData & AxiosRequestConfig) => {
+        expect(layoutServiceData.headers.cookie).to.equal('test-cookie-value');
+        expect(layoutServiceData.headers.referer).to.equal('http://sctest');
+        expect(layoutServiceData.headers['user-agent']).to.equal('test-user-agent-value');
+        expect(layoutServiceData.headers['X-Forwarded-For']).to.equal('192.168.1.10');
 
-      expect(layoutServiceData.url).to.equal(
-        'http://sctest/sitecore/api/layout/render/jss?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
-      );
-      expect(layoutServiceData.data).to.deep.equal({
-        sitecore: {
-          context: {},
-          route: { name: 'xxx' },
-        },
+        expect(layoutServiceData.url).to.equal(
+          'http://sctest/sitecore/api/layout/render/jss?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
+        );
+        expect(layoutServiceData.data).to.deep.equal({
+          sitecore: {
+            context: {},
+            route: { name: 'xxx' },
+          },
+        });
+        expect(setHeaderSpy).to.be.called.with('set-cookie', 'test-set-cookie-value');
       });
-      expect(setHeaderSpy).to.be.called.with('set-cookie', 'test-set-cookie-value');
-    });
   });
 
   it('should fetch layout data', () => {
@@ -132,7 +137,7 @@ describe('RestLayoutService', () => {
       },
     } as IncomingMessage;
 
-    const setHeaderSpy: any = spy();
+    const setHeaderSpy: SetHeader = spy();
 
     const res = {
       setHeader: setHeaderSpy,
@@ -145,23 +150,25 @@ describe('RestLayoutService', () => {
       tracking: false,
     });
 
-    return service.fetchLayoutData('/home', 'da-DK', req, res).then((layoutServiceData: any) => {
-      expect(layoutServiceData.headers.cookie).to.equal('test-cookie-value');
-      expect(layoutServiceData.headers.referer).to.equal('http://sctest');
-      expect(layoutServiceData.headers['user-agent']).to.equal('test-user-agent-value');
-      expect(layoutServiceData.headers['X-Forwarded-For']).to.equal('192.168.1.10');
+    return service
+      .fetchLayoutData('/home', 'da-DK', req, res)
+      .then((layoutServiceData: LayoutServiceData & AxiosRequestConfig) => {
+        expect(layoutServiceData.headers.cookie).to.equal('test-cookie-value');
+        expect(layoutServiceData.headers.referer).to.equal('http://sctest');
+        expect(layoutServiceData.headers['user-agent']).to.equal('test-user-agent-value');
+        expect(layoutServiceData.headers['X-Forwarded-For']).to.equal('192.168.1.10');
 
-      expect(layoutServiceData.url).to.equal(
-        'http://sctest/sitecore/api/layout/render/jss?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
-      );
-      expect(layoutServiceData.data).to.deep.equal({
-        sitecore: {
-          context: {},
-          route: { name: 'xxx' },
-        },
+        expect(layoutServiceData.url).to.equal(
+          'http://sctest/sitecore/api/layout/render/jss?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
+        );
+        expect(layoutServiceData.data).to.deep.equal({
+          sitecore: {
+            context: {},
+            route: { name: 'xxx' },
+          },
+        });
+        expect(setHeaderSpy).to.be.called.with('set-cookie', 'test-set-cookie-value');
       });
-      expect(setHeaderSpy).to.be.called.with('set-cookie', 'test-set-cookie-value');
-    });
   });
 
   it('should fetch layout data using custom configuration name', () => {
@@ -186,22 +193,24 @@ describe('RestLayoutService', () => {
       tracking: false,
     });
 
-    return service.fetchLayoutData('/home', 'da-DK').then((layoutServiceData: any) => {
-      expect(layoutServiceData.url).to.equal(
-        'http://sctest/sitecore/api/layout/render/listen?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
-      );
-      expect(layoutServiceData.data).to.deep.equal({
-        sitecore: {
-          context: {},
-          route: { name: 'xxx' },
-        },
+    return service
+      .fetchLayoutData('/home', 'da-DK')
+      .then((layoutServiceData: LayoutServiceData & AxiosRequestConfig) => {
+        expect(layoutServiceData.url).to.equal(
+          'http://sctest/sitecore/api/layout/render/listen?item=%2Fhome&sc_apikey=0FBFF61E-267A-43E3-9252-B77E71CEE4BA&sc_site=supersite&sc_lang=da-DK&tracking=false'
+        );
+        expect(layoutServiceData.data).to.deep.equal({
+          sitecore: {
+            context: {},
+            route: { name: 'xxx' },
+          },
+        });
       });
-    });
   });
 
   it('should fetch layout data using custom fetcher resolver', () => {
     const fetcherSpy = spy((url: string) => {
-      return new AxiosDataFetcher().fetch<any>(url);
+      return new AxiosDataFetcher().fetch<never>(url);
     });
 
     mock.onGet().reply(() => {
@@ -254,17 +263,19 @@ describe('RestLayoutService', () => {
       siteName: 'supersite',
     });
 
-    return service.fetchLayoutData('/styleguide', 'en').then((layoutServiceData: any) => {
-      expect(layoutServiceData).to.deep.equal({
-        sitecore: {
-          context: {
-            pageEditing: false,
-            language: 'en',
+    return service
+      .fetchLayoutData('/styleguide', 'en')
+      .then((layoutServiceData: LayoutServiceData) => {
+        expect(layoutServiceData).to.deep.equal({
+          sitecore: {
+            context: {
+              pageEditing: false,
+              language: 'en',
+            },
+            route: null,
           },
-          route: null,
-        },
+        });
       });
-    });
   });
 
   it('should allow non 404 errors through', () => {
@@ -310,7 +321,7 @@ describe('RestLayoutService', () => {
       },
     } as IncomingMessage;
 
-    const setHeaderSpy: any = spy();
+    const setHeaderSpy: SetHeader = spy();
 
     const res = {
       setHeader: setHeaderSpy,
@@ -337,7 +348,7 @@ describe('RestLayoutService', () => {
 
   it('should fetch placeholder data using custom fetcher resolver', () => {
     const fetcherSpy = spy((url: string) => {
-      return new AxiosDataFetcher().fetch<any>(url);
+      return new AxiosDataFetcher().fetch<never>(url);
     });
 
     mock.onGet().reply(() => {

--- a/packages/sitecore-jss/src/media-api.ts
+++ b/packages/sitecore-jss/src/media-api.ts
@@ -69,10 +69,8 @@ export const updateImageUrl = (
     return url;
   }
   // polyfill node `global` in browser to workaround https://github.com/unshiftio/url-parse/issues/150
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof window !== 'undefined' && !(window as any).global) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).global = {};
+  if (typeof window !== 'undefined' && !window.global) {
+    window.global = {} as NodeJS.Global;
   }
   const parsed = URL(url, {}, true);
 

--- a/packages/sitecore-jss/src/utils/editing.ts
+++ b/packages/sitecore-jss/src/utils/editing.ts
@@ -1,5 +1,17 @@
 import isServer from './is-server';
 
+type ExtendedWindow = Window &
+  typeof globalThis & {
+    [key: string]: unknown;
+    Sitecore: {
+      PageModes: {
+        ChromeManager: {
+          resetChromes: () => void;
+        };
+      };
+    };
+  };
+
 /**
  * Static utility class for Sitecore Experience Editor
  */
@@ -9,15 +21,14 @@ export class ExperienceEditor {
       return false;
     }
     // eslint-disable-next-line
-    const sc = (window as any).Sitecore;
+    const sc = (window as ExtendedWindow).Sitecore;
     return Boolean(sc && sc.PageModes && sc.PageModes.ChromeManager);
   }
   static resetChromes(): void {
     if (isServer()) {
       return;
     }
-    // eslint-disable-next-line
-    (window as any).Sitecore.PageModes.ChromeManager.resetChromes();
+    (window as ExtendedWindow).Sitecore.PageModes.ChromeManager.resetChromes();
   }
 }
 
@@ -44,8 +55,7 @@ export class HorizonEditor {
       return;
     }
     // Reset chromes in Horizon
-    // eslint-disable-next-line
-    (window as any)[ChromeRediscoveryGlobalFunctionName.name]();
+    ((window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] as () => void)();
   }
 }
 

--- a/packages/sitecore-jss/tsconfig.json
+++ b/packages/sitecore-jss/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,

--- a/samples/angular/scripts/bootstrap.ts
+++ b/samples/angular/scripts/bootstrap.ts
@@ -19,7 +19,7 @@ const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
   This is generated rather than using Angular environments because of the need to set config params
   based on build arguments, which env files don't directly allow.
 */
-function writeConfig(configOverride: any, outputPath?: string) {
+function writeConfig(configOverride: { production: boolean, sitecoreApiHost?: string }, outputPath?: string) {
   if (disconnected) {
     configOverride.sitecoreApiHost = `http://localhost:${projects['JssAngularWeb'].architect.serve.options.port}`;
   }

--- a/samples/angular/scripts/disconnected-mode-proxy.ts
+++ b/samples/angular/scripts/disconnected-mode-proxy.ts
@@ -10,9 +10,13 @@
 import * as fs from 'fs';
 import { join } from 'path';
 import { createDefaultDisconnectedServer } from '@sitecore-jss/sitecore-jss-dev-tools';
+import { ManifestInstance } from '@sitecore-jss/sitecore-jss-manifest';
 const packageJson = require('../package.json');
 
-const config = (packageJson as any).config;
+const config = (packageJson as {
+  [key: string]: unknown;
+  config: { [key: string]: unknown; appName: string; language: string };
+}).config;
 
 const touchToReloadFilePath = 'src/environments/environment.ts';
 
@@ -22,7 +26,7 @@ const proxyOptions = {
   watchPaths: ['./data'],
   language: config.language,
   port: 3043,
-  onManifestUpdated: (manifest) => {
+  onManifestUpdated: (manifest: ManifestInstance) => {
     // if we can resolve the config file, we can alter it to force reloading the app automatically
     // instead of waiting for a manual reload. We must materially alter the _contents_ of the file to trigger
     // an actual reload, so we append "// reloadnow" to the file each time. This will not cause a problem,

--- a/samples/angular/scripts/generate-component-factory.ts
+++ b/samples/angular/scripts/generate-component-factory.ts
@@ -54,10 +54,10 @@ function generateComponentFactory() {
   // NOTE: generating the component factory module is also totally optional,
   // and it can be maintained manually if preferred.
 
-  const imports = [];
-  const registrations = [];
-  const lazyRegistrations = [];
-  const declarations = [];
+  const imports: string[] = [];
+  const registrations: string[] = [];
+  const lazyRegistrations: string[] = [];
+  const declarations: string[] = [];
 
   fs.readdirSync(componentRootPath).forEach((componentFolder) => {
     // ignore ts files in component root folder

--- a/samples/angular/scripts/generate-config.ts
+++ b/samples/angular/scripts/generate-config.ts
@@ -9,7 +9,7 @@ const packageConfig = require('../package.json');
  * settings as variables into the JSS app.
  * NOTE! Any configs returned here will be written into the client-side JS bundle. DO NOT PUT SECRETS HERE.
  */
-export function generateConfig(configOverrides?: any, outputPath?: string) {
+export function generateConfig(configOverrides?: { [key: string]: unknown }, outputPath?: string) {
   const defaultConfig = {
     production: false,
     sitecoreApiHost: '',
@@ -72,7 +72,7 @@ function transformScJssConfig() {
 }
 
 function transformPackageConfig() {
-  const packageAny = packageConfig as any;
+  const packageAny = packageConfig;
 
   if (!packageAny.config) { return {}; }
 
@@ -86,7 +86,7 @@ function transformPackageConfig() {
 /**
  * Adds the GraphQL endpoint URL to the config object, and ensures that components needed to calculate it are valid
  */
-function addGraphQLConfig(baseConfig) {
+function addGraphQLConfig(baseConfig: { [key: string]: unknown }) {
   if (!baseConfig.graphQLEndpointPath || typeof baseConfig.sitecoreApiHost === 'undefined') {
     console.error(
       'The `graphQLEndpointPath` and/or `layoutServiceHost` configurations were not defined. You may need to run `jss setup`.'

--- a/samples/angular/scripts/lint-yml.ts
+++ b/samples/angular/scripts/lint-yml.ts
@@ -13,7 +13,7 @@ let isValid = true;
 const promises = files.map(filename => {
   filename = path.resolve(DATA_DIR_PATH, filename);
 
-  return yamlLint.lintFile(filename).catch(e => {
+  return yamlLint.lintFile(filename).catch((e: Error) => {
     console.error(filename);
     console.log('\x1b[31m', 'error', '\x1b[0m', e.message);
     isValid = false;

--- a/samples/angular/scripts/update-graphql-fragment-data.ts
+++ b/samples/angular/scripts/update-graphql-fragment-data.ts
@@ -44,7 +44,7 @@ fetch(jssConfig.graphQLEndpoint, {
     `,
   }),
 })
-  .then((result) => result.json())
+  .then((result: unknown) => result.json())
   .then((result) => {
     // here we're filtering out any type information unrelated to unions or interfaces
     const filteredData = result.data.__schema.types.filter((type) => type.possibleTypes !== null);
@@ -65,7 +65,7 @@ fetch(jssConfig.graphQLEndpoint, {
       }
     );
   })
-  .catch((e) => {
+  .catch((e: Error) => {
     console.error(e);
     process.exit(1);
   });

--- a/samples/angular/server.bundle.ts
+++ b/samples/angular/server.bundle.ts
@@ -16,13 +16,18 @@ const https = require('https');
 const template = readFileSync(join(__dirname, 'browser', 'index.html')).toString();
 
 // Setup Http/Https agents for keep-alive. Used in headless-proxy
-const setUpDefaultAgents = (httpAgent, httpsAgent) => {
+const setUpDefaultAgents = (httpAgent: unknown, httpsAgent: unknown) => {
   http.globalAgent = httpAgent;
   https.globalAgent = httpsAgent;
 };
 
 // this is the function expected by the JSS View Engine for "integrated mode"
-function renderView(callback, path, data, viewBag) {
+function renderView(
+  callback: (err: unknown, data: { html: string }) => void,
+  path: string,
+  data: { [key: string]: unknown },
+  viewBag: { [key: string]: unknown }
+) {
   try {
     /*
       Data from server is double-encoded since MS JSS does not allow control
@@ -34,11 +39,11 @@ function renderView(callback, path, data, viewBag) {
     const state = {
       sitecore: {
         context: {
-          pageEditing: false
+          pageEditing: false,
         },
         route: {
-          placeholders: {}
-        }
+          placeholders: {},
+        },
       },
       language: '',
       serverRoute: '',
@@ -51,7 +56,7 @@ function renderView(callback, path, data, viewBag) {
 
     // parse the URL that's being handled by Sitecore so we can pass in the initial state to the app
     const routeParser = new JssRouteBuilderService();
-    const jssRoute = routeParser.parseRouteUrl(path.split('/').filter(segment => segment));
+    const jssRoute = routeParser.parseRouteUrl(path.split('/').filter((segment) => segment));
     state.serverRoute = jssRoute.serverRoute;
     state.language = parsedViewBag.language || jssRoute.language;
 
@@ -65,10 +70,10 @@ function renderView(callback, path, data, viewBag) {
         // custom injection with the initial state that SSR should utilize
         { provide: 'JSS_SERVER_LAYOUT_DATA', useValue: transferState },
         { provide: 'JSS_SERVER_VIEWBAG', useValue: state.viewBag },
-      ]
+      ],
     })
-      .then(html => callback(null, { html }))
-      .catch(err => callback(err, null))
+      .then((html) => callback(null, { html }))
+      .catch((err) => callback(err, null));
   } catch (err) {
     // need to ensure the callback is always invoked no matter what
     // or else SSR will hang
@@ -76,12 +81,12 @@ function renderView(callback, path, data, viewBag) {
   }
 }
 
-function parseRouteUrl(url) {
+function parseRouteUrl(url: string) {
   const routeParser = new JssRouteBuilderService();
-  const jssRoute = routeParser.parseRouteUrl(url.split('/').filter(segment => segment));
+  const jssRoute = routeParser.parseRouteUrl(url.split('/').filter((segment) => segment));
   return {
     lang: jssRoute.language,
-    sitecoreRoute: jssRoute.serverRoute
+    sitecoreRoute: jssRoute.serverRoute,
   };
 }
 
@@ -90,5 +95,5 @@ module.exports = {
   parseRouteUrl,
   setUpDefaultAgents,
   apiKey: environment.sitecoreApiKey,
-  appName: environment.jssAppName
+  appName: environment.jssAppName,
 };

--- a/samples/angular/sitecore/definitions/component-content.sitecore.ts
+++ b/samples/angular/sitecore/definitions/component-content.sitecore.ts
@@ -12,7 +12,7 @@ interface TemporaryItemDefinition extends ItemDefinition {
  * Component content items are conventionally defined in /data/component-content, similar to route items.
  * This function is invoked by convention (*.sitecore.js) when `jss manifest` is run.
  */
-export default function addComponentContentToManifest(manifest: Manifest): Promise<any> {
+export default function addComponentContentToManifest(manifest: Manifest): Promise<void> {
   const rootItemName = 'Components';
   const startPath = './data/component-content'; // relative to process invocation (i.e. where package.json lives)
 
@@ -21,7 +21,7 @@ export default function addComponentContentToManifest(manifest: Manifest): Promi
   }
 
   return mergeFs(startPath)
-    .then((result) => {
+    .then((result: MergeFsResult) => {
       const items = convertToComponentItems(
         result,
         resolvePath(startPath),
@@ -30,7 +30,7 @@ export default function addComponentContentToManifest(manifest: Manifest): Promi
       );
       return items;
     })
-    .then((contentData) => {
+    .then((contentData: ItemDefinition) => {
       if (contentData) {
         manifest.addContent(contentData);
       }

--- a/samples/angular/sitecore/definitions/components/styleguide-field-usage-content-list.sitecore.ts
+++ b/samples/angular/sitecore/definitions/components/styleguide-field-usage-content-list.sitecore.ts
@@ -1,6 +1,8 @@
 import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore-jss-manifest';
 const packageJson = require('../../../package.json');
 
+const jsonConfig = packageJson as { [key: string]: unknown; config: { [key: string]: unknown } };
+
 /**
  * Adds the Styleguide-FieldUsage-ContentList component to the disconnected manifest.
  * This function is invoked by convention (*.sitecore.ts) when `jss manifest` is run.
@@ -17,10 +19,7 @@ export default function StyleguideFieldUsageContentList(manifest: Manifest) {
         // the path is based on the path the shared items are defined in, under /data/content.
         // Using 'source' is recommended to help content editors find the correct items to refer to,
         // unless they can refer to any item in the whole site.
-        source: `dataSource=/sitecore/content/${
-          (packageJson as { [key: string]: unknown; config: { [key: string]: unknown } }).config
-            .appName
-        }/Content/Styleguide/ContentListField`,
+        source: `dataSource=/sitecore/content/${jsonConfig.config.appName}/Content/Styleguide/ContentListField`,
       },
       { name: 'localContentList', type: CommonFieldTypes.ContentList },
     ],

--- a/samples/angular/sitecore/definitions/components/styleguide-field-usage-content-list.sitecore.ts
+++ b/samples/angular/sitecore/definitions/components/styleguide-field-usage-content-list.sitecore.ts
@@ -17,7 +17,10 @@ export default function StyleguideFieldUsageContentList(manifest: Manifest) {
         // the path is based on the path the shared items are defined in, under /data/content.
         // Using 'source' is recommended to help content editors find the correct items to refer to,
         // unless they can refer to any item in the whole site.
-        source: `dataSource=/sitecore/content/${(packageJson as any).config.appName}/Content/Styleguide/ContentListField`,
+        source: `dataSource=/sitecore/content/${
+          (packageJson as { [key: string]: unknown; config: { [key: string]: unknown } }).config
+            .appName
+        }/Content/Styleguide/ContentListField`,
       },
       { name: 'localContentList', type: CommonFieldTypes.ContentList },
     ],

--- a/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
+++ b/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
@@ -1,5 +1,5 @@
 import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore-jss-manifest';
-const packageJson = require('../../../package.json');
+import packageJson from '../../../package.json';
 
 /**
  * Adds the Styleguide-FieldUsage-ItemLink component to the disconnected manifest.
@@ -17,7 +17,7 @@ export default function StyleguideFieldUsageItemLink(manifest: Manifest) {
         // the path is based on the path the shared items are defined in, under /data/content.
         // Using 'source' is recommended to help content editors find the correct items to refer to,
         // unless they can refer to any item in the whole site.
-        source: `dataSource=/sitecore/content/${(packageJson as any).config.appName}/Content/Styleguide/ItemLinkField`,
+        source: `dataSource=/sitecore/content/${packageJson.config.appName}/Content/Styleguide/ItemLinkField`,
       },
       { name: 'localItemLink', type: CommonFieldTypes.ItemLink },
     ],

--- a/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
+++ b/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
@@ -1,5 +1,5 @@
 import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore-jss-manifest';
-import packageJson from '../../../package.json';
+const packageJson = require('../../../package.json');
 
 /**
  * Adds the Styleguide-FieldUsage-ItemLink component to the disconnected manifest.
@@ -17,7 +17,10 @@ export default function StyleguideFieldUsageItemLink(manifest: Manifest) {
         // the path is based on the path the shared items are defined in, under /data/content.
         // Using 'source' is recommended to help content editors find the correct items to refer to,
         // unless they can refer to any item in the whole site.
-        source: `dataSource=/sitecore/content/${packageJson.config.appName}/Content/Styleguide/ItemLinkField`,
+        source: `dataSource=/sitecore/content/${
+          (packageJson as { [key: string]: unknown; config: { [key: string]: unknown } }).config
+            .appName
+        }/Content/Styleguide/ItemLinkField`,
       },
       { name: 'localItemLink', type: CommonFieldTypes.ItemLink },
     ],

--- a/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
+++ b/samples/angular/sitecore/definitions/components/styleguide-field-usage-item-link.sitecore.ts
@@ -1,6 +1,8 @@
 import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore-jss-manifest';
 const packageJson = require('../../../package.json');
 
+const jsonConfig = packageJson as { [key: string]: unknown; config: { [key: string]: unknown } };
+
 /**
  * Adds the Styleguide-FieldUsage-ItemLink component to the disconnected manifest.
  * This function is invoked by convention (*.sitecore.ts) when `jss manifest` is run.
@@ -17,10 +19,7 @@ export default function StyleguideFieldUsageItemLink(manifest: Manifest) {
         // the path is based on the path the shared items are defined in, under /data/content.
         // Using 'source' is recommended to help content editors find the correct items to refer to,
         // unless they can refer to any item in the whole site.
-        source: `dataSource=/sitecore/content/${
-          (packageJson as { [key: string]: unknown; config: { [key: string]: unknown } }).config
-            .appName
-        }/Content/Styleguide/ItemLinkField`,
+        source: `dataSource=/sitecore/content/${jsonConfig.config.appName}/Content/Styleguide/ItemLinkField`,
       },
       { name: 'localItemLink', type: CommonFieldTypes.ItemLink },
     ],

--- a/samples/angular/sitecore/definitions/content.sitecore.ts
+++ b/samples/angular/sitecore/definitions/content.sitecore.ts
@@ -8,7 +8,7 @@ import { existsSync as fileExistsSync } from 'fs';
  * Content items are conventionally defined in /data/content, similar to route items.
  * This function is invoked by convention (*.sitecore.js) when `jss manifest` is run.
  */
-export default function addContentToManifest(manifest: Manifest): Promise<any> {
+export default function addContentToManifest(manifest: Manifest): Promise<void> {
   const rootItemName = 'Content';
   const startPath = './data/content'; // relative to process invocation (i.e. where package.json lives)
 

--- a/samples/angular/src/app/JssState.ts
+++ b/samples/angular/src/app/JssState.ts
@@ -11,5 +11,5 @@ export class JssState {
   sitecore?: LayoutServiceContextData & {
     route: RouteData;
   };
-  viewBag: any;
+  viewBag: { [key: string]: unknown };
 }

--- a/samples/angular/src/app/app.server.module.ts
+++ b/samples/angular/src/app/app.server.module.ts
@@ -15,12 +15,16 @@ import { JssTranslationServerLoaderService } from './i18n/jss-translation-server
     AppModule,
     ServerModule,
     ServerTransferStateModule,
-    TranslateModule.forRoot({ // <-- *Important* to get translation values server-side
+    TranslateModule.forRoot({
+      // <-- *Important* to get translation values server-side
       loader: {
         provide: TranslateLoader,
-        useFactory: (ssrViewBag: any) => new JssTranslationServerLoaderService(ssrViewBag),
-        deps: ['JSS_SERVER_VIEWBAG']
-      }
+        useFactory: (ssrViewBag: {
+          [key: string]: unknown;
+          dictionary: { [key: string]: string };
+        }) => new JssTranslationServerLoaderService(ssrViewBag),
+        deps: ['JSS_SERVER_VIEWBAG'],
+      },
     }),
   ],
   providers: [
@@ -29,6 +33,6 @@ import { JssTranslationServerLoaderService } from './i18n/jss-translation-server
   ],
   // Since the bootstrapped component is not inherited from your
   // imported AppModule, it needs to be repeated here.
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppServerModule { }
+export class AppServerModule {}

--- a/samples/angular/src/app/components/graph-ql-connected-demo/graph-ql-connected-demo.component.ts
+++ b/samples/angular/src/app/components/graph-ql-connected-demo/graph-ql-connected-demo.component.ts
@@ -17,7 +17,7 @@ const ComponentQuery: DocumentNode = require('graphql-tag/loader!./graph-ql-conn
 })
 export class GraphQLConnectedDemoComponent implements OnInit {
   @Input() rendering: ComponentRendering;
-  query$: Observable<ApolloQueryResult<any>>;
+  query$: Observable<ApolloQueryResult<unknown>>;
 
   // inject the JssGraphQLService to make GraphQL queries
   // note that it's possible to use Apollo directly, but the JSS

--- a/samples/angular/src/app/components/graph-ql-integrated-demo/graph-ql-integrated-demo.component.ts
+++ b/samples/angular/src/app/components/graph-ql-integrated-demo/graph-ql-integrated-demo.component.ts
@@ -1,6 +1,35 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ComponentRendering } from '@sitecore-jss/sitecore-jss-angular';
-import { ApolloQueryResult } from '@apollo/client/core';
+
+interface QueryResult {
+  data: {
+    datasource: {
+      sample1: {
+        jss: string;
+        value: string;
+      };
+      sample2: {
+        definition: {
+          type: string;
+          shared: boolean;
+        };
+        jss: string;
+        target: string;
+        text: string;
+        url: string;
+      };
+      name: string;
+      id: string;
+    };
+    contextItem: {
+      id: string;
+      pageTitle: {
+        value: string;
+      };
+      children: unknown[];
+    };
+  };
+}
 
 @Component({
   selector: 'app-graph-ql-integrated-demo',
@@ -8,11 +37,11 @@ import { ApolloQueryResult } from '@apollo/client/core';
 })
 export class GraphQLIntegratedDemoComponent implements OnInit {
   @Input() rendering: ComponentRendering;
-  queryResult: ApolloQueryResult<any>;
+  queryResult: QueryResult;
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
-    this.queryResult = this.rendering.fields as any;
+    this.queryResult = (this.rendering.fields as unknown) as QueryResult;
   }
 }

--- a/samples/angular/src/app/components/shared/styleguide-specimen/styleguide-specimen.component.ts
+++ b/samples/angular/src/app/components/shared/styleguide-specimen/styleguide-specimen.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { ComponentRendering } from '@sitecore-jss/sitecore-jss-angular';
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
-function dasherize(str) {
+function dasherize(str: string) {
   // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
   return str.replace(/[A-Z](?:(?=[^A-Z])|[A-Z]*(?=[A-Z][^A-Z]|$))/g, function(s, i) {
     return (i > 0 ? '-' : '') + s.toLowerCase();

--- a/samples/angular/src/app/i18n/jss-translation-client-loader.service.ts
+++ b/samples/angular/src/app/i18n/jss-translation-client-loader.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
-import { Observable,  EMPTY } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { makeStateKey } from '@angular/platform-browser';
 
 export const dictionaryStateKey = makeStateKey('jssDictionary');
@@ -11,7 +11,7 @@ export class JssTranslationClientLoaderService implements TranslateLoader {
     private fallbackLoader: TranslateLoader,
   ) { }
 
-  getTranslation(lang: string): Observable<any> {
+  getTranslation(lang: string) {
     if (!this.fallbackLoader) {
       return EMPTY;
     }

--- a/samples/angular/src/app/i18n/jss-translation-loader.service.ts
+++ b/samples/angular/src/app/i18n/jss-translation-loader.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
-import { Observable, from as fromPromise } from 'rxjs';
+import { from as fromPromise } from 'rxjs';
 import { RestDictionaryService } from '@sitecore-jss/sitecore-jss-angular';
 import { environment as env } from '../../environments/environment';
 
@@ -12,7 +12,7 @@ export const dictionaryService = new RestDictionaryService({
 
 @Injectable()
 export class JssTranslationLoaderService implements TranslateLoader {
-  getTranslation(lang: string): Observable<any> {
+  getTranslation(lang: string) {
     return fromPromise(dictionaryService.fetchDictionaryData(lang));
   }
 }

--- a/samples/angular/src/app/i18n/jss-translation-server-loader.service.ts
+++ b/samples/angular/src/app/i18n/jss-translation-server-loader.service.ts
@@ -1,22 +1,25 @@
 import { Inject, Injectable } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
-import { Observable, of as observableOf, EMPTY } from 'rxjs';
+import { of as observableOf, EMPTY } from 'rxjs';
 
 @Injectable()
 export class JssTranslationServerLoaderService implements TranslateLoader {
   constructor(
     // this initial state from sitecore is injected by server.bundle for "integrated" mode
-    @Inject('JSS_SERVER_VIEWBAG') private serverViewBag: any,
-  ) { }
+    @Inject('JSS_SERVER_VIEWBAG')
+    private serverViewBag: { [key: string]: unknown; dictionary: { [key: string]: string } }
+  ) {}
 
-  getTranslation(lang: string): Observable<any> {
+  getTranslation(lang: string) {
     // read initial dictionary from data injected via server.bundle wrapper
     const dictionary = this.serverViewBag.dictionary;
     if (dictionary) {
       return observableOf(dictionary);
     }
 
-    console.warn('Dictionary was not present in SSR viewbag. Translations will not be server-side rendered.');
+    console.warn(
+      'Dictionary was not present in SSR viewbag. Translations will not be server-side rendered.'
+    );
     return EMPTY;
   }
 }

--- a/samples/angular/src/app/jss-data-fetcher.service.ts
+++ b/samples/angular/src/app/jss-data-fetcher.service.ts
@@ -11,7 +11,7 @@ export class JssDataFetcherService {
     this.fetch = this.fetch.bind(this);
   }
 
-  fetch<T>(url: string, data: any): Promise<HttpResponse<T>> {
+  fetch<T>(url: string, data: unknown): Promise<HttpResponse<T>> {
     let result: Observable<T>;
 
     const options = {

--- a/samples/angular/src/app/jss-graphql.module.ts
+++ b/samples/angular/src/app/jss-graphql.module.ts
@@ -1,6 +1,6 @@
 import { NgModule, PLATFORM_ID, Inject } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { InMemoryCache } from '@apollo/client/core';
+import { InMemoryCache, NormalizedCacheObject, PossibleTypesMap } from '@apollo/client/core';
 import { Apollo } from 'apollo-angular';
 import { HttpBatchLink } from 'apollo-angular/http';
 import { createPersistedQueryLink } from 'apollo-angular/persisted-queries';
@@ -20,7 +20,7 @@ import introspectionQueryResultData from '../graphql-fragment-types';
 
 // SSR transfer state key to serialize + rehydrate apollo cache on client side
 // See https://www.apollographql.com/docs/angular/recipes/server-side-rendering.html
-const STATE_KEY = makeStateKey<any>('apollo.state');
+const STATE_KEY = makeStateKey<NormalizedCacheObject>('apollo.state');
 
 @NgModule({
   imports: [
@@ -43,7 +43,7 @@ export class GraphQLModule {
   }
 
   onBrowser(cache: InMemoryCache) {
-    const state = this.transferState.get<any>(STATE_KEY, null);
+    const state = this.transferState.get<NormalizedCacheObject>(STATE_KEY, null);
 
     cache.restore(state);
   }
@@ -74,7 +74,7 @@ export class GraphQLModule {
     // APQ + batched, or APQ + http links for example.
     const automaticPersistHttp = createPersistedQueryLink({ sha256 }).concat(batchHttp);
 
-    const possibleTypes = {};
+    const possibleTypes = {} as PossibleTypesMap;
 
     introspectionQueryResultData.__schema.types.forEach((supertype) => {
       possibleTypes[supertype.name] = supertype.possibleTypes.map((subtype) => subtype.name);
@@ -91,7 +91,7 @@ export class GraphQLModule {
       ssrForceFetchDelay: 100,
     });
 
-    const isBrowser = this.transferState.hasKey<any>(STATE_KEY);
+    const isBrowser = this.transferState.hasKey(STATE_KEY);
 
     if (isBrowser) {
       this.onBrowser(cache);

--- a/samples/angular/src/app/jss-graphql.service.ts
+++ b/samples/angular/src/app/jss-graphql.service.ts
@@ -48,7 +48,7 @@ export class JssGraphQLService {
   }
 
   private static extractVariableNames(query: DocumentNode) {
-    const variableNames = {};
+    const variableNames: { [key: string]: boolean } = {};
     query.definitions
       .map((def) => (def as ExecutableDefinitionNode).variableDefinitions)
       .filter((def) => def)
@@ -60,7 +60,7 @@ export class JssGraphQLService {
         })
       );
 
-    return variableNames as { [key: string]: string };
+    return variableNames;
   }
 
   /**
@@ -105,7 +105,7 @@ export class JssGraphQLService {
   /**
    * Executes a GraphQL subscription (real-time data) against the GraphQL endpoint
    */
-  subscribe<T, V = EmptyObject>(options: SubscriptionOptions<V> & JssGraphQLOptions, extra?: ExtraSubscriptionOptions): Observable<any> {
+  subscribe<T, V = EmptyObject>(options: SubscriptionOptions<V> & JssGraphQLOptions, extra?: ExtraSubscriptionOptions) {
     if (this.isEditingOrPreviewingAndSsr) {
       return empty();
     }
@@ -123,7 +123,7 @@ export class JssGraphQLService {
     const usedVariables = JssGraphQLService.extractVariableNames(query);
 
     if (usedVariables.datasource && rendering && rendering.dataSource) {
-      variables['datasource'] = rendering.dataSource;
+      (variables as EmptyObject).datasource = rendering.dataSource;
     }
 
     if (
@@ -132,7 +132,7 @@ export class JssGraphQLService {
       this.sitecoreContext.state.value.sitecore.route &&
       this.sitecoreContext.state.value.sitecore.route.itemId
     ) {
-      variables['contextItem'] = this.sitecoreContext.state.value.sitecore.route.itemId;
+      (variables as EmptyObject).contextItem = this.sitecoreContext.state.value.sitecore.route.itemId;
     }
 
     return variables;

--- a/samples/angular/src/app/layout/jss-layout.service.ts
+++ b/samples/angular/src/app/layout/jss-layout.service.ts
@@ -39,14 +39,12 @@ export class JssLayoutService {
   ): Observable<PlaceholderData | LayoutServiceError> {
     return fromPromise(
       layoutServiceInstance.fetchPlaceholderData(placeholderName, route, language)
-    ).pipe(
-      catchError(this.getLayoutServiceError)
-    );
+    ).pipe(catchError(this.getLayoutServiceError));
   }
 
-  private getLayoutServiceError(error: any): Observable<LayoutServiceError> {
+  private getLayoutServiceError(error: { [key: string]: unknown }): Observable<LayoutServiceError> {
     const layoutServiceError = new LayoutServiceError();
-    const response = error.response;
+    const response = error.response as { status: number; statusText: string; data: unknown };
     if (response) {
       layoutServiceError.status = response.status;
       layoutServiceError.statusText = response.statusText;

--- a/samples/angular/src/app/routing/jss-route-builder.service.ts
+++ b/samples/angular/src/app/routing/jss-route-builder.service.ts
@@ -2,6 +2,7 @@ import { environment as env } from '../../environments/environment';
 import { Injectable } from '@angular/core';
 
 export class JssRoute {
+  [key: string]: string;
   language: string;
   serverRoute: string;
 }

--- a/samples/angular/src/test.ts
+++ b/samples/angular/src/test.ts
@@ -9,23 +9,33 @@ import 'zone.js/dist/fake-async-test';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+  platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 // eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __karma__: any;
-declare const require: any;
+declare const __karma__: { [key: string]: unknown; start: () => void };
+declare const require: {
+  [key: string]: unknown;
+  context: (
+    directory: string,
+    useSubdirectories: boolean,
+    pattern: RegExp
+  ) => {
+    [key: string]: unknown;
+    keys: () => {
+      [key: string]: unknown;
+      map: (context: { [key: string]: unknown }) => void;
+    };
+  };
+};
 
 // Prevent Karma from running prematurely.
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 __karma__.loaded = function() {};
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/samples/angular/tsconfig.json
+++ b/samples/angular/tsconfig.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "noUnusedLocals": true,
+    "noImplicitAny": true,
     "target": "es5",
     "module": "es2020",
     "newLine": "LF",

--- a/samples/nextjs/src/lib/data-fetcher.ts
+++ b/samples/nextjs/src/lib/data-fetcher.ts
@@ -6,7 +6,7 @@ import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss-nextjs';
  * SSR-capable HTTP or fetch library if you like. See HttpDataFetcher<T> type
  * in sitecore-jss library for implementation details/notes.
  * @param {string} url The URL to request; may include query string
- * @param {any} data Optional data to POST with the request.
+ * @param {unknown} data Optional data to POST with the request.
  */
 export function dataFetcher<ResponseType>(
   url: string,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Remove `any` keyword everywhere where it's possible. Customers should review their types after upgrade
* Left `SitecoreContext` react component without changes, because we have separate task to refactor it and use explicit types.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
