### PR TITLE
[Horizon] Extra check for window-level Horizon chrome reset function

### DIFF
--- a/packages/sitecore-jss/src/utils/editing.ts
+++ b/packages/sitecore-jss/src/utils/editing.ts
@@ -55,7 +55,8 @@ export class HorizonEditor {
       return;
     }
     // Reset chromes in Horizon
-    ((window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] as () => void)();
+    (window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] &&
+      ((window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] as () => void)();
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
When adding a new page in Horizon, it's possible that this window-level function is not defined when called.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
