### PR TITLE
 #530304 decode url for redirects

### DIFF
--- a/packages/sitecore-jss-nextjs/src/edge/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/redirects-middleware.ts
@@ -50,15 +50,16 @@ export class RedirectsMiddleware {
 
     url.search = existsRedirect.isQueryStringPreserved ? url.search : '';
     url.pathname = existsRedirect.target;
+    const redirectUrl = decodeURIComponent(url.href);
 
     /** return Response redirect with http code of redirect type **/
     switch (existsRedirect.redirectType) {
       case REDIRECT_TYPE_301:
-        return NextResponse.redirect(url, 301);
+        return NextResponse.redirect(redirectUrl, 301);
       case REDIRECT_TYPE_302:
-        return NextResponse.redirect(url, 302);
+        return NextResponse.redirect(redirectUrl, 302);
       case REDIRECT_TYPE_SERVER_TRANSFER:
-        return NextResponse.rewrite(url);
+        return NextResponse.rewrite(redirectUrl);
       default:
         return NextResponse.next();
     }


### PR DESCRIPTION
decode URL when using query string. 
There was bug when redirects the URL where use query string in middleware redirects.
The problem was in special symbols(?) - they was encoding