### PR TITLE
[React] Set `changeOrigin: true` for proxied Sitecore requests in connected mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ This project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 `[samples/angular]` Fix issue where dk-DA language is not rendered in connected and disconnected mode ([#734](https://github.com/Sitecore/jss/pull/734))
 
+`[samples/react]` Fix 504 (Gateway Timeout) errors for proxied Sitecore requests (visitor identification, media, etc) when running in connected mode ([#808](https://github.com/Sitecore/jss/pull/808))
+
 ### Breaking Changes
 
 `[sitecore-jss]` `[sitecore-jss-vue]` `[sitecore-jss-react-native]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[sitecore-jss-angular]` Remove deprecated `dataApi` ([#744](https://github.com/Sitecore/jss/pull/744))

--- a/samples/react/src/setupProxy.js
+++ b/samples/react/src/setupProxy.js
@@ -14,10 +14,10 @@ module.exports = (app) => {
     // when in connected mode we want to proxy Sitecore paths
     // off to Sitecore
 
-    app.use(proxy('/sitecore', { target: config.sitecoreApiHost }));
+    app.use(proxy('/sitecore', { target: config.sitecoreApiHost, changeOrigin: true }));
     // media items
-    app.use(proxy('/-', { target: config.sitecoreApiHost }));
+    app.use(proxy('/-', { target: config.sitecoreApiHost, changeOrigin: true }));
     // visitor identification
-    app.use(proxy('/layouts', { target: config.sitecoreApiHost }));
+    app.use(proxy('/layouts', { target: config.sitecoreApiHost, changeOrigin: true }));
   }
 };


### PR DESCRIPTION

## Description / Motivation
When running React in connected mode against development environments, proxied Sitecore requests (visitor identification, media, etc) may result in 504 (Gateway Timeout) errors. Setting [`changeOrigin: true`](https://github.com/chimurai/http-proxy-middleware/tree/v0.21.0#readme) resolves this issue.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
