### PR TITLE
Throw error when run jss start using FETCH_WITH=GraphQL

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -33,7 +33,7 @@
     "build:client": "cross-env-shell ng build --prod --deploy-url $npm_package_config_sitecoreDistPath/browser/ --output-path=$npm_package_config_buildArtifactsPath/browser/",
     "build:server": "cross-env-shell ng run <%- appName %>:server:production --output-path=$npm_package_config_buildArtifactsPath/server --output-hashing=none --bundle-dependencies true",
     "postbuild:server": "move-cli ./dist/server/main.js ./dist/server.bundle.js && del-cli ./dist/server",
-    "bootstrap": "ts-node --project src/tsconfig.webpack-server.json scripts/bootstrap.ts",
+    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" && ts-node --project src/tsconfig.webpack-server.json scripts/bootstrap.ts",
     "graphql:update": "ts-node --project src/tsconfig.webpack-server.json ./scripts/update-graphql-fragment-data.ts"
   },
   "private": true,

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -33,7 +33,7 @@
     "build:client": "cross-env-shell ng build --prod --deploy-url $npm_package_config_sitecoreDistPath/browser/ --output-path=$npm_package_config_buildArtifactsPath/browser/",
     "build:server": "cross-env-shell ng run <%- appName %>:server:production --output-path=$npm_package_config_buildArtifactsPath/server --output-hashing=none --bundle-dependencies true",
     "postbuild:server": "move-cli ./dist/server/main.js ./dist/server.bundle.js && del-cli ./dist/server",
-    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" && ts-node --project src/tsconfig.webpack-server.json scripts/bootstrap.ts",
+    "bootstrap": "cross-env-shell FETCH_WITH=<%- fetchWith %> \"ts-node --project src/tsconfig.webpack-server.json scripts/bootstrap.ts\"",
     "graphql:update": "ts-node --project src/tsconfig.webpack-server.json ./scripts/update-graphql-fragment-data.ts"
   },
   "private": true,

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/bootstrap.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/bootstrap.ts
@@ -11,7 +11,7 @@ const projects = require('../angular.json').projects;
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
-if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+if (disconnected && process.env.FETCH_WITH === constants.FETCH_WITH.GRAPHQL) {
   throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
 }
 

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/bootstrap.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/bootstrap.ts
@@ -11,6 +11,10 @@ const projects = require('../angular.json').projects;
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
+if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+  throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
+}
+
 /*
   CONFIG GENERATION
   Generates the /src/environments/environment.ts file which contains runtime configuration

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/bootstrap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/bootstrap.ts
@@ -16,6 +16,9 @@ const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 const port = process.env.PORT || 3000;
 const configOverride: { [key: string]: string } = {};
 if (disconnected) {
+  if (process.env.FETCH_WITH === 'GraphQL') {
+    throw new Error('GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.')
+  }
   configOverride.sitecoreApiHost = `http://localhost:${port}`;
 }
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/bootstrap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/bootstrap.ts
@@ -16,7 +16,7 @@ const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 const port = process.env.PORT || 3000;
 const configOverride: { [key: string]: string } = {};
 if (disconnected) {
-  if (process.env.FETCH_WITH === 'GraphQL') {
+  if (process.env.FETCH_WITH === constants.FETCH_WITH.GRAPHQL) {
     throw new Error('GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.')
   }
   configOverride.sitecoreApiHost = `http://localhost:${port}`;

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -102,7 +102,7 @@
     "build:client": "cross-env-shell PUBLIC_URL=$npm_package_config_sitecoreDistPath \"react-scripts build\"",
     "build:client:rendering-host": "cross-env-shell PUBLIC_URL=$npm_package_config_tunnelUrl \"react-scripts build\"",
     "build:server": "cross-env-shell NODE_ENV=production \"webpack --config server/server.webpack.config.js\"",
-    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" && node scripts/bootstrap.js",
+    "bootstrap": "cross-env-shell FETCH_WITH=<%- fetchWith %> \"node scripts/bootstrap.js\"",
     "graphql:update": "node -r @babel/register ./scripts/update-graphql-fragment-data.js",
     "test": "react-scripts test --env=jsdom",
     "lint": "eslint ./src/**/*.js ./sitecore/definitions/**/*.js ./scripts/**/*.js ./server/**/*.js ./data/**/*.yml",

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -102,7 +102,7 @@
     "build:client": "cross-env-shell PUBLIC_URL=$npm_package_config_sitecoreDistPath \"react-scripts build\"",
     "build:client:rendering-host": "cross-env-shell PUBLIC_URL=$npm_package_config_tunnelUrl \"react-scripts build\"",
     "build:server": "cross-env-shell NODE_ENV=production \"webpack --config server/server.webpack.config.js\"",
-    "bootstrap": "node scripts/bootstrap.js",
+    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" && node scripts/bootstrap.js",
     "graphql:update": "node -r @babel/register ./scripts/update-graphql-fragment-data.js",
     "test": "react-scripts test --env=jsdom",
     "lint": "eslint ./src/**/*.js ./sitecore/definitions/**/*.js ./scripts/**/*.js ./server/**/*.js ./data/**/*.yml",

--- a/packages/create-sitecore-jss/src/templates/react/scripts/bootstrap.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/bootstrap.js
@@ -10,7 +10,7 @@ const configGenerator = require('./generate-config');
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
-if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+if (disconnected && process.env.FETCH_WITH === constants.FETCH_WITH.GRAPHQL) {
   throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
 }
 

--- a/packages/create-sitecore-jss/src/templates/react/scripts/bootstrap.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/bootstrap.js
@@ -10,6 +10,10 @@ const configGenerator = require('./generate-config');
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
+if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+  throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
+}
+
 /*
   CONFIG GENERATION
   Generates the /src/temp/config.js file which contains runtime configuration

--- a/packages/create-sitecore-jss/src/templates/vue/package.json
+++ b/packages/create-sitecore-jss/src/templates/vue/package.json
@@ -41,7 +41,7 @@
     "start:watch-components": "node scripts/generate-component-factory.js --watch",
     "build:client": "cross-env-shell BUILD_TARGET_ENV=client PUBLIC_URL=$npm_package_config_sitecoreDistPath \"vue-cli-service build\"",
     "build:server": "cross-env-shell BUILD_TARGET_ENV=server \"vue-cli-service build --no-clean\"",
-    "bootstrap": "node scripts/bootstrap.js",
+    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" &&node scripts/bootstrap.js",
     "graphql:update": "cross-env-shell VUE_CLI_BABEL_TRANSPILE_MODULES=true VUE_CLI_BABEL_TARGET_NODE=true \"node -r @babel/register ./scripts/update-graphql-fragment-data.js\"",
     "lint": "vue-cli-service lint ./src/**/*.vue ./src/**/*.js ./sitecore/definitions/**/*.js ./scripts/**/*.js ./server/**/*.js ./data/**/*.yml"
   },

--- a/packages/create-sitecore-jss/src/templates/vue/package.json
+++ b/packages/create-sitecore-jss/src/templates/vue/package.json
@@ -41,7 +41,7 @@
     "start:watch-components": "node scripts/generate-component-factory.js --watch",
     "build:client": "cross-env-shell BUILD_TARGET_ENV=client PUBLIC_URL=$npm_package_config_sitecoreDistPath \"vue-cli-service build\"",
     "build:server": "cross-env-shell BUILD_TARGET_ENV=server \"vue-cli-service build --no-clean\"",
-    "bootstrap": "set \"FETCH_WITH=<%- fetchWith %>\" &&node scripts/bootstrap.js",
+    "bootstrap": "cross-env-shell FETCH_WITH=<%- fetchWith %> \"node scripts/bootstrap.js\"",
     "graphql:update": "cross-env-shell VUE_CLI_BABEL_TRANSPILE_MODULES=true VUE_CLI_BABEL_TARGET_NODE=true \"node -r @babel/register ./scripts/update-graphql-fragment-data.js\"",
     "lint": "vue-cli-service lint ./src/**/*.vue ./src/**/*.js ./sitecore/definitions/**/*.js ./scripts/**/*.js ./server/**/*.js ./data/**/*.yml"
   },

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/bootstrap.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/bootstrap.js
@@ -11,6 +11,10 @@ const vueConfig = require('../vue.config');
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
+if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+  throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
+}
+
 /*
   CONFIG GENERATION
   Generates the /src/temp/config.js file which contains runtime configuration

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/bootstrap.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/bootstrap.js
@@ -11,7 +11,7 @@ const vueConfig = require('../vue.config');
 
 const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
-if (disconnected && process.env.FETCH_WITH === 'GraphQL') {
+if (disconnected && process.env.FETCH_WITH === constants.FETCH_WITH.GRAPHQL) {
   throw new Error("GraphQL requests to Dictionary and Layout service are not supported in disconnected mode.")
 }
 

--- a/packages/sitecore-jss-nextjs/tsconfig.json
+++ b/packages/sitecore-jss-nextjs/tsconfig.json
@@ -23,6 +23,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false,
   },
   "exclude": [
     "node_modules",

--- a/packages/sitecore-jss-nextjs/tsconfig.json
+++ b/packages/sitecore-jss-nextjs/tsconfig.json
@@ -23,7 +23,6 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "useUnknownInCatchVariables": false,
   },
   "exclude": [
     "node_modules",

--- a/packages/sitecore-jss/src/constants.ts
+++ b/packages/sitecore-jss/src/constants.ts
@@ -6,6 +6,11 @@ export enum SitecoreTemplateId {
   DictionaryEntry = '6d1cd89719364a3aa511289a94c2a7b1',
 }
 
+export const FETCH_WITH = {
+  GRAPHQL: 'GraphQL',
+  REST: 'Rest',
+};
+
 export const JSS_MODE = {
   CONNECTED: 'connected',
   DISCONNECTED: 'disconnected',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The user should see a friendly error message when they try to run jss start i.e disconnected mode when fetchWtih is set to 'GraphQL'.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
