### PR TITLE
[NextJs] Fix "debug module not found" error in redirects middleware

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
@@ -3,6 +3,9 @@ const { constants } = require('@sitecore-jss/sitecore-jss-nextjs');
 const disconnectedServerUrl = `http://localhost:${process.env.PROXY_PORT || 3042}/`;
 const isDisconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;
 
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const disconnectedPlugin = (nextConfig = {}) => {
   if (!isDisconnected) {
     return nextConfig;

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
@@ -1,3 +1,6 @@
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const styleguidePlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     i18n: {

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { RedirectsMiddleware } from '@sitecore-jss/sitecore-jss-nextjs/edge';
 import config from 'temp/config';
 import { MiddlewarePlugin } from '..';
-import nextConfig from '../../../../next.config';
 
 class RedirectsPlugin implements MiddlewarePlugin {
   private redirectsMiddleware: RedirectsMiddleware;
@@ -13,7 +12,9 @@ class RedirectsPlugin implements MiddlewarePlugin {
       endpoint: config.graphQLEndpoint,
       apiKey: config.sitecoreApiKey,
       siteName: config.jssAppName,
-      locales: nextConfig().i18n.locales,
+      // These are all the locales you support in your application.
+      // These should match those in your next.config.js (i18n.locales).
+      locales: ['en'],
     });
   }
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/next-config/plugins/robots.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/next-config/plugins/robots.js
@@ -1,3 +1,6 @@
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const robotsPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     async rewrites() {

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/next-config/plugins/sitemap.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/next-config/plugins/sitemap.js
@@ -1,3 +1,6 @@
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const sitemapPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     async rewrites() {

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -5,6 +5,9 @@ const plugins = require('./src/temp/next-config-plugins') || {};
 
 const publicUrl = getPublicUrl();
 
+/**
+ * @type {import('next').NextConfig}
+ */
 const nextConfig = {
   // Set assetPrefix to our public URL
   assetPrefix: publicUrl,

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/edge.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/edge.js
@@ -1,3 +1,6 @@
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const edgePlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack: (config, options) => {
@@ -6,7 +9,7 @@ const edgePlugin = (nextConfig = {}) => {
         // Point the Edge compiler in the right direction for 3rd-party module browser bundles.
 
         // debug
-        config.resolve.alias.debug = require.resolve('debug/src/browser');
+        config.resolve.alias['debug'] = require.resolve('debug/src/browser');
         
         // graphql-request
         config.resolve.alias['cross-fetch'] = require.resolve('cross-fetch/dist/browser-ponyfill');

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/graphql.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/graphql.js
@@ -1,3 +1,6 @@
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const graphqlPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack: (config, options) => {

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/monorepo.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/monorepo.js
@@ -5,6 +5,9 @@ const path = require('path');
 
 const CWD = process.cwd();
 
+/**
+ * @param {import('next').NextConfig} nextConfig
+ */
 const monorepoPlugin = (nextConfig = {}) => {
   return withTM(Object.assign({}, nextConfig, {
     webpack: (config, options) => {


### PR DESCRIPTION
## Description / Motivation
Fixes "debug module not found" error in redirects middleware.

Removes import of next.config.js in redirects middleware and use static values for now. next.config.js is not intended to be imported in this way. Will create follow-up to investigate approach to avoid duplicate locales configuration. Hopefully, we will have [access to locales directly in middleware](https://github.com/vercel/next.js/issues/37253).

Also includes type assist JSDoc comments for NextConfig.

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
