### PR TITLE
[React] Support for custom components in field-factory.tsx

### DIFF
--- a/packages/sitecore-jss-react-forms/src/field-factory.tsx
+++ b/packages/sitecore-jss-react-forms/src/field-factory.tsx
@@ -29,7 +29,7 @@ class FieldFactory {
     this._defaultComponent = component;
   }
 
-  setComponent<TProps extends FieldProps>(type: FieldTypes, component: FormFieldComponent<TProps>) {
+  setComponent<TProps extends FieldProps>(type: FieldTypes | string, component: FormFieldComponent<TProps>) {
     this._fieldMap.set(type, component);
   }
 


### PR DESCRIPTION
## Description / Motivation
Support for custom forms components in field-factory.tsx I am trying to add a custom react component to the jss-react-forms with typescript. The method definition only allows of type FieldTypes Enum that cannot be extended and We cannot pass a custom component implementation. Internally its a map that takes string and react component. String value is the GUID of the field type.

I have added optional string to the method definition so it can be FieldTypes for OOB fields and custom field can be added with the "{guid}" string format.

I am not sure if this has to go into  Sitecore:release/18.0.0 if this is maintained internally. Please include this fix.

## Testing Details
Sitecore 10.1 JSS SXA Docker environment
In my local instance I am using this approach and it works.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
