### PR TITLE
[Nextjs][SDK] RichText component not forwarding query params

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -97,7 +97,7 @@ describe('RichText', () => {
     const props = {
       field: {
         value:
-          '<div id="test"><h1>Hello!</h1><a href="/testpath/t1">t1</a><a href="/t2">t2</a></div>',
+          '<div id="test"><h1>Hello!</h1><a href="/testpath/t1?test=sample1">t1</a><a href="/t2">t2</a></div>',
       },
       internalLinksSelector: 'a[href^="/testpath"]',
     };
@@ -119,7 +119,7 @@ describe('RichText', () => {
     const link1 = links && links[0];
     const link2 = links && links[1];
 
-    expect(link1!.href).to.equal('/testpath/t1');
+    expect(link1!.href).to.equal('/testpath/t1?test=sample1');
     expect(link2!.href).to.equal('/t2');
 
     link1 && link1.click();

--- a/packages/sitecore-jss-nextjs/src/components/RichText.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.tsx
@@ -37,7 +37,8 @@ export const RichText = (props: RichTextProps): JSX.Element => {
 
     ev.preventDefault();
 
-    const pathname = (ev.target as HTMLAnchorElement).pathname;
+    const pathname = (ev.target as HTMLAnchorElement).href;
+    console.log(pathname);
 
     router.push(pathname, pathname, { locale: false });
   };

--- a/packages/sitecore-jss-nextjs/src/components/RichText.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.tsx
@@ -38,7 +38,6 @@ export const RichText = (props: RichTextProps): JSX.Element => {
     ev.preventDefault();
 
     const pathname = (ev.target as HTMLAnchorElement).href;
-    console.log(pathname);
 
     router.push(pathname, pathname, { locale: false });
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix to forward query params from the RichText component.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
