### PR TITLE
Fix line parsed as HTML

### DIFF
--- a/samples/nextjs/data/routes/en.yml
+++ b/samples/nextjs/data/routes/en.yml
@@ -49,7 +49,7 @@ placeholders:
 
           <div class="alert alert-dark">
             <h4>How to start with an empty app</h4>
-            <p>To start with a fresh app with no boilerplate, run <code>jss create <name of your app> nextjs --empty</code>. Note, disconnected mode is not supported this way</p>
+            <p>To start with a fresh app with no boilerplate, run <code>jss create {name of your app} nextjs --empty</code>. Note, disconnected mode is not supported this way</p>
             <p>To remove all of the default sample content (the Styleguide and GraphQL routes) and start out with an empty JSS app:</p>
             <ol>
               <li>Delete <code>/data/dictionary/*.yml</code></li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Nextjs styleguide homepage has a code snippet that I believe is being parsed as HTML, change to curly brackets to fix this.
## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
