### PR TITLE
VisitorIdentification component now uses sitecore context hook

### DIFF
--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { withSitecoreContext } from '../enhancers/withSitecoreContext';
-import { SitecoreContextValue } from './SitecoreContext';
-
-interface VIProps {
-  sitecoreContext: SitecoreContextValue;
-}
+import { useSitecoreContext } from '../enhancers/withSitecoreContext';
 
 let emittedVI = false;
-const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
+const VIComponent: React.FC = () => {
+  const { sitecoreContext } = useSitecoreContext();
+
   if (
     emittedVI ||
     typeof document === 'undefined' ||
@@ -36,4 +33,4 @@ const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
 
 VIComponent.displayName = 'VisitorIdentification';
 
-export const VisitorIdentification = withSitecoreContext()(VIComponent);
+export const VisitorIdentification = VIComponent;


### PR DESCRIPTION
VisitorIdentification component now uses sitecore context hook instead of withSitecoreContext helper

## Description / Motivation
Replacing withSitecoreContext usage in VI component to the context hook - in order to avoid nextjs production issues.

## Testing Details
Manual testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
