### PR TITLE
[React] [Next.js] Strongly typed SitecoreContext value

### DIFF
--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -94,6 +94,7 @@ export {
   VisitorIdentification,
   SitecoreContext,
   SitecoreContextState,
+  SitecoreContextValue,
   SitecoreContextReactContext,
   withSitecoreContext,
   useSitecoreContext,

--- a/packages/sitecore-jss-react/src/components/SitecoreContext.test.tsx
+++ b/packages/sitecore-jss-react/src/components/SitecoreContext.test.tsx
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { SitecoreContext } from './SitecoreContext';
 import { ComponentFactory } from './sharedTypes';
 import { withSitecoreContext, ComponentConsumerProps } from '../enhancers/withSitecoreContext';
+import { LayoutServiceData } from '../index';
 
 interface NestedComponentProps extends ComponentConsumerProps {
   anotherProperty?: string;
@@ -17,32 +18,116 @@ const NestedComponentWithContext = withSitecoreContext()(NestedComponent);
 const components = new Map();
 const mockComponentFactory: ComponentFactory = (name) => components.get(name);
 
-const mockSitecoreContext = {
-  x: 'test1',
-  y: 'test2',
+const mockLayoutData: LayoutServiceData = {
+  sitecore: {
+    context: {
+      pageEditing: false,
+      site: {
+        name: 'JssTestWeb',
+      },
+      language: 'en',
+    },
+    route: {
+      name: 'styleguide',
+      placeholders: {
+        'JssTestWeb-jss-main': [],
+      },
+      itemId: 'testitemid',
+    },
+  },
 };
 
 describe('SitecoreContext', () => {
   it('should update context', () => {
     const component = shallow<SitecoreContext>(
-      <SitecoreContext componentFactory={mockComponentFactory} context={mockSitecoreContext}>
+      <SitecoreContext componentFactory={mockComponentFactory} layoutData={mockLayoutData}>
         <NestedComponentWithContext />
       </SitecoreContext>
     );
 
     expect(component.state().context).deep.equal({
-      x: 'test1',
-      y: 'test2',
+      pageEditing: false,
+      itemId: 'testitemid',
+      language: 'en',
+      route: {
+        itemId: 'testitemid',
+        name: 'styleguide',
+        placeholders: {
+          'JssTestWeb-jss-main': [],
+        },
+      },
+      site: {
+        name: 'JssTestWeb',
+      },
     });
 
+    // provide LayoutServiceData type
     component.instance().setContext({
-      x: 'test11',
-      y: 'test22',
+      sitecore: {
+        context: {
+          pageEditing: false,
+          site: {
+            name: 'JssTestWeb',
+          },
+          language: 'en',
+        },
+        route: {
+          name: 'home',
+          placeholders: {
+            'JssTestWeb-jss-main': [],
+          },
+          itemId: 'homeid',
+        },
+      },
     });
 
     expect(component.state().context).deep.equal({
-      x: 'test11',
-      y: 'test22',
+      pageEditing: false,
+      itemId: 'homeid',
+      language: 'en',
+      route: {
+        itemId: 'homeid',
+        name: 'home',
+        placeholders: {
+          'JssTestWeb-jss-main': [],
+        },
+      },
+      site: {
+        name: 'JssTestWeb',
+      },
+    });
+
+    // Provide SitecoreContextValue type
+    component.instance().setContext({
+      pageEditing: false,
+      itemId: 'graphqlid',
+      language: 'en',
+      route: {
+        itemId: 'graphqlid',
+        name: 'graphql',
+        placeholders: {
+          'JssTestWeb-jss-main-graphql': [],
+        },
+      },
+      site: {
+        name: 'JssTestWeb',
+      },
+    });
+
+    expect(component.state().context).deep.equal({
+      pageEditing: false,
+      itemId: 'graphqlid',
+      language: 'en',
+      route: {
+        itemId: 'graphqlid',
+        name: 'graphql',
+        placeholders: {
+          'JssTestWeb-jss-main-graphql': [],
+        },
+      },
+      site: {
+        name: 'JssTestWeb',
+      },
     });
   });
 
@@ -70,15 +155,23 @@ describe('SitecoreContext', () => {
     });
 
     component.setProps({
-      context: {
-        v1: 10,
-        v2: 20,
-      },
+      layoutData: mockLayoutData,
     });
 
     expect(component.state().context).to.deep.equal({
-      v1: 10,
-      v2: 20,
+      pageEditing: false,
+      itemId: 'testitemid',
+      language: 'en',
+      route: {
+        itemId: 'testitemid',
+        name: 'styleguide',
+        placeholders: {
+          'JssTestWeb-jss-main': [],
+        },
+      },
+      site: {
+        name: 'JssTestWeb',
+      },
     });
   });
 });

--- a/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
@@ -3,15 +3,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import deepEqual from 'deep-equal';
 import { ComponentFactory } from './sharedTypes';
+import { LayoutServiceContext, LayoutServiceData, RouteData } from '../index';
 
-export interface SitecoreContextProps<ContextType = any> {
+export interface SitecoreContextProps {
   componentFactory: ComponentFactory;
-  context?: ContextType;
+  layoutData?: LayoutServiceData;
 }
 
-export interface SitecoreContextState<ContextType = any> {
-  setContext: (value: ContextType) => void;
-  context: ContextType;
+export interface SitecoreContextState {
+  setContext: (value: SitecoreContextValue | LayoutServiceData) => void;
+  context: SitecoreContextValue;
 }
 
 export const SitecoreContextReactContext = React.createContext<SitecoreContextState>(
@@ -21,32 +22,29 @@ export const ComponentFactoryReactContext = React.createContext<ComponentFactory
   {} as ComponentFactory
 );
 
-export class SitecoreContext<ContextType = any> extends React.Component<
-  SitecoreContextProps<ContextType>,
-  SitecoreContextState<ContextType>
-> {
+export type SitecoreContextValue = LayoutServiceContext & {
+  itemId?: string;
+  route?: RouteData;
+};
+
+export class SitecoreContext extends React.Component<SitecoreContextProps, SitecoreContextState> {
   static propTypes = {
     children: PropTypes.any.isRequired,
     componentFactory: PropTypes.func,
-    context: PropTypes.any,
+    layoutData: PropTypes.shape({
+      sitecore: PropTypes.shape({
+        context: PropTypes.any,
+        route: PropTypes.any,
+      }),
+    }),
   };
 
   static displayName = 'SitecoreContext';
 
-  constructor(props: SitecoreContextProps<ContextType>) {
+  constructor(props: SitecoreContextProps) {
     super(props);
 
-    let context: any = {
-      pageEditing: false,
-    };
-
-    if (props.context) {
-      context = props.context;
-    }
-
-    if (props.context === null) {
-      context = null;
-    }
+    const context: SitecoreContextValue = this.constructContext(props.layoutData);
 
     this.state = {
       context,
@@ -54,21 +52,40 @@ export class SitecoreContext<ContextType = any> extends React.Component<
     };
   }
 
-  componentDidUpdate(prevProps: any) {
-    if (!deepEqual(prevProps.context, this.props.context)) {
-      this.setState({
-        context: this.props.context,
-      });
+  constructContext(layoutData?: LayoutServiceData): SitecoreContextValue {
+    if (!layoutData) {
+      return {
+        pageEditing: false,
+      };
+    }
+
+    return {
+      route: layoutData.sitecore.route,
+      itemId: layoutData.sitecore.route?.itemId,
+      ...layoutData.sitecore.context,
+    };
+  }
+
+  componentDidUpdate(prevProps: SitecoreContextProps) {
+    // In case if somebody will manage SitecoreContext state by passing fresh `layoutData` prop
+    // instead of using `updateSitecoreContext`
+    if (!deepEqual(prevProps.layoutData, this.props.layoutData)) {
+      this.setContext(this.props.layoutData);
 
       return;
     }
   }
 
-  setContext = (value: ContextType) => {
-    if (deepEqual(value, this.state.context)) return;
-
+  /**
+   * Update context state. Value can be @type {LayoutServiceData} which will be automatically transformed
+   * or you can provide exact @type {SitecoreContextValue}
+   * @param {SitecoreContextValue | LayoutServiceData} value New context value
+   */
+  setContext = (value: SitecoreContextValue | LayoutServiceData) => {
     this.setState({
-      context: value,
+      context: value.sitecore
+        ? this.constructContext(value as LayoutServiceData)
+        : { ...(value as SitecoreContextValue) },
     });
   };
 

--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { withSitecoreContext } from '../enhancers/withSitecoreContext';
+import { SitecoreContextValue } from './SitecoreContext';
 
 interface VIProps {
-  sitecoreContext: {
-    visitorIdentificationTimestamp?: string;
-  };
+  sitecoreContext: SitecoreContextValue;
 }
 
 let emittedVI = false;
@@ -26,7 +25,7 @@ const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
 
   const meta = document.createElement('meta');
   meta.name = 'VIcurrentDateTime';
-  meta.content = sitecoreContext.visitorIdentificationTimestamp;
+  meta.content = sitecoreContext.visitorIdentificationTimestamp.toString();
 
   const head = document.querySelector('head');
   head && head.appendChild(script);

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
@@ -32,7 +32,7 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
     Component: React.ComponentType<ComponentProps>
   ) {
     return function WithDatasourceCheck(props: ComponentProps) {
-      const { sitecoreContext } = useSitecoreContext<{ pageEditing: boolean }>();
+      const { sitecoreContext } = useSitecoreContext();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
       return props.rendering?.dataSource ? (

--- a/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode } from 'react';
-import { SitecoreContextReactContext } from '../components/SitecoreContext';
+import { SitecoreContextReactContext, SitecoreContextValue } from '../components/SitecoreContext';
 
 export interface WithSitecoreContextOptions {
   updatable?: boolean;
 }
 
 export interface WithSitecoreContextProps {
-  sitecoreContext: unknown;
-  updateSitecoreContext?: ((value: unknown) => void) | false;
+  sitecoreContext: SitecoreContextValue;
+  updateSitecoreContext?: ((value: SitecoreContextValue) => void) | false;
 }
 
 export interface ComponentConsumerProps extends WithSitecoreContextProps {
@@ -67,12 +67,12 @@ export function withSitecoreContext(options?: WithSitecoreContextOptions) {
  * }
  * @returns {Object} { sitecoreContext, updateSitecoreContext }
  */
-export function useSitecoreContext<Context>(options?: WithSitecoreContextOptions) {
+export function useSitecoreContext(options?: WithSitecoreContextOptions) {
   const reactContext = React.useContext(SitecoreContextReactContext);
   const updatable = options?.updatable;
 
   return {
-    sitecoreContext: reactContext.context as Context,
+    sitecoreContext: reactContext.context,
     updateSitecoreContext: updatable ? reactContext.setContext : undefined,
   };
 }

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -38,6 +38,7 @@ export { VisitorIdentification } from './components/VisitorIdentification';
 export {
   SitecoreContext,
   SitecoreContextState,
+  SitecoreContextValue,
   SitecoreContextReactContext,
 } from './components/SitecoreContext';
 export { withSitecoreContext, useSitecoreContext } from './enhancers/withSitecoreContext';

--- a/samples/nextjs/src/Layout.tsx
+++ b/samples/nextjs/src/Layout.tsx
@@ -8,8 +8,8 @@ import {
   VisitorIdentification,
   withSitecoreContext,
   getPublicUrl,
+  SitecoreContextValue,
 } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideSitecoreContextValue } from 'lib/component-props';
 
 // Prefix public assets with a public URL to enable compatibility with Sitecore Experience Editor.
 // If you're not supporting the Experience Editor, you can remove this.
@@ -52,7 +52,7 @@ const Navigation = () => {
 };
 
 interface LayoutProps {
-  sitecoreContext: StyleguideSitecoreContextValue;
+  sitecoreContext: SitecoreContextValue;
 }
 
 const Layout = ({ sitecoreContext: { route } }: LayoutProps): JSX.Element => {
@@ -75,12 +75,16 @@ const Layout = ({ sitecoreContext: { route } }: LayoutProps): JSX.Element => {
       <Navigation />
       {/* root placeholder for the app, which we add components to using route data */}
       <div className="container">
-        <Placeholder name="JssNextWeb-jss-main" rendering={route} />
+        {route && <Placeholder name="JssNextWeb-jss-main" rendering={route} />}
       </div>
     </>
   );
 };
 
+// If you use:
+// * SSG mode - it's required to use `React.memo`, Nextjs renders app twice on initial load and we don't need to render <Layout /> twice.
+// * SSR mode - you can remove `React.memo`, Nextjs renders app once.
+// Read more https://nextjs.org/docs/advanced-features/automatic-static-optimization#how-it-works
 const propsAreEqual = (prevProps: LayoutProps, nextProps: LayoutProps) => {
   if (deepEqual(prevProps.sitecoreContext.route, nextProps.sitecoreContext.route)) return true;
 

--- a/samples/nextjs/src/components/graphql/GraphQL-Layout.tsx
+++ b/samples/nextjs/src/components/graphql/GraphQL-Layout.tsx
@@ -1,8 +1,8 @@
 import { Placeholder, useSitecoreContext } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideComponentProps, StyleguideSitecoreContextValue } from 'lib/component-props';
+import { StyleguideComponentProps } from 'lib/component-props';
 
 const GraphQLLayout = ({ rendering }: StyleguideComponentProps): JSX.Element => {
-  const { sitecoreContext } = useSitecoreContext<StyleguideSitecoreContextValue>();
+  const { sitecoreContext } = useSitecoreContext();
 
   const disconnectedMode =
     sitecoreContext.route && sitecoreContext.route.layoutId === 'available-in-connected-mode';

--- a/samples/nextjs/src/components/styleguide/Styleguide-CustomRouteType.tsx
+++ b/samples/nextjs/src/components/styleguide/Styleguide-CustomRouteType.tsx
@@ -1,15 +1,10 @@
 import Link from 'next/link';
 import { useSitecoreContext, Text, RichText, Field } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideSitecoreContextValue } from 'lib/component-props';
 
-type StyleguideCustomRouteTypeContext = StyleguideSitecoreContextValue & {
-  route: {
-    fields: {
-      headline: Field<string>;
-      author: Field<string>;
-      content: Field<string>;
-    };
-  };
+type StyleguideCustomRouteTypeFields = {
+  headline: Field<string>;
+  author: Field<string>;
+  content: Field<string>;
 };
 
 const StyleguideCustomRouteType = (): JSX.Element => {
@@ -17,11 +12,8 @@ const StyleguideCustomRouteType = (): JSX.Element => {
   // see the context examples in the styleguide for more details.
   // this fancy destructure syntax is essentially equivalent to
   // const fields = props.sitecoreContext.route.fields
-  const {
-    sitecoreContext: {
-      route: { fields },
-    },
-  } = useSitecoreContext<StyleguideCustomRouteTypeContext>();
+  const value = useSitecoreContext();
+  const fields = value.sitecoreContext.route?.fields as StyleguideCustomRouteTypeFields;
 
   return (
     <div data-e2e-id="styleguide-customroutetype">

--- a/samples/nextjs/src/components/styleguide/Styleguide-Layout-Tabs-Tab.tsx
+++ b/samples/nextjs/src/components/styleguide/Styleguide-Layout-Tabs-Tab.tsx
@@ -5,7 +5,7 @@ import {
   useSitecoreContext,
   withDatasourceCheck,
 } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideComponentProps, StyleguideSitecoreContextValue } from 'lib/component-props';
+import { StyleguideComponentProps } from 'lib/component-props';
 
 type StyleguideLayoutTabsTabProps = StyleguideComponentProps & {
   fields: {
@@ -20,7 +20,7 @@ type StyleguideLayoutTabsTabProps = StyleguideComponentProps & {
  * author experience.
  */
 const StyleguideLayoutTabsTab = (props: StyleguideLayoutTabsTabProps): JSX.Element => {
-  const { sitecoreContext } = useSitecoreContext<StyleguideSitecoreContextValue>();
+  const { sitecoreContext } = useSitecoreContext();
 
   return (
     <div data-e2e-class="styleguide-layout-tabs-tab">

--- a/samples/nextjs/src/components/styleguide/Styleguide-RouteFields.tsx
+++ b/samples/nextjs/src/components/styleguide/Styleguide-RouteFields.tsx
@@ -1,20 +1,12 @@
 import Link from 'next/link';
 import { Text, Field, useSitecoreContext } from '@sitecore-jss/sitecore-jss-nextjs';
 import StyleguideSpecimen from './Styleguide-Specimen';
-import {
-  StyleguideComponentProps,
-  StyleguideSitecoreContextValue,
-  StyleguideSpecimenFields,
-} from 'lib/component-props';
+import { StyleguideComponentProps, StyleguideSpecimenFields } from 'lib/component-props';
 
 type StyleguideRouteFieldsProps = StyleguideComponentProps & StyleguideSpecimenFields;
 
-type StyleguideRouteFieldsContext = StyleguideSitecoreContextValue & {
-  route: {
-    fields: {
-      pageTitle: Field<string>;
-    };
-  };
+type StyleguideRouteFields = {
+  pageTitle: Field<string>;
 };
 
 /**
@@ -23,13 +15,14 @@ type StyleguideRouteFieldsContext = StyleguideSitecoreContextValue & {
  * to also get the route level field data and make it editable.
  */
 const StyleguideRouteFields = (props: StyleguideRouteFieldsProps): JSX.Element => {
-  const { sitecoreContext } = useSitecoreContext<StyleguideRouteFieldsContext>();
+  const value = useSitecoreContext();
+  const fields = value.sitecoreContext.route?.fields as StyleguideRouteFields;
 
   return (
     <StyleguideSpecimen {...props} e2eId="styleguide-route-fields">
       <p>
         Route level <code>pageTitle</code> field:{' '}
-        {sitecoreContext.route && <Text field={sitecoreContext.route.fields.pageTitle} />}
+        {value.sitecoreContext.route && <Text field={fields.pageTitle} />}
       </p>
       <p>
         <Link href="/styleguide/custom-route-type">

--- a/samples/nextjs/src/components/styleguide/Styleguide-SitecoreContext.tsx
+++ b/samples/nextjs/src/components/styleguide/Styleguide-SitecoreContext.tsx
@@ -1,10 +1,6 @@
 import { useSitecoreContext } from '@sitecore-jss/sitecore-jss-nextjs';
 import StyleguideSpecimen from './Styleguide-Specimen';
-import {
-  StyleguideSpecimenFields,
-  StyleguideSitecoreContextValue,
-  StyleguideComponentProps,
-} from 'lib/component-props';
+import { StyleguideSpecimenFields, StyleguideComponentProps } from 'lib/component-props';
 
 type StyleguideSitecoreContextProps = StyleguideComponentProps & StyleguideSpecimenFields;
 
@@ -13,7 +9,7 @@ type StyleguideSitecoreContextProps = StyleguideComponentProps & StyleguideSpeci
  * within other components.
  */
 const StyleguideSitecoreContext = (props: StyleguideSitecoreContextProps): JSX.Element => {
-  const { sitecoreContext } = useSitecoreContext<StyleguideSitecoreContextValue>();
+  const { sitecoreContext } = useSitecoreContext();
 
   return (
     <StyleguideSpecimen {...props} e2eId="styleguide-sitecore-context">

--- a/samples/nextjs/src/lib/component-props.ts
+++ b/samples/nextjs/src/lib/component-props.ts
@@ -2,17 +2,8 @@ import {
   Field,
   ComponentParams,
   ComponentRendering,
-  LayoutServiceContext,
-  RouteData,
+  SitecoreContextValue,
 } from '@sitecore-jss/sitecore-jss-nextjs';
-
-/**
- * Styleguide sitecore context value shape
- */
-export type StyleguideSitecoreContextValue = LayoutServiceContext & {
-  itemId?: string;
-  route: RouteData;
-};
 
 /**
  * Shared styleguide specimen fields
@@ -39,5 +30,5 @@ export type StyleguideComponentProps = {
  * @example const { sitecoreContext } = useSitecoreContext()
  */
 export type StyleguideComponentWithContextProps = StyleguideComponentProps & {
-  sitecoreContext: StyleguideSitecoreContextValue;
+  sitecoreContext: SitecoreContextValue;
 };

--- a/samples/nextjs/src/lib/page-props-factory.ts
+++ b/samples/nextjs/src/lib/page-props-factory.ts
@@ -13,7 +13,6 @@ import { dictionaryServiceFactory } from 'lib/dictionary-service-factory';
 import { layoutServiceFactory } from 'lib/layout-service-factory';
 import { componentModule } from 'temp/componentFactory';
 import pkg from '../../package.json';
-import { StyleguideSitecoreContextValue } from './component-props';
 
 /**
  * Extract normalized Sitecore item path from query
@@ -66,8 +65,7 @@ export class SitecorePagePropsFactory {
       layoutData: LayoutServiceData | null,
       dictionary: DictionaryPhrases,
       componentProps = {},
-      notFound = false,
-      sitecoreContext: StyleguideSitecoreContextValue | null = null;
+      notFound = false;
 
     if (context.preview) {
       /**
@@ -116,12 +114,6 @@ export class SitecorePagePropsFactory {
 
     // Retrieve component props using side-effects defined on components level
     if (layoutData?.sitecore?.route) {
-      sitecoreContext = {
-        route: layoutData.sitecore.route,
-        itemId: layoutData.sitecore.route?.itemId,
-        ...layoutData.sitecore.context,
-      };
-
       if (isServerSidePropsContext(context)) {
         componentProps = await this.componentPropsService.fetchServerSideComponentProps({
           layoutData,
@@ -140,7 +132,7 @@ export class SitecorePagePropsFactory {
     return {
       locale,
       dictionary,
-      sitecoreContext,
+      layoutData,
       componentProps,
       notFound,
     };

--- a/samples/nextjs/src/lib/page-props.ts
+++ b/samples/nextjs/src/lib/page-props.ts
@@ -1,5 +1,8 @@
-import { DictionaryPhrases, ComponentPropsCollection } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideSitecoreContextValue } from './component-props';
+import {
+  DictionaryPhrases,
+  ComponentPropsCollection,
+  LayoutServiceData,
+} from '@sitecore-jss/sitecore-jss-nextjs';
 
 /**
  * Sitecore page props
@@ -9,5 +12,5 @@ export type SitecorePageProps = {
   dictionary: DictionaryPhrases;
   componentProps: ComponentPropsCollection;
   notFound: boolean;
-  sitecoreContext: StyleguideSitecoreContextValue | null;
+  layoutData: LayoutServiceData;
 };

--- a/samples/nextjs/src/pages/[[...path]].SSR.tsx
+++ b/samples/nextjs/src/pages/[[...path]].SSR.tsx
@@ -10,29 +10,21 @@ import Layout from 'src/Layout';
 import { SitecorePageProps } from 'lib/page-props';
 import { sitecorePagePropsFactory } from 'lib/page-props-factory';
 import { componentFactory } from 'temp/componentFactory';
-import { StyleguideSitecoreContextValue } from 'lib/component-props';
 
-const SitecorePage = ({
-  notFound,
-  componentProps,
-  sitecoreContext,
-}: SitecorePageProps): JSX.Element => {
+const SitecorePage = ({ notFound, componentProps, layoutData }: SitecorePageProps): JSX.Element => {
   useEffect(() => {
     // Since Sitecore editors do not support Fast Refresh, need to refresh EE chromes after Fast Refresh finished
     handleEditorFastRefresh();
   }, []);
 
-  if (notFound || !sitecoreContext?.route) {
+  if (notFound || !layoutData.sitecore.route) {
     // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
     return <NotFound />;
   }
 
   return (
     <ComponentPropsContext value={componentProps}>
-      <SitecoreContext<StyleguideSitecoreContextValue>
-        componentFactory={componentFactory}
-        context={sitecoreContext}
-      >
+      <SitecoreContext componentFactory={componentFactory} layoutData={layoutData}>
         <Layout />
       </SitecoreContext>
     </ComponentPropsContext>

--- a/samples/nextjs/src/pages/[[...path]].tsx
+++ b/samples/nextjs/src/pages/[[...path]].tsx
@@ -7,33 +7,27 @@ import {
   ComponentPropsContext,
   handleEditorFastRefresh,
 } from '@sitecore-jss/sitecore-jss-nextjs';
-import { StyleguideSitecoreContextValue } from 'lib/component-props';
 import { SitecorePageProps } from 'lib/page-props';
 import { sitecorePagePropsFactory } from 'lib/page-props-factory';
 import { componentFactory } from 'temp/componentFactory';
 import { sitemapFetcher } from 'lib/sitemap-fetcher';
 
-const SitecorePage = ({
-  notFound,
-  sitecoreContext,
-  componentProps,
-}: SitecorePageProps): JSX.Element => {
+const SitecorePage = (props: SitecorePageProps): JSX.Element => {
+  const { notFound, layoutData, componentProps } = props;
+
   useEffect(() => {
     // Since Sitecore editors do not support Fast Refresh, need to refresh EE chromes after Fast Refresh finished
     handleEditorFastRefresh();
   }, []);
 
-  if (notFound || !sitecoreContext?.route) {
+  if (notFound || !layoutData.sitecore.route) {
     // Shouldn't hit this (as long as 'notFound' is being returned below), but just to be safe
     return <NotFound />;
   }
 
   return (
     <ComponentPropsContext value={componentProps}>
-      <SitecoreContext<StyleguideSitecoreContextValue>
-        componentFactory={componentFactory}
-        context={sitecoreContext}
-      >
+      <SitecoreContext componentFactory={componentFactory} layoutData={layoutData}>
         <Layout />
       </SitecoreContext>
     </ComponentPropsContext>

--- a/samples/react/src/AppRoot.js
+++ b/samples/react/src/AppRoot.js
@@ -22,53 +22,21 @@ export const routePatterns = [
 // SitecoreContext: provides component resolution and context services via withSitecoreContext
 // Router: provides a basic routing setup that will resolve Sitecore item routes and allow for language URL prefixes.
 class AppRoot extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      ssrRenderComplete: false,
-    };
-
-    if (props.ssrState) {
-      this.sitecoreContext =
-        props.ssrState.sitecore && props.ssrState.sitecore.route
-          ? {
-              route: props.ssrState.sitecore.route,
-              itemId: props.ssrState.sitecore.route.itemId,
-              ...props.ssrState.sitecore.context,
-            }
-          : props.ssrState.sitecore.context;
-    } else {
-      this.sitecoreContext = null;
-    }
-  }
-
-  setSsrRenderComplete = (ssrRenderComplete) =>
-    this.setState({
-      ssrRenderComplete,
-    });
-
-  componentDidMount() {
-    this.setSsrRenderComplete(true);
-  }
+  renderRoute = (props) => {
+    return <RouteHandler route={props} isSSR={!!this.props.ssrState} />;
+  };
 
   render() {
     const { path, Router, graphQLClient } = this.props;
 
     return (
       <ApolloProvider client={graphQLClient}>
-        <SitecoreContext componentFactory={componentFactory} context={this.sitecoreContext}>
+        <SitecoreContext componentFactory={componentFactory} layoutData={this.props.ssrState}>
           <Router location={path} context={{}}>
             <Switch>
-              {routePatterns.map((routePattern) => (
-                <Route
-                  key={routePattern}
-                  path={routePattern}
-                  render={(props) => (
-                    <RouteHandler route={props} ssrRenderComplete={this.state.ssrRenderComplete} />
-                  )}
-                />
-              ))}
+              <Route path="/:lang([a-z]{2}-[A-Z]{2})/:sitecoreRoute*" render={this.renderRoute} />
+              <Route path="/:lang([a-z]{2})/:sitecoreRoute*" render={this.renderRoute} />
+              <Route path="/:sitecoreRoute*" render={this.renderRoute} />
             </Switch>
           </Router>
         </SitecoreContext>

--- a/samples/react/src/Layout.js
+++ b/samples/react/src/Layout.js
@@ -79,6 +79,8 @@ const Layout = ({ route }) => (
   </React.Fragment>
 );
 
+// We don't want to re-render `Layout` when route is changed but layout data is not loaded
+// Layout will be re-rendered only when layout data is changed
 const propsAreEqual = (prevProps, nextProps) => {
   if (deepEqual(prevProps.route, nextProps.route)) return true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* `<SitecoreContext/>` from `sitecore-jss-react` package should have exact type for `context` state
* React sample should work as expected in connected/headless/integrated modes
* Nextjs sample should work as expected using SSG/SSR modes
* `<Layout/>` component shouldn't run `render` when it's unnecessary
* (Additional issue which I noticed and fixed) Previously when you tried to switch language on the /styleguide page react re-rendered `<Layout />` component twice. Now it's fixed and it was happening b\c we rendered array of routes, see https://github.com/Sitecore/jss/pull/841/files#diff-b6f3b4055f9147512d69014aa8a1d1df8d4c129713f504a4ca597c75e224bb49R37-R39
`updateSitecoreContext` should trigger update for layout. Test it using:
// withSitecoreContext({ updatable: true }); 
// this.props.updateSitecoreContext(freshLayoutData);

## BREAKING CHANGE
* SitecoreContext accepts `layoutData` instead of `context`
* SitecoreContext has strict state type instead of `any`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
