### PR TITLE
[CLI] Ignore pdf and images when replacing or stripping prefix

### DIFF
--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -141,7 +141,9 @@ export function replacePrefix(
     console.log(chalk.cyan('Removing template prefix...'));
     const prefixWithHyphen = prefix + '-';
     glob
-      .sync(path.join(projectFolder, './{data,sitecore/definitions,src}/**/*.*'))
+      .sync(path.join(projectFolder, './{data,sitecore/definitions,src}/**/*.*'), {
+        ignore: '{.png,.pdf}',
+      })
       .forEach((filePath: string) => {
         let fileContents: string = fs.readFileSync(filePath, 'utf8');
 
@@ -157,7 +159,9 @@ export function replacePrefix(
 
   console.log(chalk.cyan(`Replacing template prefix with ${getPascalCaseName(name)}...`));
   glob
-    .sync(path.join(projectFolder, './{data,sitecore/definitions,src}/**/*.*'))
+    .sync(path.join(projectFolder, './{data,sitecore/definitions,src}/**/*.*'), {
+      ignore: '{**/*.png,**/*.pdf}',
+    })
     .forEach((filePath: string) => {
       let fileContents: string = fs.readFileSync(filePath, 'utf8');
 

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -142,7 +142,7 @@ export function replacePrefix(
     const prefixWithHyphen = prefix + '-';
     glob
       .sync(path.join(projectFolder, './{data,sitecore/definitions,src}/**/*.*'), {
-        ignore: '{.png,.pdf}',
+        ignore: '{**/*.png,**/*.pdf}',
       })
       .forEach((filePath: string) => {
         let fileContents: string = fs.readFileSync(filePath, 'utf8');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ignore .pdf and .png from the glob command so that these files aren't accidently edited and corrupted.
## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
