### PR TITLE
[sitecore-jss-react] Allow to register custom field components

### DIFF
--- a/packages/sitecore-jss-react-forms/src/field-factory.tsx
+++ b/packages/sitecore-jss-react-forms/src/field-factory.tsx
@@ -28,7 +28,10 @@ class FieldFactory {
     this._defaultComponent = component;
   }
 
-  setComponent<TProps extends FieldProps>(type: FieldTypes, component: FormFieldComponent<TProps>) {
+  setComponent<TProps extends FieldProps>(
+    type: FieldTypes | string,
+    component: FormFieldComponent<TProps>
+  ) {
     this._fieldMap.set(type, component as React.ComponentType<unknown>);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
`setComponents` supports only internal declared components.
We extend it for the ability to provide custom components

Related PR: https://github.com/Sitecore/jss/pull/875

This PR opened to fix lint issue and add change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
