### PR TITLE
[Nextjs][Build error] TypeError: Only absolute URLs are supported

### DIFF
--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -108,11 +108,13 @@ describe('GraphQLRequestClient', () => {
   });
 
   it('should throw error when endpoint is not a valid url', () => {
+    const endpoint = 'invalid';
+
     try {
-      new GraphQLRequestClient('invalid', { debugger: debug.layout });
+      new GraphQLRequestClient(endpoint, { debugger: debug.layout });
     } catch (error) {
       expect(error.toString()).to.equal(
-        'Error: Graphql endpoint must be a non-empty string. Verify that `layoutServiceHost` property in `scjssconfig.json` is not empty or appropriate environment variable is set'
+        `Error: Invalid GraphQL endpoint '${endpoint}'. Verify that 'layoutServiceHost' property in 'scjssconfig.json' file or appropriate environment variable is set`
       );
     }
   });

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -50,7 +50,7 @@ export class GraphQLRequestClient implements GraphQLClient {
 
     if (!endpoint || !parse(endpoint).hostname) {
       throw new Error(
-        'Graphql endpoint must be a non-empty string. Verify that `layoutServiceHost` property in `scjssconfig.json` is not empty or appropriate environment variable is set'
+        `Invalid GraphQL endpoint '${endpoint}'. Verify that 'layoutServiceHost' property in 'scjssconfig.json' file or appropriate environment variable is set`
       );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
With Next.js, running a build will trigger a production build, which requires a service to communicate with first. The `build` target by default then needs a running Sitecore instance configured in the `scjssconfig.json`. Without that, this confusing error is presented.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
