### PR TITLE
[Initializers] Remove `inherit` stdio setting

### DIFF
--- a/packages/create-sitecore-jss/src/common/processes/install.ts
+++ b/packages/create-sitecore-jss/src/common/processes/install.ts
@@ -30,6 +30,7 @@ export const installPackages = (projectFolder: string, silent?: boolean) => {
       {
         cwd: projectFolder,
         encoding: 'utf8',
+        stdio: 'pipe',
       },
       silent
     );

--- a/packages/create-sitecore-jss/src/common/processes/install.ts
+++ b/packages/create-sitecore-jss/src/common/processes/install.ts
@@ -30,7 +30,6 @@ export const installPackages = (projectFolder: string, silent?: boolean) => {
       {
         cwd: projectFolder,
         encoding: 'utf8',
-        stdio: 'pipe',
       },
       silent
     );

--- a/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
+++ b/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
@@ -53,7 +53,6 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
-          stdio: 'inherit',
         })
       ).to.equal(true);
     });
@@ -75,7 +74,6 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
-          stdio: 'inherit',
         })
       ).to.equal(true);
 
@@ -103,7 +101,6 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
-          stdio: 'inherit',
         })
       ).to.equal(true);
 

--- a/packages/create-sitecore-jss/src/common/utils/cmd.ts
+++ b/packages/create-sitecore-jss/src/common/utils/cmd.ts
@@ -27,7 +27,7 @@ export const spawnFunc = (
   args: string[],
   options?: SpawnSyncOptionsWithStringEncoding
 ) => {
-  const result = spawn.sync(command, args, Object.assign({ stdio: 'inherit' }, options));
+  const result = spawn.sync(command, args, Object.assign({}, options));
 
   if (result.signal === 'SIGKILL') {
     console.log(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
`npm i` hangs if `create-sitecore-jss` is executed from the powershell script. Pipe uses parent's std channel, `inherit` can't be used
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
