### PR TITLE
Initializer fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ For the creation of the samples we are using `initializers` approach.
 
 - `initializer` - the process for handling the creation of the appropriate template. See [initializers](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss/src/initializers).
 - `template` - the sample populated by [ejs](https://ejs.co/) tokens. See [templates](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss/src/templates). Templates can be:
-	- `base` - the template that contains foundation for the application (e.g. *nextjs*).
-	- `feature` - the template that provides specific feature for the base template. Multiple *feature* templates can be applied to the *base* (e.g. *nextjs-styleguide*).
+	- `base` - contains foundation for the application (e.g. *nextjs*).
+	- `add-on` - provides additional features for the base template. Multiple *add-on* templates can be applied to the *base* (e.g. *nextjs-styleguide*).
 
 If you want to use [*create-sitecore-jss*](https://github.com/Sitecore/jss/tree/dev/packages/create-sitecore-jss) from your local repository, run:
 

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -23,10 +23,22 @@ const main = async () => {
     templates = [argv._[0]];
   } else {
     // use --templates arg
-    templates = argv.templates?.split(',') || [];
+    templates = (argv.templates && argv.templates.split(/[\s,]+/)) || [];
   }
-  const baseTemplates = await getBaseTemplates(path.resolve(__dirname, 'templates'));
+
   // validate/gather templates
+  const baseTemplates = await getBaseTemplates(path.resolve(__dirname, 'templates'));
+  if (templates.length > 0) {
+    const validTemplates: string[] = [];
+    templates.forEach((template) => {
+      if (baseTemplates.includes(template)) {
+        validTemplates.push(template);
+      } else {
+        console.log(chalk.yellow(`Ignoring uknown template '${template}'...`));
+      }
+    });
+    templates = validTemplates;
+  }
   if (!templates.length) {
     const answer = await prompt({
       type: 'list',

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -36,11 +36,12 @@ const main = async () => {
   }
 
   // validate/gather templates
-  const baseTemplates = await getBaseTemplates(path.resolve(__dirname, 'templates'));
+  const templatePath = path.resolve(__dirname, 'templates');
   if (templates.length > 0) {
+    const allTemplates = fs.readdirSync(templatePath, 'utf8');
     const validTemplates: string[] = [];
     templates.forEach((template) => {
-      if (baseTemplates.includes(template)) {
+      if (allTemplates.includes(template)) {
         validTemplates.push(template);
       } else {
         console.log(chalk.yellow(`Ignoring uknown template '${template}'...`));
@@ -49,6 +50,7 @@ const main = async () => {
     templates = validTemplates;
   }
   if (!templates.length) {
+    const baseTemplates = await getBaseTemplates(templatePath);
     const answer = await prompt({
       type: 'list',
       name: 'template',

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -31,7 +31,7 @@ const main = async () => {
     const answer = await prompt({
       type: 'list',
       name: 'template',
-      message: 'Which templates would you like to create?',
+      message: 'Which template would you like to create?',
       choices: baseTemplates,
       default: 'nextjs',
     });

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -44,7 +44,7 @@ const main = async () => {
       if (allTemplates.includes(template)) {
         validTemplates.push(template);
       } else {
-        console.log(chalk.yellow(`Ignoring uknown template '${template}'...`));
+        console.log(chalk.yellow(`Ignoring unknown template '${template}'...`));
       }
     });
     templates = validTemplates;

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -10,8 +10,17 @@ import { getBaseTemplates } from './common/utils/helpers';
 // parse any command line arguments passed into `init sitecore-jss`
 // to pass to the generator prompts and skip them.
 // useful for CI and testing purposes
-const argv: ParsedArgs = parseArgs(process.argv.slice(2), {
-  boolean: ['appPrefix', 'force', 'noInstall', 'yes'],
+const options = {
+  boolean: ['appPrefix', 'force', 'noInstall', 'yes', 'silent'],
+  string: ['appName', 'destination', 'templates', 'hostName', 'fetchWith', 'language'],
+};
+const argv: ParsedArgs = parseArgs(process.argv.slice(2), options);
+
+// we need to coerce string parameters in minimist above (to prevent string options without a value e.g. `--appName` from coming in as a boolean `true`).
+// however, coersion will result in an empty string and inquirer will treat this as a valid answer value (and not prompt!).
+// we need to go back through and remove these to prevent this.
+options.string.forEach((key) => {
+  argv[key] === '' && delete argv[key];
 });
 
 const main = async () => {

--- a/packages/create-sitecore-jss/src/init-runner.ts
+++ b/packages/create-sitecore-jss/src/init-runner.ts
@@ -21,7 +21,7 @@ export const initRunner = async (initializers: string[], args: BaseArgs) => {
       appName = response.appName;
       nextStepsArr = [...nextStepsArr, ...(response.nextSteps ?? [])];
 
-      // process any (post) initializers
+      // process any (feature) initializers
       if (response.initializers && response.initializers.length > 0) {
         await runner(response.initializers);
       }

--- a/packages/create-sitecore-jss/src/init-runner.ts
+++ b/packages/create-sitecore-jss/src/init-runner.ts
@@ -21,7 +21,7 @@ export const initRunner = async (initializers: string[], args: BaseArgs) => {
       appName = response.appName;
       nextStepsArr = [...nextStepsArr, ...(response.nextSteps ?? [])];
 
-      // process any (feature) initializers
+      // process any returned initializers
       if (response.initializers && response.initializers.length > 0) {
         await runner(response.initializers);
       }

--- a/packages/create-sitecore-jss/src/initializers/angular/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/index.ts
@@ -19,6 +19,7 @@ export default class AngularInitializer implements Initializer {
           fetchWith: FetchWith.REST,
           hostName: 'sitecore-jss-angular.dev.local',
           appPrefix: false,
+          language: 'da-DK',
         }
       : {};
 

--- a/packages/create-sitecore-jss/src/initializers/angular/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/index.ts
@@ -23,7 +23,7 @@ export default class AngularInitializer implements Initializer {
         }
       : {};
 
-    const answers = await prompt<AngularAnswer>(prompts, { ...args, ...defaults });
+    const answers = await prompt<AngularAnswer>(prompts, { ...defaults, ...args });
 
     const mergedArgs = {
       ...args,

--- a/packages/create-sitecore-jss/src/initializers/nextjs-styleguide/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-styleguide/index.ts
@@ -22,7 +22,14 @@ export default class NextjsStyleguideInitializer implements Initializer {
       process.exit(1);
     }
 
+    const defaults = args.yes
+      ? {
+          language: 'da-DK',
+        }
+      : {};
+
     const answers = await prompt<StyleguideAnswer>(styleguidePrompts, {
+      ...defaults,
       ...args,
     });
 

--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -36,9 +36,9 @@ export default class NextjsInitializer implements Initializer {
 
     let featureInitializers: string[] = [];
 
-    // don't prompt for feature initializers if they've already specified
+    // don't prompt for feature initializers if --yes or they've already specified
     // multiple via --templates (assume they know what they're doing)
-    if (args.templates.length === 1) {
+    if (!args.yes && args.templates.length === 1) {
       const featureInitAnswer = await prompt({
         type: 'checkbox',
         name: 'featureInitializers',

--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -34,24 +34,24 @@ export default class NextjsInitializer implements Initializer {
       removeDevDependencies(args.destination);
     }
 
-    let featureInitializers: string[] = [];
+    let addInitializers: string[] = [];
 
-    // don't prompt for feature initializers if --yes or they've already specified
+    // don't prompt for add-on initializers if --yes or they've already specified
     // multiple via --templates (assume they know what they're doing)
     if (!args.yes && args.templates.length === 1) {
-      const featureInitAnswer = await prompt({
+      const addInitAnswer = await prompt({
         type: 'checkbox',
-        name: 'featureInitializers',
-        message: 'Would you like to add any feature initializers?',
+        name: 'addInitializers',
+        message: 'Would you like to include any add-on initializers?',
         choices: ['nextjs-styleguide'],
       });
-      featureInitializers = featureInitAnswer.featureInitializers;
+      addInitializers = addInitAnswer.addInitializers;
     }
 
     const response = {
       nextSteps: [`* Connect to Sitecore with ${chalk.green('jss setup')} (optional)`],
       appName: answers.appName,
-      initializers: featureInitializers,
+      initializers: addInitializers,
     };
 
     return response;

--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -34,24 +34,24 @@ export default class NextjsInitializer implements Initializer {
       removeDevDependencies(args.destination);
     }
 
-    let postInitializers: string[] = [];
+    let featureInitializers: string[] = [];
 
-    // don't prompt for post-initializers if they've already specified
+    // don't prompt for feature initializers if they've already specified
     // multiple via --templates (assume they know what they're doing)
     if (args.templates.length === 1) {
-      const postInitAnswer = await prompt({
+      const featureInitAnswer = await prompt({
         type: 'checkbox',
-        name: 'postInitializers',
-        message: 'Would you like to add any post-initializers?',
+        name: 'featureInitializers',
+        message: 'Would you like to add any feature initializers?',
         choices: ['nextjs-styleguide'],
       });
-      postInitializers = postInitAnswer.postInitializers;
+      featureInitializers = featureInitAnswer.featureInitializers;
     }
 
     const response = {
       nextSteps: [`* Connect to Sitecore with ${chalk.green('jss setup')} (optional)`],
       appName: answers.appName,
-      initializers: postInitializers,
+      initializers: featureInitializers,
     };
 
     return response;

--- a/packages/create-sitecore-jss/src/initializers/react-native/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react-native/index.ts
@@ -15,7 +15,6 @@ export default class ReactNativeInitializer implements Initializer {
       ? {
           appName: 'sitecore-jss-react-native',
           hostName: 'sitecore-jss-react-native.dev.local',
-          appPrefix: false,
           language: 'da-DK',
         }
       : {};

--- a/packages/create-sitecore-jss/src/initializers/react-native/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react-native/index.ts
@@ -15,6 +15,8 @@ export default class ReactNativeInitializer implements Initializer {
       ? {
           appName: 'sitecore-jss-react-native',
           hostName: 'sitecore-jss-react-native.dev.local',
+          appPrefix: false,
+          language: 'da-DK',
         }
       : {};
 

--- a/packages/create-sitecore-jss/src/initializers/react/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react/index.ts
@@ -19,6 +19,7 @@ export default class ReactInitializer implements Initializer {
           fetchWith: FetchWith.REST,
           hostName: 'sitecore-jss-react.dev.local',
           appPrefix: false,
+          language: 'da-DK',
         }
       : {};
 

--- a/packages/create-sitecore-jss/src/initializers/vue/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/vue/index.ts
@@ -19,6 +19,7 @@ export default class VueInitializer implements Initializer {
           hostName: 'sitecore-jss-vue.dev.local',
           fetchWith: FetchWith.REST,
           appPrefix: false,
+          language: 'da-DK',
         }
       : {};
 

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-FieldUsage-Checkbox.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-FieldUsage-Checkbox.sitecore.js
@@ -9,7 +9,7 @@ import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore
 export default function (manifest) {
   manifest.addComponent({
     name: 'Styleguide-FieldUsage-Checkbox',
-    templateName: '<%- helper.getAppPrefix(appPrefix, appName, false) %>Styleguide-FieldUsage-Checkbox',
+    templateName: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-FieldUsage-Checkbox',
     icon: SitecoreIcon.CheckboxSelected,
     fields: [
       { name: 'checkbox', type: CommonFieldTypes.Checkbox },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
This includes a batch of fixes for issues found during QA of initializers.

- 513110 Added early validation of provided templates, ignoring unknown. Provides better UX and alleviates some of the pain with npm 8.3.x option forwarding (not working with npm init/create)
- 513126 Added coercion of string parameters
- 513131 `--yes` handling for language and add-on initializers
- 513796 fixed app prefix missing hyphen for React `Styleguide-FieldUsage-Checkbox.sitecore.js`
- 513797 513797 fixed angular defaults/args precedence
- Misc language fixes

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
