### PR TITLE
[Angular] Update angular-devkit/build-angular to fix deprecation error

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -77,7 +77,7 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.1102.6",
+    "@angular-devkit/build-angular": "0.1102.18",
     "@angular-eslint/builder": "2.0.2",
     "@angular-eslint/eslint-plugin": "2.0.2",
     "@angular-eslint/eslint-plugin-template": "2.0.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Latest `angular-devkit/build-angular` compatible with `angular 11` package contains latest `postcss` which has fix for deprecation error

![image](https://user-images.githubusercontent.com/23364749/151988282-a938c472-ae45-4c69-87fd-ed2245cac49a.png)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
