### PR TITLE
[JSS][NextJS] - fix: Prevent passing internalLinkMatcher prop

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -3,7 +3,7 @@ import { NextRouter } from 'next/router';
 import NextLink from 'next/link';
 import { Link as ReactLink } from '@sitecore-jss/sitecore-jss-react';
 import { use, expect, spy } from 'chai';
-import { mount } from 'enzyme';
+import { mount, render } from 'enzyme';
 import spies from 'chai-spies';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import { Link } from './Link';
@@ -229,6 +229,34 @@ describe('<Link />', () => {
     );
     expect(rendered.find(NextLink).length).to.equal(0);
     expect(rendered.find(ReactLink).length).to.equal(1);
+  });
+
+  it('should prevent passing internalLinkMatcher to ReactLink', () => {
+    const field = {
+      value: {
+        href: 'http://jssreactweb/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    const rendered = mount(
+      <Page>
+        <Link
+          field={field}
+          showLinkTextWithChildrenPresent
+          internalLinkMatcher={/^http:\/\/doc.sitecore.com/g}
+        >
+          <p>Hello world...</p>
+        </Link>
+      </Page>
+    );
+    expect(rendered.find(NextLink).length).to.equal(0);
+    expect(rendered.find(ReactLink).length).to.equal(1);
+
+    const link = rendered.find('a');
+    expect(link.html()).not.to.contain('internallinkmatcher');
   });
 
   it('should render ReactLink if href not exists', () => {

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -48,7 +48,11 @@ export const Link = (props: LinkProps): JSX.Element => {
     }
   }
 
-  return <ReactLink {...htmlLinkProps} editable={editable} showLinkTextWithChildrenPresent={showLinkTextWithChildrenPresent} />;
+  // prevent passing internalLinkMatcher as it is an invalid DOM element prop
+  const reactLinkProps = { ...props };
+  delete reactLinkProps.internalLinkMatcher;
+
+  return <ReactLink {...reactLinkProps} />;
 };
 
 Link.defaultProps = {

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -48,7 +48,7 @@ export const Link = (props: LinkProps): JSX.Element => {
     }
   }
 
-  return <ReactLink {...props} />;
+  return <ReactLink {...htmlLinkProps} editable={editable} showLinkTextWithChildrenPresent={showLinkTextWithChildrenPresent} />;
 };
 
 Link.defaultProps = {


### PR DESCRIPTION
Prevented passing `internalLinkMatcher` prop to React Link component as it is an invalid HTML element prop.

## Description / Motivation
While attempting to use a custom link matcher (`/^\/|^\#/g`) to allow internal anchor links, an error occurred for all non-internal link values used in the same component.

When a non-internal link is detected, it attempts to pass all props, including the unused `internalLinkMatcher` to the JSS React Link component, which then attempts to print it onto the anchor link, resulting in the following error:
```
Warning: React does not recognize the `internalLinkMatcher` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `internallinkmatcher` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

We can prevent this error by simply not passing the prop to the JSS React Link component.

## Testing Details
Tested by utilizing forked version of JSS in existing project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)
