### PR TITLE
[JSS][React] SitecoreContextReactContext.Provider is not working properly, because value never changes as it is always same class instance

### DIFF
--- a/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/components/SitecoreContext.tsx
@@ -20,22 +20,22 @@ export class SitecoreContextFactory {
     };
   }
 
-  getSitecoreContext() {
+  getSitecoreContext = () => {
     return this.context;
   }
 
-  subscribeToContext(func: any) {
+  subscribeToContext = (func: any) => {
     this.subscribers.push(func);
   }
 
-  unsubscribeFromContext(func: any) {
+  unsubscribeFromContext = (func: any) => {
     const index = this.subscribers.indexOf(func);
     if (index >= 0) {
       this.subscribers.splice(index, 1);
     }
   }
 
-  setSitecoreContext(value: any) {
+  setSitecoreContext = (value: any) => {
     this.context = value;
     this.subscribers.forEach((func) => func(value));
   }
@@ -65,9 +65,7 @@ export class SitecoreContext extends React.Component<SitecoreContextProps> {
     } else {
       this.contextFactory = new SitecoreContextFactory();
     }
-  }
 
-  componentDidMount() {
     // we force the children of the context to re-render when the context is updated
     // even if the local props are unchanged; we assume the contents depend on the Sitecore context
     this.contextFactory.subscribeToContext(this.contextListener);
@@ -79,10 +77,16 @@ export class SitecoreContext extends React.Component<SitecoreContextProps> {
     this.contextFactory.unsubscribeFromContext(this.contextListener);
   }
 
+  /**
+   * React Context Provider should accept Object instead of
+   * SitecoreContextFactory class instance
+   */
+  getSitecoreContextValue = () => ({ ...this.contextFactory });
+
   render() {
     return (
     <ComponentFactoryReactContext.Provider value={this.componentFactory}>
-      <SitecoreContextReactContext.Provider value={this.contextFactory}>
+      <SitecoreContextReactContext.Provider value={this.getSitecoreContextValue()}>
         {this.props.children}
       </SitecoreContextReactContext.Provider>
     </ComponentFactoryReactContext.Provider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Use context value as an object instead of class instance. Initially was fixed in #354 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
