### PR TITLE
[Node-headless-ssr-experience-edge/ proxy] Fix for error while running `npm start` on headless apps

### DIFF
--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-experience-edge/index.js
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-experience-edge/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const compression = require('compression');
-const { GraphQLLayoutService, GraphQLDictionaryService } = require('@sitecore-jss/sitecore-jss');
+const { GraphQLLayoutService } = require('@sitecore-jss/sitecore-jss/layout');
+const { GraphQLDictionaryService} = require('@sitecore-jss/sitecore-jss/i18n');
 const config = require('./config');
 
 const server = express();

--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/config.js
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/config.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { RestDictionaryService } = require('@sitecore-jss/sitecore-jss');
+const { RestDictionaryService } = require('@sitecore-jss/sitecore-jss/i18n');
 const httpAgents = require("./httpAgents");
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As the base packages were refactored and the @sitecore-jss base package was broken down into submodules, the submodules import was not refactored in the `node-headless-ssr-experience-edge` and `node-headless-ssr-proxy` apps.

`npm start` works as expected after updating imports.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
