### PR TITLE
[Initializers] Restore sub-command (npm install / lint) console output

### DIFF
--- a/packages/create-sitecore-jss/package.json
+++ b/packages/create-sitecore-jss/package.json
@@ -51,6 +51,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.7",
     "@types/sinon": "^10.0.6",
+    "@types/sinon-chai": "^3.2.8",
     "chai": "^4.3.4",
     "chokidar": "^3.5.2",
     "del-cli": "^4.0.1",
@@ -58,6 +59,7 @@
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
     "sinon": "^12.0.1",
+    "sinon-chai": "^3.7.0",
     "ts-node": "^10.4.0",
     "typescript": "~4.3.5"
   }

--- a/packages/create-sitecore-jss/src/common/processes/install.ts
+++ b/packages/create-sitecore-jss/src/common/processes/install.ts
@@ -49,5 +49,13 @@ export const lintFix = (projectFolder: string, silent?: boolean) => {
   }
 
   silent || console.log(chalk.cyan('Linting app...'));
-  run('npm', ['run', 'lint', '--', '--fix'], { cwd: projectFolder, encoding: 'utf8' });
+  run(
+    'npm',
+    ['run', 'lint', '--', '--fix'],
+    {
+      cwd: projectFolder,
+      encoding: 'utf8',
+    },
+    silent
+  );
 };

--- a/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
+++ b/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
@@ -31,11 +31,13 @@ describe('cmd', () => {
     let spawnStub: SinonStub;
     let exitStub: SinonStub;
     let logStub: SinonStub;
+    let stderrTTYStub: SinonStub;
 
     afterEach(() => {
       spawnStub?.restore();
       exitStub?.restore();
       logStub?.restore();
+      stderrTTYStub?.restore();
     });
 
     it('should exit when result has status', () => {
@@ -53,6 +55,7 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
+          stdio: ['inherit', 'inherit', 'inherit'],
         })
       ).to.equal(true);
     });
@@ -74,6 +77,7 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
+          stdio: ['inherit', 'inherit', 'inherit'],
         })
       ).to.equal(true);
 
@@ -101,6 +105,7 @@ describe('cmd', () => {
         spawnStub.calledOnceWith('jss', ['start', 'production'], {
           cwd: 'samples/next',
           encoding: 'utf-8',
+          stdio: ['inherit', 'inherit', 'inherit'],
         })
       ).to.equal(true);
 
@@ -110,6 +115,25 @@ describe('cmd', () => {
             'Someone might have called `kill` or `killall`, or the system could ' +
             'be shutting down.'
         )
+      ).to.equal(true);
+    });
+
+    it('should use pipe for stdio if not tty', () => {
+      spawnStub = sinon
+        .stub(spawn, 'sync')
+        .returns({ output: [], pid: 1, stderr: '', stdout: '', status: 1, signal: 'SIGINFO' });
+      exitStub = sinon.stub(process, 'exit');
+
+      stderrTTYStub = sinon.stub(process.stderr, 'isTTY').value(false);
+
+      cmd.spawnFunc('npm', ['install'], { cwd: 'samples/next', encoding: 'utf-8' });
+
+      expect(
+        spawnStub.calledOnceWith('npm', ['install'], {
+          cwd: 'samples/next',
+          encoding: 'utf-8',
+          stdio: ['inherit', 'inherit', 'pipe'],
+        })
       ).to.equal(true);
     });
   });

--- a/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
+++ b/packages/create-sitecore-jss/src/common/utils/cmd.test.ts
@@ -31,12 +31,24 @@ describe('cmd', () => {
     let spawnStub: SinonStub;
     let exitStub: SinonStub;
     let logStub: SinonStub;
+    let stdinTTYStub: SinonStub;
+    let stdoutTTYStub: SinonStub;
     let stderrTTYStub: SinonStub;
+
+    beforeEach(() => {
+      exitStub = sinon.stub(process, 'exit');
+      logStub = sinon.stub(console, 'log');
+      stdinTTYStub = sinon.stub(process.stdin, 'isTTY').value(true);
+      stdoutTTYStub = sinon.stub(process.stdout, 'isTTY').value(true);
+      stderrTTYStub = sinon.stub(process.stderr, 'isTTY').value(true);
+    });
 
     afterEach(() => {
       spawnStub?.restore();
       exitStub?.restore();
       logStub?.restore();
+      stdinTTYStub?.restore();
+      stdoutTTYStub?.restore();
       stderrTTYStub?.restore();
     });
 
@@ -44,8 +56,6 @@ describe('cmd', () => {
       spawnStub = sinon
         .stub(spawn, 'sync')
         .returns({ output: [], pid: 1, stderr: '', stdout: '', status: 5, signal: 'SIGINFO' });
-
-      exitStub = sinon.stub(process, 'exit');
 
       cmd.spawnFunc('jss', ['start', 'production'], { cwd: 'samples/next', encoding: 'utf-8' });
 
@@ -64,10 +74,6 @@ describe('cmd', () => {
       spawnStub = sinon
         .stub(spawn, 'sync')
         .returns({ output: [], pid: 1, stderr: '', stdout: '', status: 5, signal: 'SIGKILL' });
-
-      exitStub = sinon.stub(process, 'exit');
-
-      logStub = sinon.stub(console, 'log');
 
       cmd.spawnFunc('jss', ['start', 'production'], { cwd: 'samples/next', encoding: 'utf-8' });
 
@@ -94,8 +100,6 @@ describe('cmd', () => {
       spawnStub = sinon
         .stub(spawn, 'sync')
         .returns({ output: [], pid: 1, stderr: '', stdout: '', status: 5, signal: 'SIGTERM' });
-      exitStub = sinon.stub(process, 'exit');
-      logStub = sinon.stub(console, 'log');
 
       cmd.spawnFunc('jss', ['start', 'production'], { cwd: 'samples/next', encoding: 'utf-8' });
 
@@ -122,7 +126,6 @@ describe('cmd', () => {
       spawnStub = sinon
         .stub(spawn, 'sync')
         .returns({ output: [], pid: 1, stderr: '', stdout: '', status: 1, signal: 'SIGINFO' });
-      exitStub = sinon.stub(process, 'exit');
 
       stderrTTYStub = sinon.stub(process.stderr, 'isTTY').value(false);
 

--- a/packages/create-sitecore-jss/src/common/utils/cmd.ts
+++ b/packages/create-sitecore-jss/src/common/utils/cmd.ts
@@ -21,21 +21,25 @@ export const run = (
  * @param {string} command
  * @param {string[]} args
  * @param {SpawnSyncOptionsWithStringEncoding} options
+ * @param {NodeJS.Process} parentProcess
  */
 export const spawnFunc = (
   command: string,
   args: string[],
-  options?: SpawnSyncOptionsWithStringEncoding
+  options?: SpawnSyncOptionsWithStringEncoding,
+  parentProcess?: NodeJS.Process
 ) => {
+  const parent = parentProcess ?? process;
+
   // Use 'inherit' (better UX) when being run within a TTY context, use 'pipe' otherwise.
   // In most cases, TTY will be the case. However, when running inside of our dotnet template,
   // stderr is not TTY (will be a socket instead of a WriteStream) and commands such as
   // `npm install` will error out if using 'inherit' (and ultimately hang the parent process).
   const defaults = {
     stdio: [
-      process.stdin.isTTY ? 'inherit' : 'pipe',
-      process.stdout.isTTY ? 'inherit' : 'pipe',
-      process.stderr.isTTY ? 'inherit' : 'pipe',
+      parent.stdin.isTTY ? 'inherit' : 'pipe',
+      parent.stdout.isTTY ? 'inherit' : 'pipe',
+      parent.stderr.isTTY ? 'inherit' : 'pipe',
     ],
   };
   const result = spawn.sync(command, args, Object.assign(defaults, options));
@@ -55,6 +59,6 @@ export const spawnFunc = (
   }
 
   if (result.status && result.status > 0) {
-    process.exit(result.status);
+    parent.exit(result.status);
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5095,6 +5095,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/sinon-chai@npm:^3.2.8":
+  version: 3.2.8
+  resolution: "@types/sinon-chai@npm:3.2.8"
+  dependencies:
+    "@types/chai": "*"
+    "@types/sinon": "*"
+  checksum: a0f7a8cef24904db25a695f3c3adcc03ae72bab89a954c9b6e23fe7e541228e67fe4119cec069e8b36c80e9af33102b626129ff538efade9391cc0f65f1d4933
+  languageName: node
+  linkType: hard
+
 "@types/sinon@npm:*, @types/sinon@npm:^10.0.6":
   version: 10.0.6
   resolution: "@types/sinon@npm:10.0.6"
@@ -9761,6 +9771,7 @@ __metadata:
     "@types/mocha": ^9.0.0
     "@types/node": ^16.11.7
     "@types/sinon": ^10.0.6
+    "@types/sinon-chai": ^3.2.8
     chai: ^4.3.4
     chalk: ^4.1.2
     chokidar: ^3.5.2
@@ -9776,6 +9787,7 @@ __metadata:
     mocha: ^9.1.3
     nyc: ^15.1.0
     sinon: ^12.0.1
+    sinon-chai: ^3.7.0
     ts-node: ^10.4.0
     typescript: ~4.3.5
   bin:


### PR DESCRIPTION
## Description / Motivation
We moved away from `inherit` for `stdio` in https://github.com/Sitecore/jss/pull/912 to address an issue with the `npm install` hanging when run within our dotnet template for Next.js. However, this resulted in a loss of useful output. This PR goes back to using `inherit` for `stdio` w/ fallback to `pipe` (when not TTY context).

## Testing Details
Tested on Node.js LTS (16.10), including within dotnet template for Next.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
