### PR TITLE
#530659: [SXA][Headless] In preview mode links are broken because ? remains encoded

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ interface Fields {
   Title: TextField;
   NavigationTitle: TextField;
   Href: string;
+  Querystring: string;
   Children: Array<Fields>;
   Styles: string[];
 }
@@ -34,6 +35,7 @@ const getLinkField = (props: NavigationProps): LinkField => ({
   value: {
     href: props.fields.Href,
     title: props.fields.DisplayName,
+    querystring: props.fields.Querystring
   },
 });
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Title.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Title.tsx
@@ -64,7 +64,7 @@ export const Default = (props: TitleProps): JSX.Element => {
     },
   };
   if (useSitecoreContext().sitecoreContext.pageState !== 'normal') {
-    link.value.href += `?sc_site=${datasource?.url?.siteName}`;
+    link.value.querystring = `sc_site=${datasource?.url?.siteName}`;
     if (!text.value) {
       text.value = 'Title field';
       link.value.href = '#';


### PR DESCRIPTION
Update renderings due to the changes in [https://github.com/Sitecore/jss/commit/be48bd1d2e44818ffba85f8df11755ec9bf188d4](https://github.com/Sitecore/jss/commit/be48bd1d2e44818ffba85f8df11755ec9bf188d4)