### PR TITLE
[Next.js] Preview Mode doesn't work with fallback: false on Vercel

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/editing-render-middleware.ts
@@ -124,11 +124,22 @@ export class EditingRenderMiddleware {
       // Note timestamp effectively disables caching the request in Axios (no amount of cache headers seemed to do it)
       const requestUrl = this.resolvePageUrl(serverUrl, editingData.path);
       debug.experienceEditor('fetching page route for %s', editingData.path);
-      const pageRes = await this.dataFetcher.get<string>(`${requestUrl}?timestamp=${Date.now()}`, {
-        headers: {
-          Cookie: cookies.join(';'),
-        },
-      });
+      const pageRes = await this.dataFetcher
+        .get<string>(`${requestUrl}?timestamp=${Date.now()}`, {
+          headers: {
+            Cookie: cookies.join(';'),
+          },
+        })
+        .catch((err) => {
+          // We need to handle not found error provided by Vercel
+          // for `fallback: false` pages
+          if (err.response.status === 404) {
+            return err.response;
+          }
+
+          throw err;
+        });
+
       let html = pageRes.data;
       if (!html || html.length === 0) {
         throw new Error(`Failed to render html for ${requestUrl}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Handle 404 error from Vercel when we use `fallback: false`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
