### PR TITLE
#530555: [SXA][Headless] Redirects with defined language in source URL don't work

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
@@ -6,16 +6,17 @@ import nextConfig from '../../../../next.config';
 
 class RedirectsPlugin implements MiddlewarePlugin {
   private redirectsMiddleware: RedirectsMiddleware;
-  private locales: string[];
   order = 0;
 
   constructor() {
-    this.redirectsMiddleware = new RedirectsMiddleware({
-      endpoint: config.graphQLEndpoint,
-      apiKey: config.sitecoreApiKey,
-      siteName: config.jssAppName,
-    });
-    this.locales = nextConfig().i18n.locales;
+    this.redirectsMiddleware = new RedirectsMiddleware(
+      {
+        endpoint: config.graphQLEndpoint,
+        apiKey: config.sitecoreApiKey,
+        siteName: config.jssAppName,
+      },
+      nextConfig().i18n.locales
+    );
   }
 
   /**
@@ -24,7 +25,7 @@ class RedirectsPlugin implements MiddlewarePlugin {
    * @returns Promise<NextResponse>
    */
   async exec(req: NextRequest): Promise<NextResponse> {
-    return this.redirectsMiddleware.getHandler()(req, this.locales);
+    return this.redirectsMiddleware.getHandler()(req);
   }
 }
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
@@ -9,14 +9,12 @@ class RedirectsPlugin implements MiddlewarePlugin {
   order = 0;
 
   constructor() {
-    this.redirectsMiddleware = new RedirectsMiddleware(
-      {
-        endpoint: config.graphQLEndpoint,
-        apiKey: config.sitecoreApiKey,
-        siteName: config.jssAppName,
-      },
-      nextConfig().i18n.locales
-    );
+    this.redirectsMiddleware = new RedirectsMiddleware({
+      endpoint: config.graphQLEndpoint,
+      apiKey: config.sitecoreApiKey,
+      siteName: config.jssAppName,
+      locales: nextConfig().i18n.locales,
+    });
   }
 
   /**

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { RedirectsMiddleware } from '@sitecore-jss/sitecore-jss-nextjs/edge';
 import config from 'temp/config';
 import { MiddlewarePlugin } from '..';
+import nextConfig from '../../../../next.config';
 
 class RedirectsPlugin implements MiddlewarePlugin {
   private redirectsMiddleware: RedirectsMiddleware;
+  private locales: string[];
   order = 0;
 
   constructor() {
@@ -13,6 +15,7 @@ class RedirectsPlugin implements MiddlewarePlugin {
       apiKey: config.sitecoreApiKey,
       siteName: config.jssAppName,
     });
+    this.locales = nextConfig().i18n.locales;
   }
 
   /**
@@ -21,7 +24,7 @@ class RedirectsPlugin implements MiddlewarePlugin {
    * @returns Promise<NextResponse>
    */
   async exec(req: NextRequest): Promise<NextResponse> {
-    return this.redirectsMiddleware.getHandler()(req);
+    return this.redirectsMiddleware.getHandler()(req, this.locales);
   }
 }
 

--- a/packages/sitecore-jss-nextjs/src/edge/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/redirects-middleware.ts
@@ -12,8 +12,9 @@ import {
 /**
  * extended RedirectsMiddlewareConfig config type for RedirectsMiddleware
  */
-export type RedirectsMiddlewareConfig = Omit<GraphQLRedirectsServiceConfig, 'fetch'>;
-
+export type RedirectsMiddlewareConfig = Omit<GraphQLRedirectsServiceConfig, 'fetch'> & {
+  locales: string[];
+};
 /**
  * Middleware / handler fetches all redirects from Sitecore instance by grapqhl service
  * compares with current url and redirects to target url
@@ -27,9 +28,9 @@ export class RedirectsMiddleware {
    * (underlying default 'cross-fetch' is not currently compatible: https://github.com/lquixada/cross-fetch/issues/78)
    * @param {RedirectsMiddlewareConfig} [config] redirects middleware config
    */
-  constructor(config: RedirectsMiddlewareConfig, locales: string[]) {
+  constructor(config: RedirectsMiddlewareConfig) {
     this.redirectsService = new GraphQLRedirectsService({ ...config, fetch: fetch });
-    this.locales = locales;
+    this.locales = config.locales;
   }
 
   /**
@@ -43,11 +44,11 @@ export class RedirectsMiddleware {
   private handler = async (req: NextRequest): Promise<NextResponse> => {
     // Find the redirect from result of RedirectService
     const existsRedirect = await this.getExistsRedirect(req);
-    
+
     if (!existsRedirect) {
       return NextResponse.next();
     }
-    
+
     const url = req.nextUrl.clone();
     url.search = existsRedirect.isQueryStringPreserved ? url.search : '';
     const urlFirstPart = existsRedirect.target.split('/')[1];


### PR DESCRIPTION
SXA Redirects middleware now checks the patterns for registered locales and updates the URL parameters accordingly.