### PR TITLE
[Nextjs] Dynamic components markup is missing in Experience Editor after adding new rendering

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
@@ -52,8 +52,7 @@ ${componentFiles
       const moduleName = removeDynamicModuleNameEnding(component.moduleName);
       return `const ${moduleName} = {
   module: () => import('${component.path}'),
-  element: () => dynamic(${moduleName}.module),
-  elementEditingMode: () => require('${component.path}')
+  element: (isEditing?:boolean) => isEditing ? require('${component.path}')?.default : dynamic(${moduleName}.module)
 }`;
     }
 
@@ -90,7 +89,9 @@ ${componentFiles
 // componentFactory uses 'dynamic(...)' because primary usage of it to render 'React Component' (default export).
 // See https://nextjs.org/docs/advanced-features/dynamic-import
 // At the end you will have single preloaded script for each lazy loading module.
-// Editing mode doesn't work well with dynamic components in nextjs so we add an extra way to obtain them via elementEditingMode
+// Editing mode doesn't work well with dynamic components in nextjs: dynamic components are not displayed without refresh after a rendering is added. 
+// This happens beacuse Experience Editor simply inserts updated HTML generated on server side. This conflicts with nextjs dynamic logic as no HTML gets rendered for dynamic component
+// So we use require() to obtain dynamic components in editing mode while preserving dynamic logic for non-editing scenarios
 // As we need to be able to seamlessly work with dynamic components in both editing and normal modes, different componentFactory functions will be passed to app
 
 export function componentModule(componentName: string) {
@@ -111,7 +112,7 @@ function baseComponentFactory(componentName: string, exportName?: string, isEdit
   // check that component should be dynamically imported
   if (component?.element) {
     // return next.js dynamic import
-    return isEditing ? component.elementEditingMode()?.default : component.element();
+    return component.element(isEditing);
   }
 
   if (exportName) {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
@@ -52,7 +52,8 @@ ${componentFiles
       const moduleName = removeDynamicModuleNameEnding(component.moduleName);
       return `const ${moduleName} = {
   module: () => import('${component.path}'),
-  element: () => dynamic(${moduleName}.module)
+  element: () => dynamic(${moduleName}.module),
+  elementEditingMode: () => require('${component.path}')
 }`;
     }
 
@@ -89,6 +90,8 @@ ${componentFiles
 // componentFactory uses 'dynamic(...)' because primary usage of it to render 'React Component' (default export).
 // See https://nextjs.org/docs/advanced-features/dynamic-import
 // At the end you will have single preloaded script for each lazy loading module.
+// Editing mode doesn't work well with dynamic components in nextjs so we add an extra way to obtain them via elementEditingMode
+// As we need to be able to seamlessly work with dynamic components in both editing and normal modes, different componentFactory functions will be passed to app
 
 export function componentModule(componentName: string) {
   const component = components.get(componentName);
@@ -101,14 +104,14 @@ export function componentModule(componentName: string) {
 
   return component;
 }
-  
-export function componentFactory(componentName: string, exportName?: string) {
+
+function baseComponentFactory(componentName: string, exportName?: string, isEditing: boolean) {
   const component = components.get(componentName);
 
   // check that component should be dynamically imported
   if (component?.element) {
     // return next.js dynamic import
-    return component.element();
+    return isEditing ? component.elementEditingMode()?.default : component.element();
   }
 
   if (exportName) {
@@ -116,6 +119,14 @@ export function componentFactory(componentName: string, exportName?: string) {
   }
 
   return component?.default || component;
+}
+  
+export function componentFactory(componentName: string, exportName?: string) {
+  return baseComponentFactory(componentName, exportName, false);
+}
+
+export function editingComponentFactory(componentName: string, exportName?: string) {
+  return baseComponentFactory(componentName, exportName, true);
 }
 `;
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/templates/component-factory.ts
@@ -52,7 +52,7 @@ ${componentFiles
       const moduleName = removeDynamicModuleNameEnding(component.moduleName);
       return `const ${moduleName} = {
   module: () => import('${component.path}'),
-  element: (isEditing?:boolean) => isEditing ? require('${component.path}')?.default : dynamic(${moduleName}.module)
+  element: (isEditing?: boolean) => isEditing ? require('${component.path}')?.default : dynamic(${moduleName}.module)
 }`;
     }
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -13,7 +13,8 @@ import {
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import { SitecorePageProps } from 'lib/page-props';
 import { sitecorePagePropsFactory } from 'lib/page-props-factory';
-import { componentFactory } from 'temp/componentFactory';
+// different componentFactory method will be used based on whether page is being edited
+import { componentFactory, editingComponentFactory } from 'temp/componentFactory';
 <% if (prerender === 'SSG') { -%>
 import { sitemapFetcher } from 'lib/sitemap-fetcher';
 <% } -%>
@@ -29,9 +30,11 @@ const SitecorePage = ({ notFound, componentProps, layoutData }: SitecorePageProp
     return <NotFound />;
   }
 
+  const isEditing = layoutData.sitecore.context.pageEditing;
+
   return (
     <ComponentPropsContext value={componentProps}>
-      <SitecoreContext componentFactory={componentFactory} layoutData={layoutData}>
+      <SitecoreContext componentFactory={isEditing? editingComponentFactory:componentFactory} layoutData={layoutData}>
         <Layout layoutData={layoutData} />
       </SitecoreContext>
     </ComponentPropsContext>

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -34,7 +34,10 @@ const SitecorePage = ({ notFound, componentProps, layoutData }: SitecorePageProp
 
   return (
     <ComponentPropsContext value={componentProps}>
-      <SitecoreContext componentFactory={isEditing? editingComponentFactory:componentFactory} layoutData={layoutData}>
+      <SitecoreContext
+        componentFactory={isEditing ? editingComponentFactory : componentFactory}
+        layoutData={layoutData}
+      >
         <Layout layoutData={layoutData} />
       </SitecoreContext>
     </ComponentPropsContext>


### PR DESCRIPTION
This change adds an extra method for componentFactory that will ensure dynamic nextjs components can be returned and rendered properly when adding renderings in Experience Editor

## Description / Motivation
componentFactory is generated with two factory methods - and nextjs apps will use one or the other depending on the pageEditing sitecore context value.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
