### PR TITLE
Adding nextjs-specific Layout Service configuration

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/sitecore/config/{{appName}}.config
+++ b/packages/create-sitecore-jss/src/templates/nextjs/sitecore/config/{{appName}}.config
@@ -88,7 +88,7 @@
           compatible with JSS versions < 18.0.0).
         -->
         <app name="<%- appName %>"
-            layoutServiceConfiguration="default"
+            layoutServiceConfiguration="next-default"
             sitecorePath="/sitecore/content/<%- appName %>"
             useLanguageSpecificLayout="true"
             graphQLEndpoint="/sitecore/api/graph/edge"
@@ -145,19 +145,21 @@
     -->
     <layoutService>
       <configurations>
-        <config name="default">
-          <rendering>
-            <renderingContentsResolver>
+        <config name="next-default">
+          <rendering ref="/sitecore/layoutService/configurations/config[@name='default']/rendering">
+            <renderingContentsResolver ref="/sitecore/layoutService/configurations/config[@name='default']/rendering/renderingContentsResolver">
               <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
             </renderingContentsResolver>
           </rendering>
+          <serialization ref="/sitecore/layoutService/configurations/config[@name='default']/serialization"/>
         </config>
-        <config name="jss">
-          <rendering>
-            <renderingContentsResolver>
+        <config name="next-jss">
+          <rendering ref="/sitecore/layoutService/configurations/config[@name='jss']/rendering">
+            <renderingContentsResolver ref="/sitecore/layoutService/configurations/config[@name='jss']/rendering/renderingContentsResolver">
               <IncludeServerUrlInMediaUrls>false</IncludeServerUrlInMediaUrls>
             </renderingContentsResolver>
           </rendering>
+          <serialization ref="/sitecore/layoutService/configurations/config[@name='jss']/serialization"/>
         </config>
       </configurations>
     </layoutService>


### PR DESCRIPTION
## Description / Motivation
NextJS needs to have IncludeServerUrlInMediaUrls set to false without conflicting with other apps deployed to Sitecore.
This change ensures next uses its own configuration entry for Layout Service that inherits from default ones.

## Testing Details
Manual testing with angular and nextJS apps deployed at the same time: with REST and GraphQL fetch approaches.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
