### PR TITLE
[sitecore-jss-react] Make Image handle 'class' prop when it's passed down

### DIFF
--- a/packages/sitecore-jss-react/src/components/Image.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.test.tsx
@@ -157,7 +157,7 @@ describe('<Image />', () => {
       media: { editable: eeImageData, value: { src: '/assets/img/test0.png', alt: 'my image' } },
       editable: false,
       style: { width: '100%' },
-      className: 'the-dude-abides'
+      className: 'the-dude-abides',
     };
     const rendered = mount(<Image {...props} />).find('img');
 
@@ -184,10 +184,9 @@ describe('<Image />', () => {
 
     const rendered = mount(<Image {...props} />).find('img');
 
-    it('should attach "class" value at the end of class attribute', ()=> {
+    it('should attach "class" value at the end of class attribute', () => {
       expect(rendered.prop('className')).to.eql(`${props.className} ${props.class}`);
     });
-
   });
 
   describe('with "mediaUrlPrefix" property', () => {

--- a/packages/sitecore-jss-react/src/components/Image.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.test.tsx
@@ -157,7 +157,7 @@ describe('<Image />', () => {
       media: { editable: eeImageData, value: { src: '/assets/img/test0.png', alt: 'my image' } },
       editable: false,
       style: { width: '100%' },
-      className: 'the-dude-abides',
+      className: 'the-dude-abides'
     };
     const rendered = mount(<Image {...props} />).find('img');
 
@@ -171,6 +171,23 @@ describe('<Image />', () => {
       expect(rendered.prop('style')).to.eql(props.style);
       expect(rendered.prop('className')).to.eql(props.className);
     });
+  });
+
+  describe('with "class" and "className" property set', () => {
+    const props = {
+      media: { editable: eeImageData, value: { src: '/assets/img/test0.png', alt: 'my image' } },
+      editable: false,
+      style: { width: '100%' },
+      className: 'the-dude',
+      class: 'abides',
+    };
+
+    const rendered = mount(<Image {...props} />).find('img');
+
+    it('should attach "class" value at the end of class attribute', ()=> {
+      expect(rendered.prop('className')).to.eql(`${props.className} ${props.class}`);
+    });
+
   });
 
   describe('with "mediaUrlPrefix" property', () => {

--- a/packages/sitecore-jss-react/src/components/Image.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.tsx
@@ -99,6 +99,19 @@ const getImageAttrs = (
     return null;
   }
 
+  // we want to get rid of class prop in compliance with JSX
+  if (otherAttrs.class) {
+    // if any classes are defined properly already
+    if (otherAttrs.className) {
+      let className:string = otherAttrs.className as string;
+      className += ` ${otherAttrs.class}`;
+      otherAttrs.className = className;
+    }
+    else
+      otherAttrs.className = otherAttrs.class;
+    delete otherAttrs.class;
+  }
+
   const newAttrs: { [attr: string]: unknown } = {
     ...otherAttrs,
   };

--- a/packages/sitecore-jss-react/src/components/Image.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.tsx
@@ -103,12 +103,12 @@ const getImageAttrs = (
   if (otherAttrs.class) {
     // if any classes are defined properly already
     if (otherAttrs.className) {
-      let className:string = otherAttrs.className as string;
+      let className: string = otherAttrs.className as string;
       className += ` ${otherAttrs.class}`;
       otherAttrs.className = className;
-    }
-    else
+    } else {
       otherAttrs.className = otherAttrs.class;
+    }
     delete otherAttrs.class;
   }
 


### PR DESCRIPTION
Fixes the issue with 'class' property not being handled property, after it is passed into Image component. 
This could lead to a console error in Experience Editor when displaying a placeholder image.

## Description / Motivation
If "class" property is passed down from Layout Service it will be transformed into or appended to "className" instead.

## Testing Details
Unit test added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

