### PR TITLE
[Submodules error fix] Reverted back typescript aliases

### DIFF
--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/manifest.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/manifest.ts
@@ -1,4 +1,4 @@
-import { runPipeline } from '@root';
+import { runPipeline } from './../../index';
 import fieldTypes from './fieldTypes';
 import {
   ComponentDefinition,

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateContentItem/pipeline.config.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateContentItem/pipeline.config.ts
@@ -1,4 +1,4 @@
-import { pipelineFactory, PipelineRegistry } from '@root';
+import { pipelineFactory, PipelineRegistry } from './../../../../index';
 import * as path from 'path';
 
 // __dirname returns the directory of this file/module, so it has to be called here

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateContentItem/processNestedContent.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateContentItem/processNestedContent.ts
@@ -1,4 +1,4 @@
-import { runPipeline } from '@root';
+import { runPipeline } from './../../../../index';
 import { GenerateContentItemArgs, ItemDefinition } from '../../manifest.types';
 
 export default async (args: GenerateContentItemArgs) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateContentItems.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateContentItems.ts
@@ -1,4 +1,4 @@
-import { ExecutablePipeline, runPipeline } from '@root';
+import { ExecutablePipeline, runPipeline } from './../../../../index';
 import {
   ComponentDefinition,
   GenerateContentItemArgs,

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateMedia.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateMedia.ts
@@ -1,4 +1,4 @@
-import { runPipeline } from '@root';
+import { runPipeline } from './../../../../index';
 import { GeneratePipelineArgs } from '../../manifest.types';
 
 const generateMedia = async ({ items, templates, pipelines }: any) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generatePlaceholders.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generatePlaceholders.ts
@@ -1,4 +1,4 @@
-import { runPipeline } from '@root';
+import { runPipeline } from './../../../../index';
 import { GeneratePipelineArgs, GeneratePlaceholdersPipelineArgs } from '../../manifest.types';
 
 const generatePlaceholders = async ({

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateRouteItems.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/generateRouteItems.ts
@@ -1,4 +1,4 @@
-import { ExecutablePipeline, runPipeline } from '@root';
+import { ExecutablePipeline, runPipeline } from './../../../../index';
 import {
   ComponentDefinition,
   GeneratePipelineArgs,

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/pipeline.config.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateManifest/pipeline.config.ts
@@ -1,4 +1,4 @@
-import { pipelineFactory, PipelineRegistry } from '@root';
+import { pipelineFactory, PipelineRegistry } from './../../../../index';
 import * as path from 'path';
 
 // __dirname returns the directory of this file/module, so it has to be called here

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateMedia/pipeline.config.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateMedia/pipeline.config.ts
@@ -1,4 +1,4 @@
-import { pipelineFactory, PipelineRegistry } from '@root';
+import { pipelineFactory, PipelineRegistry } from './../../../../index';
 
 export const config = (pipelines: PipelineRegistry) => {
   const pipeline = pipelineFactory.create('generateMedia');

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generatePlaceholders/pipeline.config.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generatePlaceholders/pipeline.config.ts
@@ -1,4 +1,4 @@
-import { pipelineFactory, PipelineRegistry } from '@root';
+import { pipelineFactory, PipelineRegistry } from './../../../../index';
 import * as path from 'path';
 
 // __dirname returns the directory of this file/module, so it has to be called here

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateRouteItem/pipeline.config.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateRouteItem/pipeline.config.ts
@@ -1,4 +1,4 @@
-import { pipelineFactory, PipelineRegistry } from '@root';
+import { pipelineFactory, PipelineRegistry } from './../../../../index';
 import * as path from 'path';
 import { getDynamicPlaceholderKey } from '../../dynamicPlaceholders';
 import processRenderings from './processRenderings';

--- a/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateRouteItem/processChildRoutes.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/generator/pipelines/generateRouteItem/processChildRoutes.ts
@@ -1,4 +1,4 @@
-import { runPipeline } from '@root';
+import { runPipeline } from './../../../../index';
 import { GenerateRouteItemPipelineArgs } from '../../manifest.types';
 
 export default async (args: GenerateRouteItemPipelineArgs) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/components/Welcome.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/components/Welcome.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 import { CommonFieldTypes } from '../../generator/manifest.types';
 
 export default (manifest: Manifest) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/components/async.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/components/async.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 
 export default (manifest: Manifest) => {
   return Promise.resolve(manifest).then((manifest1) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/components/component0.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/components/component0.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 import { CommonFieldTypes } from '../../generator/manifest.types';
 
 export default (manifest: Manifest) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/components/component1.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/components/component1.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 
 export default (manifest: Manifest) => {
   manifest.addComponent({

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/components/folder0/component0-0.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/components/folder0/component0-0.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../../index';
 import { CommonFieldTypes } from '../../../generator/manifest.types';
 
 export default (manifest: Manifest) => {

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/content/content.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/content/content.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 import { CommonFieldTypes } from '../../generator/manifest.types';
 import data from './contentData';
 

--- a/packages/sitecore-jss-dev-tools/src/manifest/testData/routes/routes.sitecore.ts
+++ b/packages/sitecore-jss-dev-tools/src/manifest/testData/routes/routes.sitecore.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '@root';
+import { Manifest } from './../../../index';
 import json from './children.json';
 import data from './route';
 

--- a/packages/sitecore-jss-dev-tools/tsconfig.json
+++ b/packages/sitecore-jss-dev-tools/tsconfig.json
@@ -10,12 +10,6 @@
       "es2017",
       "dom"
     ],
-    "baseUrl": "src",
-    "paths": {
-      "@root": [
-        "index"
-      ]
-    },
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Module paths maps cannot be resolved by typescript. 
Instead of installing more dependencies, it's best to stick to what we had previously.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
