### PR TITLE
fixing query and output type with personalization enabled

### DIFF
--- a/packages/sitecore-jss-nextjs/src/testData/sitemapPersonalizeQueryResult.json
+++ b/packages/sitecore-jss-nextjs/src/testData/sitemapPersonalizeQueryResult.json
@@ -11,14 +11,18 @@
           "results": [
             {
               "path": "/",
-              "personalize": {
-                "variantIds": ["green"]
-              }
+              "route": {
+                "personalization": {
+                  "variantIds": ["green"]
+                }
+              }              
             },
             {
               "path": "/y1/y2/y3/y4",
-              "personalize": {
-                "variantIds": ["green", "red", "purple"]
+              "route": {
+                "personalization": {
+                  "variantIds": ["green", "red", "purple"]
+                }
               }
             }
           ]


### PR DESCRIPTION
Some fixes to graphQL site query - bringing it to common form, fixing personalization type placement

## Description / Motivation
Changes to personalize query and output type.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
