### PR TITLE
#526106: Extend SXA Headless layout with 3 placeholders instead of one

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/Layout.tsx
@@ -40,11 +40,21 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
 
       <Navigation />
       {/* root placeholder for the app, which we add components to using route data */}
-      <div className="container">
-        <div className="row">
-          {route && <Placeholder name="<%- helper.getAppPrefix(appPrefix, appName) %>jss-main" rendering={route} />}
+      <header>
+        <div id="header" className="container">
+          <div className="row">{route && <Placeholder name="headless-header" rendering={route} />}</div>
         </div>
-      </div>
+      </header>
+      <main>
+        <div id="content" className="container">
+          <div className="row">{route && <Placeholder name="headless-main" rendering={route} />}</div>
+        </div>
+      </main>
+      <footer>
+        <div id="footer" className="container">
+          <div className="row">{route && <Placeholder name="headless-footer" rendering={route} />}</div>
+        </div>
+      </footer>
     </>
   );
 };


### PR DESCRIPTION
- Added Header and Footer placeholders to the layout. Now placeholders are the same as in MVC SXA.
- The `<%- helper.getAppPrefix(appPrefix, appName) %>` prefix was removed. In SXA there are three predefined placeholders (Header, Main and Footer), which don't have any dynamic prefixes in their names.