### PR TITLE
[Nextjs][Regression] jss start for newly created app fail

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
+++ b/packages/sitecore-jss-dev-tools/src/disconnected-server/create-default-disconnected-server.ts
@@ -32,7 +32,7 @@ export interface DisconnectedServerOptions {
   /**
    * Module to require before starting the disconnected server (i.e. a transpiler, or a config script that loads one)
    */
-  requireArg?: string;
+  requireArg?: string | null;
 
   /**
    * Express-like server instance to attach to. Defaults to a new Express instance if not passed.

--- a/packages/sitecore-jss-dev-tools/src/manifest-manager.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest-manager.ts
@@ -16,7 +16,7 @@ export interface ManifestManagerOptions {
   rootPath?: string;
   sourceFiles?: string[];
   watchOnlySourceFiles?: string[];
-  requireArg?: string;
+  requireArg?: string | null;
   outputPath?: string;
   pipelinePatchFiles?: string[];
   appName?: string;

--- a/samples/nextjs/scripts/disconnected-mode-proxy.ts
+++ b/samples/nextjs/scripts/disconnected-mode-proxy.ts
@@ -20,7 +20,7 @@ const serverOptions = {
   appRoot: path.join(__dirname, '..'),
   appName: config.appName,
   // Prevent require of ./sitecore/definitions/config.js, because ts-node is running
-  requireArg: '',
+  requireArg: null,
   watchPaths: ['./data'],
   language: config.language,
   port: Number(process.env.PROXY_PORT) || 3042,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update to the `DisconnectedServerOptions` and `ManifestManagerOptions` interfaces to accept null for the `requireArg` key to work with change from https://github.com/Sitecore/jss/pull/777.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
