### PR TITLE
[sitecore-jss] Import lodash correctly

### DIFF
--- a/packages/sitecore-jss/src/media-api.ts
+++ b/packages/sitecore-jss/src/media-api.ts
@@ -1,4 +1,4 @@
-import unescape from 'lodash/unescape';
+import unescape from 'lodash.unescape';
 import URL from 'url-parse';
 
 // finds an img tag with HTML attributes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Import `lodash.unescape` instead of `lodash/unescape`
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
