### PR TITLE
Prettier issue when performing jss build or jss deploy using long prefix

### DIFF
--- a/packages/sitecore-jss-angular/src/public_api.ts
+++ b/packages/sitecore-jss-angular/src/public_api.ts
@@ -41,15 +41,11 @@ export {
   ComponentFields,
   ComponentParams,
 } from '@sitecore-jss/sitecore-jss/layout';
-export {
-  constants,
-  HttpDataFetcher,
-  HttpResponse
-} from '@sitecore-jss/sitecore-jss';
+export { constants, HttpDataFetcher, HttpResponse } from '@sitecore-jss/sitecore-jss';
 export {
   isServer,
   isExperienceEditorActive,
   resetExperienceEditorChromes,
   isEditorActive,
-  resetEditorChromes, }
-  from '@sitecore-jss/sitecore-jss/utils'
+  resetEditorChromes,
+} from '@sitecore-jss/sitecore-jss/utils';

--- a/packages/sitecore-jss-cli/src/create/index.ts
+++ b/packages/sitecore-jss-cli/src/create/index.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import glob from 'glob';
 import path from 'path';
+import runPackageScript from '../run-package-script';
 
 interface PackageJsonConfig {
   appName: string;
@@ -120,6 +121,10 @@ export function applyNameToProject(
     });
 
   replacePrefix(projectFolder, name, replaceName, withPrefix);
+
+  // fix any lint errors created by replacePrefix
+  console.log(chalk.cyan('Fixing potential linting errors...'));
+  runPackageScript(['lint', '--fix'], { cwd: projectFolder, encoding: 'utf-8' });
 }
 
 /**

--- a/samples/nextjs/.eslintrc
+++ b/samples/nextjs/.eslintrc
@@ -5,8 +5,8 @@
     "next/core-web-vitals",
     "plugin:@typescript-eslint/recommended",
     "prettier/@typescript-eslint",
-    "plugin:prettier/recommended",
-    "plugin:yaml/recommended"
+    "plugin:yaml/recommended",
+    "plugin:prettier/recommended"
   ],
   "plugins": [
     "@typescript-eslint",

--- a/samples/react/.eslintrc
+++ b/samples/react/.eslintrc
@@ -4,9 +4,9 @@
     "prettier",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:prettier/recommended",
     "plugin:react/recommended",
-    "plugin:yaml/recommended"
+    "plugin:yaml/recommended",
+    "plugin:prettier/recommended"
   ],
   "parser": "babel-eslint",
   "parserOptions": {


### PR DESCRIPTION
- add lint --fix to create after replace prefix
- fix lint error in angular package
- reorder .eslintrc prettier plugin

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
fix `jss create`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
ran `jss create very-long-appname-that-will-surely-cause-problems app --source .` with fix applied, then built resulting code successfully.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
