### PR TITLE
[NextJS] Prevent webpack-5 to throw error for `sitecore-import.json` when app started first time

### DIFF
--- a/samples/nextjs/next.config.base.js
+++ b/samples/nextjs/next.config.base.js
@@ -96,6 +96,12 @@ const nextConfig = {
   webpack: (config, options) => {
     applyGraphQLCodeGenerationLoaders(config, options);
 
+    // #START_EMPTY
+    config.resolve.fallback = {
+      'sitecore/manifest/sitecore-import.json': false
+    };
+    // #END_EMPTY
+
     return config;
   },
 };


### PR DESCRIPTION
…when app started first time

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Create a new nextjs sample
Run `jss build` or `jss start:production`
The following error occurs:
- ModuleNotFoundError: Module not found: Error: Can't resolve 'sitecore/manifest/sitecore-import.json' in 'C:\WIP\_TEMP\JSS\jss-next-dev\src\lib'. This is referenced in `/lib/sitemap-fetcher.ts` of the sample app.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
