### PR TITLE
[Angular] [10.3] "Edit related item" button redirects to home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ This project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 * `[caching]` Make _tmpDir_ a configurable parameter ([#839](https://github.com/Sitecore/jss/pull/839))
 
 `[angular]`
+* [10.3] "Edit related item" button redirects to home ([#944](https://github.com/Sitecore/jss/pull/944))
 * Update angular-devkit/build-angular to fix deprecation error ([#917](https://github.com/Sitecore/jss/pull/917))
 * Convert language to the sitecore compatible format ([#906](https://github.com/Sitecore/jss/pull/906))
 * Fix issues with Angular in disconnected mode (incorrect componentName + reverts changes ([#commit](https://github.com/Sitecore/jss/commit/4698d9735cf4062e8208d399146b927b1496d811))

--- a/packages/sitecore-jss/src/utils/editing.ts
+++ b/packages/sitecore-jss/src/utils/editing.ts
@@ -98,7 +98,7 @@ export const handleEditorAnchors = () => {
   const callback = (mutationList: MutationRecord[]) => {
     mutationList.forEach((mutation: MutationRecord) => {
       const btns: NodeListOf<HTMLAnchorElement> = document.querySelectorAll(
-        '.scChromeDropDown > a[href="#"], a[onclick]'
+        '.scChromeDropDown > a[href="#"], .scChromeDropDown > a[href="#!"], a[onclick]'
       );
       if (mutation.type === 'childList') {
         btns.forEach((link: HTMLAnchorElement) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Using 10.3 second dropdown item has `#!` instead of `!`, we have to check it
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
