### PR TITLE
[RAV] Include Sitecore server URL in media URLs by default (regression)

### DIFF
--- a/samples/angular/sitecore/config/JssAngularWeb.config
+++ b/samples/angular/sitecore/config/JssAngularWeb.config
@@ -86,31 +86,5 @@
         </styleguide-image-sample-adaptive>
       </allowedMediaParams>
     </javaScriptServices>
-    <!--
-      Media URLs resolving
-      Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
-      This eliminates exposing the Sitecore server publicly.
-
-      "default" configuration is used for Sitecore GraphQL Edge requests.
-      "jss" configuration is used for Sitecore Layout Service REST requests.
-    -->
-    <layoutService>
-      <configurations>
-        <config name="default">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-        <config name="jss">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-      </configurations>
-    </layoutService>
   </sitecore>
 </configuration>

--- a/samples/react/sitecore/config/JssReactWeb.config
+++ b/samples/react/sitecore/config/JssReactWeb.config
@@ -86,31 +86,5 @@
         </styleguide-image-sample-adaptive>
       </allowedMediaParams>
     </javaScriptServices>
-    <!--
-      Media URLs resolving
-      Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
-      This eliminates exposing the Sitecore server publicly.
-
-      "default" configuration is used for Sitecore GraphQL Edge requests.
-      "jss" configuration is used for Sitecore Layout Service REST requests.
-    -->
-    <layoutService>
-      <configurations>
-        <config name="default">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-        <config name="jss">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-      </configurations>
-    </layoutService>
   </sitecore>
 </configuration>

--- a/samples/vue/sitecore/config/JssVueWeb.config
+++ b/samples/vue/sitecore/config/JssVueWeb.config
@@ -85,31 +85,5 @@
         </styleguide-image-sample-adaptive>
       </allowedMediaParams>
     </javaScriptServices>
-    <!--
-      Media URLs resolving
-      Tells Sitecore to not include the Sitecore server URL as part of the media requests, so that they are instead routed through Next.js rewrites (see next.config.js).
-      This eliminates exposing the Sitecore server publicly.
-
-      "default" configuration is used for Sitecore GraphQL Edge requests.
-      "jss" configuration is used for Sitecore Layout Service REST requests.
-    -->
-    <layoutService>
-      <configurations>
-        <config name="default">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-        <config name="jss">
-          <rendering>
-            <renderingContentsResolver>
-              <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
-            </renderingContentsResolver>
-          </rendering>
-        </config>
-      </configurations>
-    </layoutService>
   </sitecore>
 </configuration>


### PR DESCRIPTION
## Description / Motivation
Removed Sitecore config patch for `<IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>` in RAV samples. This should only be disabled for the Next.js sample and for RAV when using the SSR Proxy.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
