### PR TITLE
[React][EE] Placeholder key is not defined

### DIFF
--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -57,6 +57,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
   }
 
   componentDidMount() {
+    super.componentDidMount();
     if (this.isEmpty && HorizonEditor.isActive()) {
       HorizonEditor.resetChromes();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 - Fixed issue for when trying to add a rendering to the second placeholder to the page, it will throw an error.
 - This issue is caused because the componentDidMount function to Placeholder class overrides the same function in PlaceholderCommon.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
