### PR TITLE
[NextJS] Can't start app in disconnected mode, throws webpack `fallback` option error

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
@@ -27,7 +27,8 @@ const disconnectedPlugin = (nextConfig = {}) => {
     webpack: (config, options) => {
       // Prevent webpack-5 from throwing error for sitecore-import.json when app first starts
       config.resolve.fallback = {
-        'sitecore/manifest/sitecore-import.json': false
+        'sitecore/manifest/sitecore-import.json': false,
+        ...config.resolve.fallback
       };
 
       // Overload the Webpack config if it was already overloaded


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* We shouldn't remove default `fallback` options provided by nextjs, in another case it throws an error

![image](https://user-images.githubusercontent.com/23364749/150909393-f913acd9-5400-4edd-990d-9c29ef2608e1.png)

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
