### PR TITLE
Make tmpDir a configurable parameter

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/editing-data-cache.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-data-cache.ts
@@ -19,6 +19,9 @@ export interface EditingDataCache {
 export class EditingDataDiskCache implements EditingDataCache {
   private cache: CacheInstance;
 
+  /**
+   * @param {string} [tmpDir] Temp directory to use. Default is the OS temp directory (os.tmpdir()).
+   */
   constructor(tmpDir: string = os.tmpdir()) {
     // Use gzip compression and store using the OS temp directory (Vercel Serverless Functions have temp directory access)
     this.cache = new Cache('editing-data', { compression: 'gzip', location: tmpDir });


### PR DESCRIPTION
Hi Team,

I'm loving the Next.js JSS SDK so far, we are currently running it on a custom server hosted in Azure Functions. With a custom server, the API pages don't work so I had to create separate Azure Functions for these, this was fine because middlewares (EditingRenderMiddleware/EditingDataMiddleware) are easily imported and configurable. In our case, this was useful because the default dataDiskCache middleware did not work correctly. 

With this simple change, we can use the default dataDiskCache middleware. Because the only issue with the implementation is that the os.tmpdir does not seem to work using Azure Functions on a consumption plan.

