### PR TITLE
[Focused improvement] Add a linting gate for git push actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint-packages": "lerna run lint --ignore *-sample*",
     "lint-apps": "lerna run lint --ignore @sitecore-jss/*",
     "coverage-packages": "lerna run coverage --ignore *-sample*",
-    "install-git-hooks": "node ./scripts/installHooks.js"
+    "install-git-hooks": "node ./scripts/install-hooks.js"
   },
   "author": {
     "name": "Sitecore Corporation",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build-apps": "lerna run build --scope *-sample*",
     "lint-packages": "lerna run lint --ignore *-sample*",
     "lint-apps": "lerna run lint --ignore @sitecore-jss/*",
-    "coverage-packages": "lerna run coverage --ignore *-sample*"
+    "coverage-packages": "lerna run coverage --ignore *-sample*",
+    "install-git-hooks": "node ./scripts/installHooks.js"
   },
   "author": {
     "name": "Sitecore Corporation",

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const installHook = async () => {
+const installHooks = () => {
   // data to be written to the file
   const data = `#!/bin/sh
 #
@@ -29,4 +29,4 @@ npm run lint-apps;`;
   });
 };
 
-installHook();
+installHooks();

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -4,11 +4,11 @@ const installHooks = () => {
   // data to be written to the file
   const data = `#!/bin/sh
 #
-# pre-commit hook that runs lint so we don't have to wait for
+# pre-push hook that runs our linter so we don't have to wait for
 # CI to do it for us!
 #
 # To skip this hook, use the --no-verify flag
-# when adding a new commit.
+# when pushing.
 #
 
 echo "Linting packages..."
@@ -21,7 +21,7 @@ npm run lint-apps;`;
 
   // Write the hook to the local .git folder. Using writeFile in order to catch any errors
   /* eslint-disable no-unused-vars */
-  fs.writeFile('./.git/hooks/pre-commit', data, 'utf8', (err, _) => {
+  fs.writeFile('./.git/hooks/pre-push', data, 'utf8', (err, _) => {
     if (err) {
       console.log('\x1b[31m%o\x1b[0m', err);
     }

--- a/scripts/installHooks.js
+++ b/scripts/installHooks.js
@@ -21,7 +21,7 @@ npm run lint-apps;`;
 
   // Write the hook to the local .git folder. Using writeFile in order to catch any errors
   /* eslint-disable no-unused-vars */
-  fs.writeFile('./.git/hooks/pre-commit.local-linter', data, 'utf8', (err, _) => {
+  fs.writeFile('./.git/hooks/pre-commit', data, 'utf8', (err, _) => {
     if (err) {
       console.log('\x1b[31m%o\x1b[0m', err);
     }

--- a/scripts/installHooks.js
+++ b/scripts/installHooks.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const installHook = async () => {
+  // data to be written to the file
+  const data = `#!/bin/sh
+#
+# pre-commit hook that runs lint so we don't have to wait for
+# CI to do it for us!
+#
+# To skip this hook, use the --no-verify flag
+# when adding a new commit.
+#
+
+echo "Linting packages..."
+npm run lint-packages;
+echo "Linting samples..."
+npm run lint-apps;`;
+
+  // \x1b[32m%s\x1b[0m - set color to green, insert the string, reset color after string is logged to console
+  console.log('\x1b[32m%s\x1b[0m', 'Writing to local .git folder...');
+
+  // Write the hook to the local .git folder. Using writeFile in order to catch any errors
+  /* eslint-disable no-unused-vars */
+  fs.writeFile('./.git/hooks/pre-commit.local-linter', data, 'utf8', (err, _) => {
+    if (err) {
+      console.log('\x1b[31m%o\x1b[0m', err);
+    }
+    console.log('\x1b[32m%s\x1b[0m', 'Success!');
+  });
+};
+
+installHook();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a script that 'installs' a pre-commit hook which will lint packages and apps on ~~commit~~ push. If you'd like to skip this hook, add the `--no-verify` flag to your ~~commit~~ push i.e. `git push origin head --no-verify`
## Description / Motivation
<!--- Describe your changes in detail -->
Instead of waiting for CI to potentially fail due to unlinted apps/packages, we want to catch those errors locally.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
