### PR TITLE
[Vue] Fix Sitecore querystring property in Link component

### DIFF
--- a/packages/sitecore-jss-vue/src/components/Link.test.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.test.ts
@@ -91,13 +91,19 @@ describe('<Link />', () => {
           class: 'my-link',
           title: 'My Link',
           target: '_blank',
+          querystring: 'foo=bar',
         },
       },
     };
     const rendered = mount(Link, { props }).find('a');
-    const renderedAttrs = rendered.attributes();
+    // const renderedAttrs = rendered.attributes();
     // note: order of comparison is important for `toMatchObject` as renderedAttrs won't fully match props.field.value
-    expect(props.field.value).toMatchObject(renderedAttrs);
+    expect(rendered.html()).toContain(
+      `href="${props.field.value.href}?${props.field.value.querystring}"`
+    );
+    expect(rendered.html()).toContain(`class="${props.field.value.class}"`);
+    expect(rendered.html()).toContain(`title="${props.field.value.title}"`);
+    expect(rendered.html()).toContain(`target="${props.field.value.target}"`);
   });
 
   it('should render other attributes with other props provided', () => {

--- a/packages/sitecore-jss-vue/src/components/Link.test.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.test.ts
@@ -96,8 +96,6 @@ describe('<Link />', () => {
       },
     };
     const rendered = mount(Link, { props }).find('a');
-    // const renderedAttrs = rendered.attributes();
-    // note: order of comparison is important for `toMatchObject` as renderedAttrs won't fully match props.field.value
     expect(rendered.html()).toContain(
       `href="${props.field.value.href}?${props.field.value.querystring}"`
     );

--- a/packages/sitecore-jss-vue/src/components/Link.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.ts
@@ -6,6 +6,7 @@ export interface LinkFieldValue {
   className?: string;
   title?: string;
   target?: string;
+  querystring?: string;
 }
 
 export interface LinkField {
@@ -105,7 +106,7 @@ export const Link = defineComponent({
       ...this.$data,
       class: link.class,
       ...this.$attrs,
-      href: link.href,
+      href: link.querystring ? `${link.href}?${link.querystring}` : link.href,
       title: link.title,
       target: link.target,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 Make sure the query strings are rendered properly for Vue (anchor).

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
