### PR TITLE
[React][NextJs] Handle Sitecore `querystring` property in Link component

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -41,6 +41,7 @@ describe('<Link />', () => {
         class: 'my-link',
         title: 'My Link',
         target: '_blank',
+        querystring: 'foo=bar',
       },
     };
 
@@ -52,7 +53,7 @@ describe('<Link />', () => {
 
     const link = c.find('a');
 
-    expect(link.html()).to.contain(`href="${field.value.href}"`);
+    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}"`);
     expect(link.html()).to.contain(`class="${field.value.class}"`);
     expect(link.html()).to.contain(`title="${field.value.title}"`);
     expect(link.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -19,29 +19,30 @@ export type LinkProps = ReactLinkProps & {
 
 export const Link = (props: LinkProps): JSX.Element => {
   const {
+    field,
     editable,
+    children,
     internalLinkMatcher = /^\//g,
     showLinkTextWithChildrenPresent,
     ...htmlLinkProps
   } = props;
 
-  const value = ((props.field as LinkFieldValue).href
-    ? props.field
-    : (props.field as LinkField).value) as LinkFieldValue;
-  const { href } = value;
-  const isEditing = editable && (props.field as LinkFieldValue).editable;
+  const value = ((field as LinkFieldValue).href
+    ? field
+    : (field as LinkField).value) as LinkFieldValue;
+  const { href, querystring } = value;
+  const isEditing = editable && (field as LinkFieldValue).editable;
 
   if (href && !isEditing) {
-    const text =
-      showLinkTextWithChildrenPresent || !props.children ? value.text || value.href : null;
+    const text = showLinkTextWithChildrenPresent || !children ? value.text || value.href : null;
 
     // determine if a link is a route or not.
     if (internalLinkMatcher.test(href)) {
       return (
-        <NextLink href={href} key="link" locale={false}>
+        <NextLink href={{ pathname: href, query: querystring }} key="link" locale={false}>
           <a title={value.title} target={value.target} className={value.class} {...htmlLinkProps}>
             {text}
-            {props.children}
+            {children}
           </a>
         </NextLink>
       );

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -68,10 +68,11 @@ describe('<Link />', () => {
         class: 'my-link',
         title: 'My Link',
         target: '_blank',
+        querystring: 'foo=bar',
       },
     };
     const rendered = mount(<Link field={field} />).find('a');
-    expect(rendered.html()).to.contain(`href="${field.value.href}"`);
+    expect(rendered.html()).to.contain(`href="${field.value.href}?${field.value.querystring}"`);
     expect(rendered.html()).to.contain(`class="${field.value.class}"`);
     expect(rendered.html()).to.contain(`title="${field.value.title}"`);
     expect(rendered.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -9,6 +9,7 @@ export interface LinkFieldValue {
   title?: string;
   target?: string;
   text?: string;
+  querystring?: string;
 }
 
 export interface LinkField {
@@ -94,7 +95,7 @@ export const Link: React.SFC<LinkProps> = ({
   }
 
   const anchorAttrs: { [attr: string]: unknown } = {
-    href: link.href,
+    href: link.querystring ? `${link.href}?${link.querystring}` : link.href,
     className: link.class,
     title: link.title,
     target: link.target,


### PR DESCRIPTION
## Description / Motivation
Sitecore allows configuration of a query string for internal links. Make sure these are rendered properly for React (anchor) and NextJs (next/link).

This PR also fixes an issue for NextJs where the rendered markup would contain invalid attributes e.g. `field="[object Object]"`.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
