### PR TITLE
[Next.js] Remove withSitecoreContext HOC from `Layout.tsx`

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -30,7 +30,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@sitecore-jss/sitecore-jss-nextjs": "^20.0.0-canary",
-    "deep-equal": "^2.0.5",
     "graphql": "~15.4.0",
     "graphql-tag": "^2.11.0",
     "next": "^12.0.4",
@@ -47,7 +46,6 @@
     "@graphql-codegen/typescript-resolvers": "^1.17.10",
     "@graphql-typed-document-node/core": "^3.1.0",
     "@sitecore-jss/sitecore-jss-cli": "^20.0.0-canary",
-    "@types/deep-equal": "^1.0.1",
     "@types/node": "^14.6.4",
     "@types/react": "^17.0.15",
     "@types/react-dom": "^17.0.9",

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Head from 'next/head';
-import deepEqual from 'deep-equal';
 import {
   Placeholder,
   VisitorIdentification,
@@ -50,11 +49,4 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
   );
 };
 
-const propsAreEqual = (prevProps: LayoutProps, nextProps: LayoutProps) => {
-  if (deepEqual(prevProps.layoutData.sitecore.route, nextProps.layoutData.sitecore.route))
-    return true;
-
-  return false;
-};
-
-export default React.memo(Layout, propsAreEqual);
+export default Layout;

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
@@ -4,9 +4,8 @@ import deepEqual from 'deep-equal';
 import {
   Placeholder,
   VisitorIdentification,
-  withSitecoreContext,
   getPublicUrl,
-  SitecoreContextValue,
+  LayoutServiceData,
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import Navigation from 'src/Navigation';
 
@@ -15,14 +14,14 @@ import Navigation from 'src/Navigation';
 const publicUrl = getPublicUrl();
 
 interface LayoutProps {
-  sitecoreContext: SitecoreContextValue;
+  layoutData: LayoutServiceData;
 }
 
-const Layout = ({ sitecoreContext: { route } }: LayoutProps): JSX.Element => {
+const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
   return (
     <>
       <Head>
-        <title>{route?.fields?.pageTitle?.value || 'Page'}</title>
+        <title>{layoutData.sitecore.route?.fields?.pageTitle?.value || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
 
@@ -38,16 +37,22 @@ const Layout = ({ sitecoreContext: { route } }: LayoutProps): JSX.Element => {
       <Navigation />
       {/* root placeholder for the app, which we add components to using route data */}
       <div className="container">
-        {route && <Placeholder name="<%- appPrefix ? `${appName}-` : '' %>jss-main" rendering={route} />}
+        {layoutData.sitecore.route && (
+          <Placeholder
+            name="<%- appPrefix ? `${appName}-` : '' %>jss-main"
+            rendering={layoutData.sitecore.route}
+          />
+        )}
       </div>
     </>
   );
 };
 
 const propsAreEqual = (prevProps: LayoutProps, nextProps: LayoutProps) => {
-  if (deepEqual(prevProps.sitecoreContext.route, nextProps.sitecoreContext.route)) return true;
+  if (deepEqual(prevProps.layoutData.sitecore.route, nextProps.layoutData.sitecore.route))
+    return true;
 
   return false;
 };
 
-export default withSitecoreContext()(React.memo(Layout, propsAreEqual));
+export default React.memo(Layout, propsAreEqual);

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
@@ -39,10 +39,7 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
       {/* root placeholder for the app, which we add components to using route data */}
       <div className="container">
         {route && (
-          <Placeholder
-            name="<%- appPrefix ? `${appName}-` : '' %>jss-main"
-            rendering={route}
-          />
+          <Placeholder name="<%- appPrefix ? `${appName}-` : '' %>jss-main" rendering={route} />
         )}
       </div>
     </>

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/Layout.tsx
@@ -18,10 +18,12 @@ interface LayoutProps {
 }
 
 const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
+  const { route } = layoutData.sitecore;
+
   return (
     <>
       <Head>
-        <title>{layoutData.sitecore.route?.fields?.pageTitle?.value || 'Page'}</title>
+        <title>{route?.fields?.pageTitle?.value || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
 
@@ -37,10 +39,10 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
       <Navigation />
       {/* root placeholder for the app, which we add components to using route data */}
       <div className="container">
-        {layoutData.sitecore.route && (
+        {route && (
           <Placeholder
             name="<%- appPrefix ? `${appName}-` : '' %>jss-main"
-            rendering={layoutData.sitecore.route}
+            rendering={route}
           />
         )}
       </div>

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -32,7 +32,7 @@ const SitecorePage = ({ notFound, componentProps, layoutData }: SitecorePageProp
   return (
     <ComponentPropsContext value={componentProps}>
       <SitecoreContext componentFactory={componentFactory} layoutData={layoutData}>
-        <Layout />
+        <Layout layoutData={layoutData} />
       </SitecoreContext>
     </ComponentPropsContext>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Removing `withSitecoreContext` from the `Layout.tsx` because it's should be used in case if somebody updates context using `updateSitecoreContext`, but in the sample we don't use such approach

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
