### PR TITLE
[VUE] Experience Editor controls does not work until hard reload is done

### DIFF
--- a/packages/sitecore-jss-vue/src/components/PlaceholderCommon.ts
+++ b/packages/sitecore-jss-vue/src/components/PlaceholderCommon.ts
@@ -6,7 +6,7 @@ import {
   Item,
   RouteData,
 } from '@sitecore-jss/sitecore-jss/layout';
-import { HorizonEditor, resetEditorChromes } from '@sitecore-jss/sitecore-jss/utils';
+import { resetEditorChromes } from '@sitecore-jss/sitecore-jss/utils';
 import { Component, h, VNode, DefineComponent, ref, onMounted } from 'vue';
 import { MissingComponent } from './MissingComponent';
 import { HiddenRendering, HIDDEN_RENDERING_NAME } from './HiddenRendering';
@@ -218,9 +218,10 @@ function createRawElement(elem: any) {
         ) {
           elRef.value.setAttribute('key', elem.attributes.key);
 
-          if (elRef && HorizonEditor.isActive()) {
-            resetEditorChromes();
-          }
+          // Reset chromes since sometimes experience editor script is executed earlier
+          // than Vue script and EE can't set required attributes and chromes aren't visible
+          // Also required for Horizon
+          resetEditorChromes();
         }
       });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* We have to reset EE chromes since sometimes experience editor script is executed earlier
than Vue script and EE can't set required attributes and chromes aren't visible
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
