### PR TITLE
[Next.js] Use more focused paths for Sitecore rewrites

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
@@ -10,11 +10,12 @@ const disconnectedPlugin = (nextConfig = {}) => {
 
   return Object.assign({}, nextConfig, {
     async rewrites() {
-      // When disconnected we proxy to the local faux layout service host, see scripts/disconnected-mode-server.js
+      // When disconnected we proxy to the local faux layout service host, see scripts/disconnected-mode-proxy.ts
       return [
+        // API endpoints
         {
-          source: '/sitecore/:path*',
-          destination: `${disconnectedServerUrl}/sitecore/:path*`,
+          source: '/sitecore/api/:path*',
+          destination: `${disconnectedServerUrl}/sitecore/api/:path*`,
         },
         // media items
         {

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -47,9 +47,10 @@ const nextConfig = {
   async rewrites() {
     // When in connected mode we want to proxy Sitecore paths off to Sitecore
     return [
+      // API endpoints
       {
-        source: '/sitecore/:path*',
-        destination: `${jssConfig.sitecoreApiHost}/sitecore/:path*`,
+        source: '/sitecore/api/:path*',
+        destination: `${jssConfig.sitecoreApiHost}/sitecore/api/:path*`,
       },
       // media items
       {
@@ -58,8 +59,8 @@ const nextConfig = {
       },
       // visitor identification
       {
-        source: '/layouts/:path*',
-        destination: `${jssConfig.sitecoreApiHost}/layouts/:path*`,
+        source: '/layouts/system/:path*',
+        destination: `${jssConfig.sitecoreApiHost}/layouts/system/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Description / Motivation
Use more focused paths for Sitecore rewrites (similar to RAV / headless proxy) to avoid interference with allowed path "/sitecore/templates". This fixes an issue which prevented template standard values from being edited in Sitecore.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
