### PR TITLE
[Typescript] Bug fix to allow custom components

### DIFF
--- a/packages/sitecore-jss-react-forms/src/field-factory.tsx
+++ b/packages/sitecore-jss-react-forms/src/field-factory.tsx
@@ -28,7 +28,7 @@ class FieldFactory {
     this._defaultComponent = component;
   }
 
-  setComponent<TProps extends FieldProps>(type: FieldTypes, component: FormFieldComponent<TProps>) {
+  setComponent<TProps extends FieldProps>(type: FieldTypes | string, component: FormFieldComponent<TProps>) {
     this._fieldMap.set(type, component as React.ComponentType<unknown>);
   }
 


### PR DESCRIPTION
## Description / Motivation
Support for custom components in field-factory.tsx I am trying to add a custom react component to the jss-react-forms and relying on typescript.
The method definition only allows of type FieldTypes Enum and I dont have an override to pass my custom component implementation. Internally its a map that takes string and react component for that type.

I have added string so it can be FieldTypes for OOB field and custom field can be added with the {guid} string.

## Testing Details
Sitecore 10.1 JSS SXA Docker environment Typescript
In my local instance I am using this approach and it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
