### PR TITLE
[sitecore-jss-cli] RAV fetchWith uses old GraphQl endpoint path in package.json

### DIFF
--- a/packages/sitecore-jss-cli/src/create/index.test.ts
+++ b/packages/sitecore-jss-cli/src/create/index.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import {
   applyNameToPackageJson,
   applyHostNameToSitecoreConfig,
-  applyNameToSitecoreConfig,
   applyNameReplacement,
 } from './index';
 
@@ -44,19 +43,6 @@ describe('applyNameReplacement', () => {
 });
 
 describe('applyNameToPackageJson', () => {
-  it('should apply name using defaults', () => {
-    const result = applyNameToPackageJson(
-      {
-        name: 'FooName',
-        config: { appName: 'FooAppName', sitecoreDistPath: 'na' },
-      },
-      'bar'
-    );
-    expect(result.name).to.equal('bar');
-    expect(result.config.appName).to.equal('bar');
-    expect(result.config.sitecoreDistPath).to.equal('/dist/bar');
-  });
-
   it('should apply name using replaceName', () => {
     const result = applyNameToPackageJson(
       {
@@ -99,7 +85,8 @@ describe('applyNameToPackageJson', () => {
         name: 'FooName',
         config: { appName: 'FooAppName' },
       },
-      'bar'
+      'bar',
+      'JssTestWeb'
     );
     expect(result.config.sitecoreDistPath).to.be.undefined;
     expect(result.config.graphQLEndpointPath).to.be.undefined;
@@ -126,114 +113,5 @@ describe('applyHostNameToSitecoreConfig', () => {
     const config = mockConfig();
     const result = applyHostNameToSitecoreConfig(config, 'bar.localhost');
     expect(result).to.match(/<site ((.|\n|\r)*?)hostName="bar.localhost"/, 'site host name');
-  });
-});
-
-describe('applyNameToSitecoreConfig', () => {
-  const mockConfig = (appName: string, customPath?: string) => {
-    return `
-<configuration>
-  <sitecore>
-    <sites>
-      <site patch:before="site[@name='website']"
-            inherits="website"
-            name="${appName}"
-            rootPath="${customPath ? customPath : '/sitecore/content/'}${appName}"
-            startItem="/home"
-            database="master" />
-    </sites>
-    <javaScriptServices>
-      <apps>
-        <app name="${appName}"
-            sitecorePath="${customPath ? customPath : '/sitecore/content/'}${appName}"
-            useLanguageSpecificLayout="true"
-            graphQLEndpoint="/sitecore/api/graph/edge"
-            inherits="defaults"
-        />
-      </apps>
-    </javaScriptServices>
-    <api>
-      <GraphQL>
-        <endpoints>
-          <${appName}GraphQLEndpoint url="/sitecore/api/graph/edge">
-            <schema>
-              <content>
-                <templates>
-                  <paths>
-                    <templates>${
-                      customPath ? customPath : '/sitecore/templates/Project/'
-                    }${appName}</templates>
-                  </paths>
-                </templates>
-              </content>
-            </schema>
-          </${appName}GraphQLEndpoint>
-        </endpoints>
-      </GraphQL>
-    </api>
-  </sitecore>
-</configuration>
-    `;
-  };
-
-  it('should apply name using defaults', () => {
-    const config = mockConfig('FooApp', '/somewhere/else/');
-    const result = applyNameToSitecoreConfig(config, 'Bar');
-    expect(result).to.match(/<site ((.|\n|\r)*?)name="Bar"/, 'site name');
-    expect(result).to.match(
-      /<site ((.|\n|\r)*?)rootPath="\/sitecore\/content\/Bar"/,
-      'site root path'
-    );
-    expect(result).to.match(/<app ((.|\n|\r)*?)name="Bar"/, 'app name');
-    expect(result).to.match(
-      /<app ((.|\n|\r)*?)sitecorePath="\/sitecore\/content\/Bar"/,
-      'app sitecorePath'
-    );
-    expect(result).to.match(
-      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/sitecore\/api\/graph\/edge"/,
-      'GraphQL endpoint'
-    );
-  });
-
-  it('should apply name using replaceName', () => {
-    const config = mockConfig('FooApp', '/somewhere/else/');
-    const result = applyNameToSitecoreConfig(config, 'Bar', 'FooApp');
-    expect(result).to.match(/<site ((.|\n|\r)*?)name="Bar"/, 'site name');
-    expect(result).to.match(
-      /<site ((.|\n|\r)*?)rootPath="\/somewhere\/else\/Bar"/,
-      'site root path'
-    );
-    expect(result).to.match(/<app ((.|\n|\r)*?)name="Bar"/, 'app name');
-    expect(result).to.match(
-      /<app ((.|\n|\r)*?)sitecorePath="\/somewhere\/else\/Bar"/,
-      'app sitecorePath'
-    );
-    expect(result).to.match(
-      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/sitecore\/api\/graph\/edge"/,
-      'GraphQL endpoint'
-    );
-  });
-
-  it('should not apply name using replaceName if no match', () => {
-    const config = mockConfig('FooApp', '/somewhere/else/');
-    const result = applyNameToSitecoreConfig(config, 'Bar', 'BarApp');
-    expect(result).to.not.match(/<site ((.|\n|\r)*?)name="Bar"/, 'site name');
-    expect(result).to.not.match(
-      /<site ((.|\n|\r)*?)rootPath="\/somewhere\/else\/Bar"/,
-      'site root path'
-    );
-    expect(result).to.not.match(/<app ((.|\n|\r)*?)name="Bar"/, 'app name');
-    expect(result).to.not.match(
-      /<app ((.|\n|\r)*?)sitecorePath="\/somewhere\/else\/Bar"/,
-      'app sitecorePath'
-    );
-    expect(result).to.not.match(
-      /<app ((.|\n|\r)*?)graphQLEndpoint="\/somewhere\/else\/Bar"/,
-      'app graphQLEndpoint'
-    );
-    expect(result).to.not.match(
-      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/somewhere\/else\/Bar"/,
-      'GraphQL endpoint'
-    );
   });
 });

--- a/packages/sitecore-jss-cli/src/create/index.test.ts
+++ b/packages/sitecore-jss-cli/src/create/index.test.ts
@@ -48,14 +48,13 @@ describe('applyNameToPackageJson', () => {
     const result = applyNameToPackageJson(
       {
         name: 'FooName',
-        config: { appName: 'FooAppName', sitecoreDistPath: 'na', graphQLEndpointPath: 'na' },
+        config: { appName: 'FooAppName', sitecoreDistPath: 'na' },
       },
       'bar'
     );
     expect(result.name).to.equal('bar');
     expect(result.config.appName).to.equal('bar');
     expect(result.config.sitecoreDistPath).to.equal('/dist/bar');
-    expect(result.config.graphQLEndpointPath).to.equal('/sitecore/api/graph/edge');
   });
 
   it('should apply name using replaceName', () => {
@@ -65,7 +64,6 @@ describe('applyNameToPackageJson', () => {
         config: {
           appName: 'FooAppName',
           sitecoreDistPath: '/somewhere/dist/FooAppName',
-          graphQLEndpointPath: '/somewhere/api/FooAppName',
         },
       },
       'bar',
@@ -74,7 +72,6 @@ describe('applyNameToPackageJson', () => {
     expect(result.name).to.equal('bar');
     expect(result.config.appName).to.equal('bar');
     expect(result.config.sitecoreDistPath).to.equal('/somewhere/dist/bar');
-    expect(result.config.graphQLEndpointPath).to.equal('/somewhere/api/bar');
   });
 
   it('should not apply name using replaceName if no match', () => {
@@ -150,7 +147,7 @@ describe('applyNameToSitecoreConfig', () => {
         <app name="${appName}"
             sitecorePath="${customPath ? customPath : '/sitecore/content/'}${appName}"
             useLanguageSpecificLayout="true"
-            graphQLEndpoint="${customPath ? customPath : '/api/'}${appName}"
+            graphQLEndpoint="/sitecore/api/graph/edge"
             inherits="defaults"
         />
       </apps>
@@ -158,7 +155,7 @@ describe('applyNameToSitecoreConfig', () => {
     <api>
       <GraphQL>
         <endpoints>
-          <${appName}GraphQLEndpoint url="${customPath ? customPath : '/api/'}${appName}">
+          <${appName}GraphQLEndpoint url="/sitecore/api/graph/edge">
             <schema>
               <content>
                 <templates>
@@ -193,11 +190,7 @@ describe('applyNameToSitecoreConfig', () => {
       'app sitecorePath'
     );
     expect(result).to.match(
-      /<app ((.|\n|\r)*?)graphQLEndpoint="\/api\/Bar"/,
-      'app graphQLEndpoint'
-    );
-    expect(result).to.match(
-      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/api\/Bar"/,
+      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/sitecore\/api\/graph\/edge"/,
       'GraphQL endpoint'
     );
   });
@@ -216,11 +209,7 @@ describe('applyNameToSitecoreConfig', () => {
       'app sitecorePath'
     );
     expect(result).to.match(
-      /<app ((.|\n|\r)*?)graphQLEndpoint="\/somewhere\/else\/Bar"/,
-      'app graphQLEndpoint'
-    );
-    expect(result).to.match(
-      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/somewhere\/else\/Bar"/,
+      /<BarGraphQLEndpoint ((.|\n|\r)*?)url="\/sitecore\/api\/graph\/edge"/,
       'GraphQL endpoint'
     );
   });

--- a/packages/sitecore-jss-cli/src/create/index.test.ts
+++ b/packages/sitecore-jss-cli/src/create/index.test.ts
@@ -55,7 +55,7 @@ describe('applyNameToPackageJson', () => {
     expect(result.name).to.equal('bar');
     expect(result.config.appName).to.equal('bar');
     expect(result.config.sitecoreDistPath).to.equal('/dist/bar');
-    expect(result.config.graphQLEndpointPath).to.equal('/api/bar');
+    expect(result.config.graphQLEndpointPath).to.equal('/sitecore/api/graph/edge');
   });
 
   it('should apply name using replaceName', () => {

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -31,18 +31,18 @@ export function applyNameReplacement(value: string, replaceName: string, withNam
 /**
  * @param {PackageJson} pkg package.json object
  * @param {string} name App name
- * @param {string} [replaceName] Optional token which will enable "name replacement mode". If omitted, default/conventional values are used.
+ * @param {string} replaceName Token which will enable "name replacement mode".
  */
-export function applyNameToPackageJson(pkg: PackageJson, name: string, replaceName?: string) {
+export function applyNameToPackageJson(pkg: PackageJson, name: string, replaceName: string) {
   pkg.name = name; // root name will never match "replaceName", so always set directly
-  pkg.config.appName = replaceName
-    ? applyNameReplacement(pkg.config.appName, replaceName, name)
-    : name;
+  pkg.config.appName = applyNameReplacement(pkg.config.appName, replaceName, name);
 
   if (pkg.config.sitecoreDistPath) {
-    pkg.config.sitecoreDistPath = replaceName
-      ? applyNameReplacement(pkg.config.sitecoreDistPath, replaceName, name)
-      : `/dist/${name}`;
+    pkg.config.sitecoreDistPath = applyNameReplacement(
+      pkg.config.sitecoreDistPath,
+      replaceName,
+      name
+    );
   }
   return pkg;
 }
@@ -61,60 +61,16 @@ export function applyHostNameToSitecoreConfig(configXml: string, hostName: strin
 }
 
 /**
- * @param {string} configXml Sitecore configuration xml
- * @param {string} name App name
- * @param {string} [replaceName] Optional token which will enable "name replacement mode". If omitted, default/conventional values are used.
- */
-export function applyNameToSitecoreConfig(configXml: string, name: string, replaceName?: string) {
-  if (replaceName) {
-    return applyNameReplacement(configXml, replaceName, name);
-  }
-
-  // replace site name
-  configXml = configXml.replace(/<site ((.|\n|\r)*?)name="[^"]+"/g, `<site $1name="${name}"`);
-
-  // replace root path
-  configXml = configXml.replace(
-    /<site ((.|\n|\r)*?)rootPath="[^"]+"/g,
-    `<site $1rootPath="/sitecore/content/${name}"`
-  );
-
-  // replace jss app name
-  configXml = configXml.replace(/<app ((.|\n|\r)*?)name="[^"]+"/g, `<app $1name="${name}"`);
-
-  // replace jss app sitecorePath
-  configXml = configXml.replace(
-    /<app ((.|\n|\r)*?)sitecorePath="[^"]+"/g,
-    `<app $1sitecorePath="/sitecore/content/${name}"`
-  );
-
-  // replace GraphQL url
-  configXml = configXml.replace(
-    /<([^ ]+)GraphQLEndpoint ((.|\n|\r)*?)url="[^"]+"/g,
-    `<${name}GraphQLEndpoint url="/sitecore/api/graph/edge"`
-  );
-
-  configXml = configXml.replace(/<\/(.+)GraphQLEndpoint>/g, `</${name}GraphQLEndpoint>`);
-
-  // replace GraphQL templates path
-  configXml = configXml.replace(
-    /(<templates>\/sitecore\/templates\/Project\/)[^<]+(<\/templates>)/g,
-    `$1${name}$2`
-  );
-  return configXml;
-}
-
-/**
  * @param {string} projectFolder Project folder
  * @param {string} name App name
  * @param {string} hostName App hostname
- * @param {string} [replaceName] Optional token which will enable "name replacement mode" on project files. If omitted, default/conventional values are used.
+ * @param {string} replaceName Token which will enable "name replacement mode" on project files.
  */
 export function applyNameToProject(
   projectFolder: string,
   name: string,
   hostName: string,
-  replaceName?: string
+  replaceName: string
 ) {
   // Apply name to package.json file
   console.log(chalk.cyan(`Applying name ${name} to package.json...`));
@@ -134,7 +90,7 @@ export function applyNameToProject(
       console.log(
         chalk.cyan(`Applying name ${name} and hostName ${hostName} to ${sitecoreConfigPath}...`)
       );
-      configXml = applyNameToSitecoreConfig(configXml, name, replaceName);
+      configXml = applyNameReplacement(configXml, replaceName, name);
       configXml = applyHostNameToSitecoreConfig(configXml, hostName);
 
       fs.unlinkSync(sitecoreConfigPath);

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -44,11 +44,6 @@ export function applyNameToPackageJson(pkg: PackageJson, name: string, replaceNa
       ? applyNameReplacement(pkg.config.sitecoreDistPath, replaceName, name)
       : `/dist/${name}`;
   }
-  if (pkg.config.graphQLEndpointPath) {
-    pkg.config.graphQLEndpointPath = replaceName
-      ? applyNameReplacement(pkg.config.graphQLEndpointPath, replaceName, name)
-      : '/sitecore/api/graph/edge';
-  }
   return pkg;
 }
 
@@ -93,16 +88,10 @@ export function applyNameToSitecoreConfig(configXml: string, name: string, repla
     `<app $1sitecorePath="/sitecore/content/${name}"`
   );
 
-  // replace jss app graphQLEndpoint
-  configXml = configXml.replace(
-    /<app ((.|\n|\r)*?)graphQLEndpoint="[^"]+"/g,
-    `<app $1graphQLEndpoint="/api/${name}"`
-  );
-
   // replace GraphQL url
   configXml = configXml.replace(
     /<([^ ]+)GraphQLEndpoint ((.|\n|\r)*?)url="[^"]+"/g,
-    `<${name}GraphQLEndpoint $2url="/api/${name}"`
+    `<${name}GraphQLEndpoint url="/sitecore/api/graph/edge"`
   );
 
   configXml = configXml.replace(/<\/(.+)GraphQLEndpoint>/g, `</${name}GraphQLEndpoint>`);

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -47,7 +47,7 @@ export function applyNameToPackageJson(pkg: PackageJson, name: string, replaceNa
   if (pkg.config.graphQLEndpointPath) {
     pkg.config.graphQLEndpointPath = replaceName
       ? applyNameReplacement(pkg.config.graphQLEndpointPath, replaceName, name)
-      : `/api/${name}`;
+      : '/sitecore/api/graph/edge';
   }
   return pkg;
 }

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -31,7 +31,7 @@ export function applyNameReplacement(value: string, replaceName: string, withNam
 /**
  * @param {PackageJson} pkg package.json object
  * @param {string} name App name
- * @param {string} replaceName Token which will enable "name replacement mode".
+ * @param {string} replaceName Name value to replace
  */
 export function applyNameToPackageJson(pkg: PackageJson, name: string, replaceName: string) {
   pkg.name = name; // root name will never match "replaceName", so always set directly
@@ -64,7 +64,7 @@ export function applyHostNameToSitecoreConfig(configXml: string, hostName: strin
  * @param {string} projectFolder Project folder
  * @param {string} name App name
  * @param {string} hostName App hostname
- * @param {string} replaceName Token which will enable "name replacement mode" on project files.
+ * @param {string} replaceName Name value to replace
  */
 export function applyNameToProject(
   projectFolder: string,

--- a/samples/angular/jss-create.js
+++ b/samples/angular/jss-create.js
@@ -18,7 +18,7 @@ const { applyNameToProject } = require('@sitecore-jss/sitecore-jss-cli/dist/cjs/
 module.exports = function createJssProject(argv, nextSteps) {
   console.log(`Executing create script: ${__filename}...`);
 
-  applyNameToProject(__dirname, argv.name, argv.hostName);
+  applyNameToProject(__dirname, argv.name, argv.hostName, 'JssAngularWeb');
 
   // Replace app name in Angular-specific locations
   function replaceAngularAppNameInFile(filePath) {

--- a/samples/react/jss-create.js
+++ b/samples/react/jss-create.js
@@ -18,7 +18,7 @@ const { applyNameToProject } = require('@sitecore-jss/sitecore-jss-cli/dist/cjs/
 module.exports = function createJssProject(argv, nextSteps) {
   console.log(`Executing create script: ${__filename}...`);
 
-  applyNameToProject(__dirname, argv.name, argv.hostName);
+  applyNameToProject(__dirname, argv.name, argv.hostName, 'JssReactWeb');
 
   if (!argv.fetchWith) {
     nextSteps.push(

--- a/samples/vue/jss-create.js
+++ b/samples/vue/jss-create.js
@@ -18,7 +18,7 @@ const { applyNameToProject } = require('@sitecore-jss/sitecore-jss-cli/dist/cjs/
 module.exports = function createJssProject(argv, nextSteps) {
   console.log(`Executing create script: ${__filename}...`);
 
-  applyNameToProject(__dirname, argv.name, argv.hostName);
+  applyNameToProject(__dirname, argv.name, argv.hostName, 'JssVueWeb');
 
   if (!argv.fetchWith) {
     nextSteps.push(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Set `/sitecore/api/graph/edge` graphqlEndpointPath as default one when use `jss create`

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
