### PR TITLE
[CLI] Handle underscores in app name when replacing prefix

### DIFF
--- a/packages/sitecore-jss-cli/src/create/index.test.ts
+++ b/packages/sitecore-jss-cli/src/create/index.test.ts
@@ -216,6 +216,12 @@ describe('getPascalCaseName', () => {
     expect(result).to.match(/MyNextSitecoreApp/);
   });
 
+  it('should reformat snake_case to PascalCase', () => {
+    const result = getPascalCaseName('my_next_sitecore_app');
+
+    expect(result).to.match(/MyNextSitecoreApp/);
+  });
+
   it('should reformat one word lowercase app name to be capitalized', () => {
     const result = getPascalCaseName('onewordappnamenohyphen');
 

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -117,7 +117,8 @@ export function applyNameToProject(
  * @param {string} name
  */
 export function getPascalCaseName(name: string): string {
-  const temp: string[] = name.split('-');
+  // handle underscores by converting them to hyphens
+  const temp: string[] = name.replace(/_/g, '-').split('-');
   name = temp.map((item: string) => (item = item.charAt(0).toUpperCase() + item.slice(1))).join('');
   return name;
 }

--- a/samples/vue/sitecore/definitions/components/ContentBlock.sitecore.js
+++ b/samples/vue/sitecore/definitions/components/ContentBlock.sitecore.js
@@ -10,7 +10,6 @@ export default function(manifest) {
   manifest.addComponent({
     name: 'ContentBlock',
     templateName: 'JssVueWeb-ContentBlock',
-    displayName: 'Content Block',
     // totally optional, but fun
     icon: SitecoreIcon.DocumentTag,
     fields: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pr updates the `getPascalCaseName` function to handle app names including underscore. Unit test also added.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
