### PR TITLE
[RAV] Fix Template id for styleguide-explanatory-component-template & vue graphql fragment data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 ### New Features & Improvements
 
 `[samples/angular]` Language is now preserved when navigating to another page ([#793](https://github.com/Sitecore/jss/pull/793))
-`[samples/nextjs][samples/react][samples/vue][samples/angular][sitecore-jss-cli]` Prefix added to templates which is replaced on jss create ([#800](https://github.com/Sitecore/jss/pull/800), [#811](https://github.com/Sitecore/jss/pull/811), [#813](https://github.com/Sitecore/jss/pull/813), (https://github.com/Sitecore/jss/pull/814))
+
+`[samples/nextjs][samples/react][samples/vue][samples/angular][sitecore-jss-cli]` Prefix added to templates which is replaced on jss create ([#800](https://github.com/Sitecore/jss/pull/800), [#811](https://github.com/Sitecore/jss/pull/811), [#813](https://github.com/Sitecore/jss/pull/813), [#814](https://github.com/Sitecore/jss/pull/814), [#816](https://github.com/Sitecore/jss/pull/816))
 
 ## 19.0.0
 

--- a/samples/angular/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.ts
+++ b/samples/angular/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.ts
@@ -10,7 +10,7 @@ import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-manifest'
 export default function StyleguideExplanatoryComponentTemplate(manifest: Manifest) {
   manifest.addTemplate({
     name: 'JssAngularWeb-Styleguide-Explanatory-Component',
-    id: 'styleguide-explanatory-component-template',
+    id: 'JssAngularWeb-styleguide-explanatory-component-template',
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },
       { name: 'description', type: CommonFieldTypes.RichText },

--- a/samples/react/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.js
+++ b/samples/react/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.js
@@ -11,7 +11,7 @@ import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-manifest'
 export default function (manifest) {
   manifest.addTemplate({
     name: 'JssReactWeb-Styleguide-Explanatory-Component',
-    id: 'styleguide-explanatory-component-template',
+    id: 'JssReactWeb-styleguide-explanatory-component-template',
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },
       { name: 'description', type: CommonFieldTypes.RichText },

--- a/samples/vue/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.js
+++ b/samples/vue/sitecore/definitions/templates/Styleguide-Explanatory-Component.sitecore.js
@@ -11,7 +11,7 @@ import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-manifest'
 export default function(manifest) {
   manifest.addTemplate({
     name: 'JssVueWeb-Styleguide-Explanatory-Component',
-    id: 'styleguide-explanatory-component-template',
+    id: 'JssVueWeb-styleguide-explanatory-component-template',
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },
       { name: 'description', type: CommonFieldTypes.RichText },

--- a/samples/vue/src/temp/GraphQLFragmentTypes.json
+++ b/samples/vue/src/temp/GraphQLFragmentTypes.json
@@ -60,91 +60,91 @@
             "name": "RenderEngineType"
           },
           {
-            "name": "JssAngularWebStyleguideTracking"
+            "name": "JssVueWebStyleguideTracking"
           },
           {
-            "name": "JssAngularWebStyleguideSitecoreContext"
+            "name": "JssVueWebStyleguideSitecoreContext"
           },
           {
-            "name": "JssAngularWebStyleguideSection"
+            "name": "JssVueWebStyleguideSection"
           },
           {
-            "name": "JssAngularWebStyleguideRouteFields"
+            "name": "JssVueWebStyleguideRouteFields"
           },
           {
-            "name": "JssAngularWebStyleguideMultilingual"
+            "name": "JssVueWebStyleguideMultilingual"
           },
           {
-            "name": "JssAngularWebStyleguideLayoutTabsTab"
+            "name": "JssVueWebStyleguideLayoutTabsTab"
           },
           {
-            "name": "JssAngularWebStyleguideLayoutTabs"
+            "name": "JssVueWebStyleguideLayoutTabs"
           },
           {
-            "name": "JssAngularWebStyleguideLayoutReuse"
+            "name": "JssVueWebStyleguideLayoutReuse"
           },
           {
-            "name": "JssAngularWebStyleguideItemLinkItemTemplate"
+            "name": "JssVueWebStyleguideItemLinkItemTemplate"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageText"
+            "name": "JssVueWebStyleguideFieldUsageText"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageRichText"
+            "name": "JssVueWebStyleguideFieldUsageRichText"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageNumber"
+            "name": "JssVueWebStyleguideFieldUsageNumber"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageLink"
+            "name": "JssVueWebStyleguideFieldUsageLink"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageItemLink"
+            "name": "JssVueWebStyleguideFieldUsageItemLink"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageImage"
+            "name": "JssVueWebStyleguideFieldUsageImage"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageFile"
+            "name": "JssVueWebStyleguideFieldUsageFile"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageDate"
+            "name": "JssVueWebStyleguideFieldUsageDate"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageCustom"
+            "name": "JssVueWebStyleguideFieldUsageCustom"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageContentList"
+            "name": "JssVueWebStyleguideFieldUsageContentList"
           },
           {
-            "name": "JssAngularWebStyleguideFieldUsageCheckbox"
+            "name": "C__JssVueWebStyleguideExplanatoryComponent"
           },
           {
-            "name": "JssAngularWebStyleguideExplanatoryComponent"
+            "name": "JssVueWebStyleguideContentListItemTemplate"
           },
           {
-            "name": "JssAngularWebStyleguideContentListItemTemplate"
+            "name": "JssVueWebStyleguideComponentParams"
           },
           {
-            "name": "JssAngularWebStyleguideComponentParams"
+            "name": "JssVueWebGraphQLSSRDemo"
           },
           {
-            "name": "JssAngularWebStyleguideAngularLazyLoading"
+            "name": "JssVueWebGraphQLIntegratedDemo"
           },
           {
-            "name": "JssAngularWebGraphQLIntegratedDemo"
+            "name": "JssVueWebGraphQLConnectedDemo"
           },
           {
-            "name": "JssAngularWebGraphQLConnectedDemo"
+            "name": "JssVueWebFieldUsageCheckbox"
           },
           {
-            "name": "JssAngularWebExampleCustomRouteType"
+            "name": "JssVueWebExampleCustomRouteType"
           },
           {
-            "name": "JssAngularWebContentBlock"
+            "name": "JssVueWebContentBlock"
           },
           {
-            "name": "C__JssAngularWebAppRoute"
+            "name": "C__JssVueWebAppRoute"
           },
           {
             "name": "JsonRendering"
@@ -183,13 +183,76 @@
       },
       {
         "kind": "INTERFACE",
-        "name": "JssAngularWebAppRoute",
+        "name": "JssVueWebStyleguideExplanatoryComponent",
         "possibleTypes": [
           {
-            "name": "JssAngularWebExampleCustomRouteType"
+            "name": "JssVueWebStyleguideTracking"
           },
           {
-            "name": "C__JssAngularWebAppRoute"
+            "name": "JssVueWebStyleguideSitecoreContext"
+          },
+          {
+            "name": "JssVueWebStyleguideRouteFields"
+          },
+          {
+            "name": "JssVueWebStyleguideMultilingual"
+          },
+          {
+            "name": "JssVueWebStyleguideLayoutTabs"
+          },
+          {
+            "name": "JssVueWebStyleguideLayoutReuse"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageText"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageRichText"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageNumber"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageLink"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageItemLink"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageImage"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageFile"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageDate"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageCustom"
+          },
+          {
+            "name": "JssVueWebStyleguideFieldUsageContentList"
+          },
+          {
+            "name": "C__JssVueWebStyleguideExplanatoryComponent"
+          },
+          {
+            "name": "JssVueWebStyleguideComponentParams"
+          },
+          {
+            "name": "JssVueWebFieldUsageCheckbox"
+          }
+        ]
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "JssVueWebAppRoute",
+        "possibleTypes": [
+          {
+            "name": "JssVueWebExampleCustomRouteType"
+          },
+          {
+            "name": "C__JssVueWebAppRoute"
           }
         ]
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update template id which was missing the prefix for RAV and was causing warnings on importing items.
Also update vue graphql fragment data

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
