### PR TITLE
 #532998 temporary fix. set fix version of NextJs

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -32,7 +32,7 @@
     "@sitecore-jss/sitecore-jss-nextjs": "^21.0.0-canary",
     "graphql": "~15.4.0",
     "graphql-tag": "^2.11.0",
-    "next": "^12.1.0",
+    "next": "12.1.5",
     "next-localization": "^0.10.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react": "^7.21.5",
     "jsdom": "^15.1.1",
     "mocha": "^9.1.3",
-    "next": "^12.1.0",
+    "next": "12.1.5",
     "nock": "^13.0.5",
     "nyc": "^15.1.0",
     "react": "^17.0.2",
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "next": "^12.1.0",
+    "next": "12.1.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3916,7 +3916,7 @@ __metadata:
     eslint-plugin-react: ^7.21.5
     jsdom: ^15.1.1
     mocha: ^9.1.3
-    next: ^12.1.0
+    next: 12.1.5
     nock: ^13.0.5
     nyc: ^15.1.0
     prop-types: ^15.7.2
@@ -3930,7 +3930,7 @@ __metadata:
     ts-node: ^9.0.0
     typescript: ~4.3.5
   peerDependencies:
-    next: ^12.1.0
+    next: 12.1.5
     react: ^17.0.2
     react-dom: ^17.0.2
   languageName: unknown
@@ -8489,9 +8489,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001283":
-  version: 1.0.30001316
-  resolution: "caniuse-lite@npm:1.0.30001316"
-  checksum: 8a96ee89f5e64f42f684475905c73c67f995abd6d9b111ab8a9d2e0a5d3b871f1a600ff42e4ffe7f7f3498d0243beeafc11cf7b4dbe3e022a2e5cdf639564152
+  version: 1.0.30001341
+  resolution: "caniuse-lite@npm:1.0.30001341"
+  checksum: 7262b093fb0bf49dbc5328418f5ce4e3dbb0b13e39c015f986ba1807634c123ac214efc94df7d095a336f57f86852b4b63ee61838f18dcc3a4a35f87b390c8f5
   languageName: node
   linkType: hard
 
@@ -18217,7 +18217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^12.1.0":
+"next@npm:12.1.5":
   version: 12.1.5
   resolution: "next@npm:12.1.5"
   dependencies:


### PR DESCRIPTION
NextJs has bug in the version of 12.1.6 with middleware features. Just I set fixed version for our samples projects and sitecore-nextjs module