### PR TITLE
Initializer fixes (round 2)

### DIFF
--- a/packages/create-sitecore-jss/src/common/prompts/base.ts
+++ b/packages/create-sitecore-jss/src/common/prompts/base.ts
@@ -1,23 +1,26 @@
 import chalk from 'chalk';
-import { DistinctQuestion } from 'inquirer';
+import { Answers, DistinctQuestion } from 'inquirer';
 
 export enum FetchWith {
   GraphQL = 'GraphQL',
   REST = 'REST',
 }
 
-export interface ClientAppAnswer {
+export interface ClientAppAnswer extends Answers {
   appName: string;
   fetchWith: FetchWith;
   hostName: string;
 }
 
-export const clientAppPrompts: DistinctQuestion[] = [
+export const DEFAULT_APPNAME = 'sitecore-jss-app';
+export const DEFAULT_FETCHWITH = FetchWith.GraphQL;
+
+export const clientAppPrompts: DistinctQuestion<ClientAppAnswer>[] = [
   {
     type: 'input',
     name: 'appName',
     message: 'What is the name of your app?',
-    default: 'sitecore-jss-app',
+    default: DEFAULT_APPNAME,
     validate: (input: string): boolean => {
       if (!/^[a-z\-_.]+$/.test(input)) {
         console.error(
@@ -29,18 +32,36 @@ export const clientAppPrompts: DistinctQuestion[] = [
       }
       return true;
     },
+    when: (answers: ClientAppAnswer): boolean => {
+      if (answers.yes && !answers.appName) {
+        answers.appName = DEFAULT_APPNAME;
+      }
+      return !answers.appName;
+    },
   },
   {
     type: 'input',
     name: 'hostName',
     message: 'What is your Sitecore hostname (used if deployed to Sitecore)?',
     default: (answers: ClientAppAnswer) => `${answers.appName}.dev.local`,
+    when: (answers: ClientAppAnswer): boolean => {
+      if (answers.yes && !answers.hostName) {
+        answers.hostName = `${answers.appName}.dev.local`;
+      }
+      return !answers.hostName;
+    },
   },
   {
     type: 'list',
     name: 'fetchWith',
     message: 'How would you like to fetch Layout and Dictionary data?',
     choices: Object.values(FetchWith),
-    default: FetchWith.GraphQL,
+    default: DEFAULT_FETCHWITH,
+    when: (answers: ClientAppAnswer): boolean => {
+      if (answers.yes && !answers.fetchWith) {
+        answers.fetchWith = DEFAULT_FETCHWITH;
+      }
+      return !answers.fetchWith;
+    },
   },
 ];

--- a/packages/create-sitecore-jss/src/common/prompts/styleguide.ts
+++ b/packages/create-sitecore-jss/src/common/prompts/styleguide.ts
@@ -6,6 +6,7 @@ export interface StyleguideAnswer extends Answers {
 }
 
 const LANGUAGE_REGEXP = /^(([a-z]{2}-[A-Z]{2})|([a-z]{2}))$/;
+const DEFAULT_LANGUAGE = 'da-DK';
 
 export const styleguidePrompts: DistinctQuestion<StyleguideAnswer>[] = [
   {
@@ -13,7 +14,7 @@ export const styleguidePrompts: DistinctQuestion<StyleguideAnswer>[] = [
     name: 'language',
     message:
       'Which additional language do you want to support (en is already included and required)?',
-    default: 'da-DK',
+    default: DEFAULT_LANGUAGE,
     validate: (input: string): boolean => {
       if (!LANGUAGE_REGEXP.test(input)) {
         console.error(
@@ -34,6 +35,12 @@ export const styleguidePrompts: DistinctQuestion<StyleguideAnswer>[] = [
       }
 
       return true;
+    },
+    when: (answers: StyleguideAnswer): boolean => {
+      if (answers.yes && !answers.language) {
+        answers.language = DEFAULT_LANGUAGE;
+      }
+      return !answers.language;
     },
   },
 ];

--- a/packages/create-sitecore-jss/src/index.ts
+++ b/packages/create-sitecore-jss/src/index.ts
@@ -29,7 +29,7 @@ const main = async () => {
   // check if templates were provided
   if (argv._.length > 0 && argv._[0] !== undefined) {
     // use positional parameter
-    templates = [argv._[0]];
+    templates = (argv._[0] && argv._[0].split(/[\s,]+/)) || [];
   } else {
     // use --templates arg
     templates = (argv.templates && argv.templates.split(/[\s,]+/)) || [];

--- a/packages/create-sitecore-jss/src/initializers/angular/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/index.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import { prompt } from 'inquirer';
 import { AngularArgs } from './args';
 import { AngularAnswer, prompts } from './prompts';
-import { FetchWith } from '../../common/prompts/base';
 import { Initializer } from '../../common/Initializer';
 import { transform } from '../../common/steps/transform';
 
@@ -13,17 +12,7 @@ export default class AngularInitializer implements Initializer {
   }
 
   async init(args: AngularArgs) {
-    const defaults = args.yes
-      ? {
-          appName: 'sitecore-jss-angular',
-          fetchWith: FetchWith.REST,
-          hostName: 'sitecore-jss-angular.dev.local',
-          appPrefix: false,
-          language: 'da-DK',
-        }
-      : {};
-
-    const answers = await prompt<AngularAnswer>(prompts, { ...defaults, ...args });
+    const answers = await prompt<AngularAnswer>(prompts, args);
 
     const mergedArgs = {
       ...args,

--- a/packages/create-sitecore-jss/src/initializers/nextjs-styleguide/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-styleguide/index.ts
@@ -4,6 +4,7 @@ import { prompt } from 'inquirer';
 import { Initializer } from '../../common/Initializer';
 import { isJssApp, openPackageJson } from '../../common/utils/helpers';
 import { transform } from '../../common/steps/index';
+import { DEFAULT_APPNAME } from '../../common/prompts/base';
 import { styleguidePrompts, StyleguideAnswer } from '../../common/prompts/styleguide';
 import { StyleguideArgs } from '../../common/args/styleguide';
 import { ClientAppArgs } from '../../common/args/base';
@@ -22,20 +23,11 @@ export default class NextjsStyleguideInitializer implements Initializer {
       process.exit(1);
     }
 
-    const defaults = args.yes
-      ? {
-          language: 'da-DK',
-        }
-      : {};
-
-    const answers = await prompt<StyleguideAnswer>(styleguidePrompts, {
-      ...defaults,
-      ...args,
-    });
+    const answers = await prompt<StyleguideAnswer>(styleguidePrompts, args);
 
     const mergedArgs = {
       ...args,
-      appName: args.appName || pkg?.config?.appName || 'default',
+      appName: args.appName || pkg?.config?.appName || DEFAULT_APPNAME,
       appPrefix: args.appPrefix || pkg?.config?.prefix || false,
       ...answers,
     };

--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -1,13 +1,12 @@
 import chalk from 'chalk';
 import path from 'path';
 import { prompt } from 'inquirer';
-import { prompts, NextjsAnswer, Prerender } from './prompts';
+import { prompts, NextjsAnswer } from './prompts';
 import { Initializer } from '../../common/Initializer';
 import { transform } from '../../common/steps';
 import { isDevEnvironment } from '../../common/utils/helpers';
 import { removeDevDependencies } from './remove-dev-dependencies';
 import { NextjsArgs } from './args';
-import { FetchWith } from '../../common/prompts/base';
 
 export default class NextjsInitializer implements Initializer {
   get isBase(): boolean {
@@ -15,17 +14,7 @@ export default class NextjsInitializer implements Initializer {
   }
 
   async init(args: NextjsArgs) {
-    const defaults = args.yes
-      ? {
-          appName: 'sitecore-jss-nextjs',
-          fetchWith: FetchWith.REST,
-          prerender: Prerender.SSG,
-          hostName: 'sitecore-jss-nextjs.dev.local',
-          appPrefix: false,
-        }
-      : {};
-
-    const answers = await prompt<NextjsAnswer>(prompts, { ...defaults, ...args });
+    const answers = await prompt<NextjsAnswer>(prompts, args);
 
     const templatePath = path.resolve(__dirname, '../../templates/nextjs');
     await transform(templatePath, { ...args, ...answers });

--- a/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
@@ -11,6 +11,8 @@ export interface NextjsAnswer extends ClientAppAnswer {
   prerender: Prerender;
 }
 
+const DEFAULT_PRERENDER = Prerender.SSG;
+
 export const prompts: QuestionCollection<NextjsAnswer> = [
   ...clientAppPrompts,
   {
@@ -18,6 +20,12 @@ export const prompts: QuestionCollection<NextjsAnswer> = [
     name: 'prerender',
     message: 'How would you like to prerender your application?',
     choices: Object.values(Prerender),
-    default: Prerender.SSG,
+    default: DEFAULT_PRERENDER,
+    when: (answers: NextjsAnswer): boolean => {
+      if (answers.yes && !answers.prerender) {
+        answers.prerender = DEFAULT_PRERENDER;
+      }
+      return !answers.prerender;
+    },
   },
 ];

--- a/packages/create-sitecore-jss/src/initializers/react-native/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react-native/index.ts
@@ -11,15 +11,7 @@ export default class ReactNativeInitializer implements Initializer {
   }
 
   async init(args: ReactNativeArgs) {
-    const defaults = args.yes
-      ? {
-          appName: 'sitecore-jss-react-native',
-          hostName: 'sitecore-jss-react-native.dev.local',
-          language: 'da-DK',
-        }
-      : {};
-
-    const answers = await prompt<ReactNativeAnswer>(prompts, { ...defaults, ...args });
+    const answers = await prompt<ReactNativeAnswer>(prompts, args);
 
     const mergedArgs = {
       ...args,

--- a/packages/create-sitecore-jss/src/initializers/react-native/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/react-native/prompts.ts
@@ -5,6 +5,6 @@ import { clientAppPrompts, ClientAppAnswer } from '../../common/prompts/base';
 export interface ReactNativeAnswer extends Omit<ClientAppAnswer, 'fetchWith'>, StyleguideAnswer {}
 
 export const prompts: QuestionCollection<ReactNativeAnswer> = [
-  ...clientAppPrompts.filter((p: DistinctQuestion) => p.name !== 'fetchWith'),
+  ...clientAppPrompts.filter((p: DistinctQuestion<ClientAppAnswer>) => p.name !== 'fetchWith'),
   ...styleguidePrompts,
 ];

--- a/packages/create-sitecore-jss/src/initializers/react/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react/index.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import { prompt } from 'inquirer';
 import { Initializer } from '../../common/Initializer';
 import { transform } from '../../common/steps';
-import { FetchWith } from '../../common/prompts/base';
 import { prompts, ReactAnswer } from './prompts';
 import { ReactArgs } from './args';
 
@@ -13,17 +12,7 @@ export default class ReactInitializer implements Initializer {
   }
 
   async init(args: ReactArgs) {
-    const defaults = args.yes
-      ? {
-          appName: 'sitecore-jss-react',
-          fetchWith: FetchWith.REST,
-          hostName: 'sitecore-jss-react.dev.local',
-          appPrefix: false,
-          language: 'da-DK',
-        }
-      : {};
-
-    const answers = await prompt<ReactAnswer>(prompts, { ...defaults, ...args });
+    const answers = await prompt<ReactAnswer>(prompts, args);
 
     const mergedArgs = {
       ...args,

--- a/packages/create-sitecore-jss/src/initializers/vue/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/vue/index.ts
@@ -4,7 +4,6 @@ import { prompts, VueAnswer } from './prompts';
 import { Initializer } from '../../common/Initializer';
 import { transform } from '../../common/steps';
 import { VueArgs } from './args';
-import { FetchWith } from '../../common/prompts/base';
 import chalk from 'chalk';
 
 export default class VueInitializer implements Initializer {
@@ -13,17 +12,7 @@ export default class VueInitializer implements Initializer {
   }
 
   async init(args: VueArgs) {
-    const defaults = args.yes
-      ? {
-          appName: 'sitecore-jss-vue',
-          hostName: 'sitecore-jss-vue.dev.local',
-          fetchWith: FetchWith.REST,
-          appPrefix: false,
-          language: 'da-DK',
-        }
-      : {};
-
-    const answers = await prompt<VueAnswer>(prompts, { ...defaults, ...args });
+    const answers = await prompt<VueAnswer>(prompts, args);
 
     const mergedArgs = {
       ...args,


### PR DESCRIPTION
## Description / Motivation
Another round of fixes addressing the following:

- 514353 Fix inconsistency with default values applied in `--yes` mode across initializers. Responsibility is now owned by the individual prompts themselves (using inquirer "when").
- 514355 Handle multiple templates on positional parameter as well

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
