### PR TITLE
[RAV] Change the classname of ContentBlock from display-4 to contentTitle

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/content-block/content-block.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/content-block/content-block.component.html
@@ -1,4 +1,4 @@
 <div class="contentBlock">
-  <h2 class="display-4" *scText="rendering.fields.heading"></h2>
+  <h2 class="contentTitle" *scText="rendering.fields.heading"></h2>
   <div class="contentDescription" *scRichText="rendering.fields.content"></div>
 </div>

--- a/packages/create-sitecore-jss/src/templates/angular/src/styles.css
+++ b/packages/create-sitecore-jss/src/templates/angular/src/styles.css
@@ -15,3 +15,12 @@ a[target='_blank']:after {
   are set to edit mode.
 */
 .scChromeData, .scpm { display: none !important; }
+
+/* 
+  Style for default content block
+*/
+.contentTitle {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}

--- a/packages/create-sitecore-jss/src/templates/react/src/assets/app.css
+++ b/packages/create-sitecore-jss/src/templates/react/src/assets/app.css
@@ -8,3 +8,12 @@ a[target='_blank']:after {
   are set to edit mode.
 */
 .scChromeData, .scpm { display: none !important; }
+
+/* 
+  Style for default content block
+*/
+.contentTitle {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}

--- a/packages/create-sitecore-jss/src/templates/react/src/components/ContentBlock/index.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/components/ContentBlock/index.js
@@ -8,7 +8,7 @@ import { Text, RichText } from '@sitecore-jss/sitecore-jss-react';
  */
 const ContentBlock = ({ fields }) => (
   <div className="contentBlock">
-    <Text tag="h2" className="display-4" field={fields.heading} />
+    <Text tag="h2" className="contentTitle" field={fields.heading} />
 
     <RichText className="contentDescription" field={fields.content} />
   </div>

--- a/packages/create-sitecore-jss/src/templates/vue/src/assets/app.css
+++ b/packages/create-sitecore-jss/src/templates/vue/src/assets/app.css
@@ -11,3 +11,12 @@ a[target='_blank']:after {
 .scpm {
   display: none !important;
 }
+
+/* 
+  Style for default content block
+*/
+.contentTitle {
+  font-size: 3.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}

--- a/packages/create-sitecore-jss/src/templates/vue/src/components/ContentBlock.vue
+++ b/packages/create-sitecore-jss/src/templates/vue/src/components/ContentBlock.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="contentBlock">
-    <sc-text tag="h2" class="display-4" :field="fields.heading" />
+    <sc-text tag="h2" class="contentTitle" :field="fields.heading" />
     <sc-rich-text class="contentDescription" :field="fields.content" />
   </div>
 </template>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* NextJS tests are failing because we are validating the ContentBlock content by checking the classname
* We should have same the classname for each framework
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
