### PR TITLE
[Next.js][Personalize] Switchover to Variants and latest CDP API

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/.env
@@ -10,5 +10,5 @@ NEXT_PUBLIC_CDP_TARGET_URL=https://api.boxever.com/v1.2
 # Your Sitecore CDP JavaScript library URL
 NEXT_PUBLIC_CDP_SCRIPT_URL=https://d1mj578wat5n4o.cloudfront.net/boxever-1.4.8.min.js
 
-# Sitecore CDP point of sale
+# Your Sitecore CDP point of sale
 NEXT_PUBLIC_CDP_POINTOFSALE=

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
@@ -19,6 +19,7 @@ class PersonalizePlugin implements MiddlewarePlugin {
       cdpConfig: {
         endpoint: process.env.NEXT_PUBLIC_CDP_API_URL || '',
         clientKey: process.env.NEXT_PUBLIC_CDP_CLIENT_KEY || '',
+        pointOfSale: process.env.NEXT_PUBLIC_CDP_POINTOFSALE || '',
       },
     });
   }

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/page-props-factory/plugins/personalize.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/page-props-factory/plugins/personalize.ts
@@ -10,15 +10,15 @@ class PersonalizePlugin implements Plugin {
     if (!context?.params?.path) {
       return props;
     }
-    // Get segment for personalization (from path)
+    // Get variant for personalization (from path)
     const path = Array.isArray(context.params.path)
       ? context.params.path.join('/')
       : context.params.path ?? '/';
 
     const personalizeData = getPersonalizedRewriteData(path);
 
-    // Modify layoutData to use specific segment instead of default
-    personalizeLayout(props.layoutData, personalizeData.segmentId);
+    // Modify layoutData to use specific variant instead of default
+    personalizeLayout(props.layoutData, personalizeData.variantId);
 
     return props;
   }

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.ts
@@ -4,6 +4,7 @@ import {
   GraphQLPersonalizeServiceConfig,
   CdpService,
   CdpServiceConfig,
+  ExperienceContext,
   getPersonalizedRewrite,
 } from '@sitecore-jss/sitecore-jss/personalize';
 import { debug, NativeDataFetcher } from '@sitecore-jss/sitecore-jss';
@@ -11,7 +12,7 @@ import { debug, NativeDataFetcher } from '@sitecore-jss/sitecore-jss';
 export type PersonalizeMiddlewareConfig = {
   /**
    * Function used to determine if route should be excluded from personalization.
-   * By default, files (pathname.includes('.')) and API routes (pathname.startsWith('/api/')) are ignored.
+   * By default, files (pathname.includes('.')), Next.js API routes (pathname.startsWith('/api/')), and Sitecore API routes (pathname.startsWith('/sitecore/')) are ignored.
    * This is an important performance consideration since Next.js Edge middleware runs on every request.
    * @param {string} pathname The pathname
    * @returns {boolean} Whether to exclude the route from personalization
@@ -81,10 +82,31 @@ export class PersonalizeMiddleware {
     }
   }
 
+  protected getExperienceContext(req: NextRequest): ExperienceContext {
+    return {
+      geo: {
+        city: req.geo?.city ?? null,
+        country: req.geo?.country ?? null,
+        latitude: req.geo?.latitude ?? null,
+        longitude: req.geo?.longitude ?? null,
+        region: req.geo?.region ?? null,
+      },
+      referrer: req.referrer,
+      ua: req.ua?.ua ?? null,
+      utm: {
+        utm_campaign: req.nextUrl.searchParams.get('utm_campaign'),
+        utm_content: req.nextUrl.searchParams.get('utm_content'),
+        utm_medium: req.nextUrl.searchParams.get('utm_medium'),
+        utm_source: req.nextUrl.searchParams.get('utm_source'),
+      },
+    };
+  }
+
   private excludeRoute(pathname: string) {
     if (
       pathname.includes('.') || // Ignore files
-      pathname.startsWith('/api/') // Ignore API calls
+      pathname.startsWith('/api/') || // Ignore Next.js API calls
+      pathname.startsWith('/sitecore/') // Ignore Sitecore API calls
     ) {
       return true;
     }
@@ -98,17 +120,15 @@ export class PersonalizeMiddleware {
   private handler = async (req: NextRequest, res?: NextResponse): Promise<NextResponse> => {
     const pathname = req.nextUrl.pathname;
     const language = req.nextUrl.locale || req.nextUrl.defaultLocale || 'en';
+    const context = this.getExperienceContext(req);
     let browserId = this.getBrowserId(req);
-    let segment: string | undefined = undefined;
+    let variantId: string | undefined = undefined;
 
     debug.personalize('personalize middleware start: %o', {
       pathname,
       language,
+      context,
       browserId,
-      ip: req.ip,
-      ua: req.ua,
-      geo: req.geo,
-      headers: req.headers,
     });
 
     // Response will be provided if other middleware is run before us (e.g. redirects)
@@ -135,30 +155,33 @@ export class PersonalizeMiddleware {
       return response;
     }
 
-    if (personalizeInfo.segments.length === 0) {
+    if (personalizeInfo.variantIds.length === 0) {
       debug.personalize('skipped (no personalization configured)');
       return response;
     }
 
-    // Get segment data from CDP
-    const segmentData = await this.cdpService.getSegments(personalizeInfo.contentId, browserId);
+    // Get variant data from CDP
+    const variantData = await this.cdpService.executeExperience(
+      personalizeInfo.contentId,
+      context,
+      browserId
+    );
     // If a browserId was not passed in (new session), a new browserId will be returned
-    browserId = segmentData.browserId;
-    // This may change, but for now we are only expected to use the first segment if there are multiple
-    segment = segmentData.segments.length ? segmentData.segments[0] : undefined;
+    browserId = variantData.browserId;
+    variantId = variantData.variantId;
 
-    if (!segment) {
-      debug.personalize('skipped (no segment identified)');
+    if (!variantId) {
+      debug.personalize('skipped (no variant identified)');
       return response;
     }
 
-    if (!personalizeInfo.segments.includes(segment)) {
-      debug.personalize('skipped (invalid segment)');
+    if (!personalizeInfo.variantIds.includes(variantId)) {
+      debug.personalize('skipped (invalid variant)');
       return response;
     }
 
     // Rewrite to persononalized path
-    const rewritePath = getPersonalizedRewrite(pathname, { segmentId: segment });
+    const rewritePath = getPersonalizedRewrite(pathname, { variantId });
     // Note an absolute URL is required: https://nextjs.org/docs/messages/middleware-relative-urls
     const rewriteUrl = req.nextUrl.clone();
     rewriteUrl.pathname = rewritePath;

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -194,7 +194,7 @@ describe('GraphQLSitemapService', () => {
         },
         {
           params: {
-            path: ['_segmentId_green'],
+            path: ['_variantId_green'],
           },
           locale: lang,
         },
@@ -206,19 +206,19 @@ describe('GraphQLSitemapService', () => {
         },
         {
           params: {
-            path: ['_segmentId_green', 'y1', 'y2', 'y3', 'y4'],
+            path: ['_variantId_green', 'y1', 'y2', 'y3', 'y4'],
           },
           locale: lang,
         },
         {
           params: {
-            path: ['_segmentId_red', 'y1', 'y2', 'y3', 'y4'],
+            path: ['_variantId_red', 'y1', 'y2', 'y3', 'y4'],
           },
           locale: lang,
         },
         {
           params: {
-            path: ['_segmentId_purple', 'y1', 'y2', 'y3', 'y4'],
+            path: ['_variantId_purple', 'y1', 'y2', 'y3', 'y4'],
           },
           locale: lang,
         },

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
@@ -244,7 +244,7 @@ export class GraphQLSitemapService {
             if (item.route?.personalization?.variantIds.length) {
               aggregatedPaths.push(
                 ...item.route?.personalization?.variantIds.map((varId) =>
-                  formatPath(getPersonalizedRewrite(item.path, { segmentId: varId }))
+                  formatPath(getPersonalizedRewrite(item.path, { variantId: varId }))
                 )
               );
             }

--- a/packages/sitecore-jss/src/personalize/cdp-service.ts
+++ b/packages/sitecore-jss/src/personalize/cdp-service.ts
@@ -3,9 +3,9 @@ import { HttpDataFetcher } from '../data-fetcher';
 import { AxiosDataFetcher } from '../axios-fetcher';
 
 /**
- * Object model of CDP variant data
+ * Object model of CDP execute experience result
  */
-export type VariantData = {
+export type ExecuteExperienceResult = {
   /**
    * The identified variant
    */
@@ -72,21 +72,21 @@ export class CdpService {
    * Executes targeted experience for a page and context to determine the variant to render.
    * @param {string} contentId the friendly content id of the page
    * @param {ExperienceContext} context the experience context for the user
-   * @param {string} [browserId] the browser id. If omitted, a browserId will be created and returned in the response.
-   * @returns {VariantData} the variant data
+   * @param {string} [browserId] the browser id. If omitted, a browserId will be created and returned in the result.
+   * @returns {ExecuteExperienceResult} the execute experience result
    */
   async executeExperience(
     contentId: string,
     context: ExperienceContext,
     browserId = ''
-  ): Promise<VariantData> {
+  ): Promise<ExecuteExperienceResult> {
     const endpoint = this.getExecuteExperienceUrl(contentId);
 
     debug.personalize('executing experience for %s %s %o', contentId, browserId, context);
 
     const fetcher = this.config.dataFetcherResolver
-      ? this.config.dataFetcherResolver<VariantData>()
-      : this.getDefaultFetcher<VariantData>();
+      ? this.config.dataFetcherResolver<ExecuteExperienceResult>()
+      : this.getDefaultFetcher<ExecuteExperienceResult>();
     const response = await fetcher(endpoint, {
       clientKey: this.config.clientKey,
       pointOfSale: this.config.pointOfSale,

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -11,7 +11,7 @@ describe('GraphQLPersonalizeService', () => {
   const apiKey = 'api-key';
   const id = 'item-id';
   const version = '1';
-  const segments = ['segment-1', 'segment-2'];
+  const variantIds = ['variant-1', 'variant-2'];
 
   const config = {
     endpoint,
@@ -24,7 +24,7 @@ describe('GraphQLPersonalizeService', () => {
         id,
         version,
         personalization: {
-          variantIds: segments,
+          variantIds,
         },
       },
     },
@@ -50,7 +50,7 @@ describe('GraphQLPersonalizeService', () => {
 
     expect(personalizeData).to.deep.equal({
       contentId: `${id}_en_${version}`.toLowerCase(),
-      segments,
+      variantIds,
     });
   });
 

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -29,9 +29,9 @@ export type PersonalizeInfo = {
    */
   contentId: string;
   /**
-   * The configured segments
+   * The configured variant ids
    */
-  segments: string[];
+  variantIds: string[];
 };
 
 type PersonalizeQueryResult = {
@@ -96,7 +96,7 @@ export class GraphQLPersonalizeService {
     return {
       // CDP expects content id format `<id>_<language>_<version>` (lowercase)
       contentId: `${data.layout.item.id}_${language}_${data.layout.item.version}`.toLowerCase(),
-      segments: data.layout.item.personalization.variantIds,
+      variantIds: data.layout.item.personalization.variantIds,
     };
   }
 

--- a/packages/sitecore-jss/src/personalize/index.ts
+++ b/packages/sitecore-jss/src/personalize/index.ts
@@ -3,7 +3,12 @@ export {
   GraphQLPersonalizeService,
   GraphQLPersonalizeServiceConfig,
 } from './graphql-personalize-service';
-export { CdpService, CdpServiceConfig, ExperienceContext, VariantData } from './cdp-service';
+export {
+  CdpService,
+  CdpServiceConfig,
+  ExperienceContext,
+  ExecuteExperienceResult,
+} from './cdp-service';
 export {
   getPersonalizedRewrite,
   getPersonalizedRewriteData,

--- a/packages/sitecore-jss/src/personalize/index.ts
+++ b/packages/sitecore-jss/src/personalize/index.ts
@@ -3,9 +3,10 @@ export {
   GraphQLPersonalizeService,
   GraphQLPersonalizeServiceConfig,
 } from './graphql-personalize-service';
-export { CdpService, CdpServiceConfig } from './cdp-service';
+export { CdpService, CdpServiceConfig, ExperienceContext, VariantData } from './cdp-service';
 export {
   getPersonalizedRewrite,
   getPersonalizedRewriteData,
   normalizePersonalizedRewrite,
+  PersonalizedRewriteData,
 } from './utils';

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
@@ -9,7 +9,7 @@ import {
   componentWithExperiences,
   layoutDataWithoutPlaceholder,
   withoutComponentName,
-  segmentIsNull,
+  variantIsNull,
 } from '../test-data/personalizeData';
 
 const { personalizeLayout, personalizePlaceholder, personalizeComponent } = personalize;
@@ -17,50 +17,50 @@ const { personalizeLayout, personalizePlaceholder, personalizeComponent } = pers
 describe('layout-personalizer', () => {
   describe('personalizeLayout', () => {
     it('should not return anything', () => {
-      const segment = 'test';
-      const personalizedLayoutResult = personalizeLayout(layoutData, segment);
+      const variant = 'test';
+      const personalizedLayoutResult = personalizeLayout(layoutData, variant);
       expect(personalizedLayoutResult).to.equal(undefined);
     });
 
     it('should return undefined if no placeholders', () => {
-      const segment = 'test';
-      const personalizedLayoutResult = personalizeLayout(layoutDataWithoutPlaceholder, segment);
+      const variant = 'test';
+      const personalizedLayoutResult = personalizeLayout(layoutDataWithoutPlaceholder, variant);
       expect(personalizedLayoutResult).to.equal(undefined);
     });
   });
 
   describe('personalizePlaceholder', () => {
     it('should return array of personalized components', () => {
-      const segment = 'mountain_bike_audience';
-      const personalizedPlaceholderResult = personalizePlaceholder(componentsArray, segment);
+      const variant = 'mountain_bike_audience';
+      const personalizedPlaceholderResult = personalizePlaceholder(componentsArray, variant);
       expect(personalizedPlaceholderResult).to.deep.equal(componentsWithExperiencesArray);
     });
   });
 
   describe('personalizeComponent', () => {
     it('should return personalized component', () => {
-      const segment = 'mountain_bike_audience';
+      const variant = 'mountain_bike_audience';
       const personalizedComponentResult = personalizeComponent(
         (component as unknown) as ComponentRenderingWithExperiences,
-        segment
+        variant
       );
       expect(personalizedComponentResult).to.deep.equal(componentWithExperiences);
     });
 
-    it('should return null when segmentVariant is null', () => {
-      const segment = 'mountain_bike_audience';
+    it('should return null when variantVariant is null', () => {
+      const variant = 'mountain_bike_audience';
       const personalizedComponentResult = personalizeComponent(
-        (segmentIsNull as unknown) as ComponentRenderingWithExperiences,
-        segment
+        (variantIsNull as unknown) as ComponentRenderingWithExperiences,
+        variant
       );
       expect(personalizedComponentResult).to.equal(null);
     });
 
-    it('should return null when segmentVariant and componentName is undefined', () => {
-      const segment = 'test';
+    it('should return null when variantVariant and componentName is undefined', () => {
+      const variant = 'test';
       const personalizedComponentResult = personalizeComponent(
         (withoutComponentName as unknown) as ComponentRenderingWithExperiences,
-        segment
+        variant
       );
       expect(personalizedComponentResult).to.equal(null);
     });

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -8,16 +8,16 @@ export type ComponentRenderingWithExperiences = ComponentRendering & {
 /**
  * Apply personalization to layout data. This will recursively go through all placeholders/components, check experiences nodes and replace default with object from specific experience.
  * @param {LayoutServiceData} layout Layout data
- * @param {string} segment segmentId
+ * @param {string} variantId variant id
  */
-export function personalizeLayout(layout: LayoutServiceData, segment: string): void {
+export function personalizeLayout(layout: LayoutServiceData, variantId: string): void {
   const placeholders = layout.sitecore.route?.placeholders;
   if (Object.keys(placeholders ?? {}).length === 0) {
     return;
   }
   if (placeholders) {
     Object.keys(placeholders).forEach((placeholder) => {
-      placeholders[placeholder] = personalizePlaceholder(placeholders[placeholder], segment);
+      placeholders[placeholder] = personalizePlaceholder(placeholders[placeholder], variantId);
     });
   }
 }
@@ -25,17 +25,17 @@ export function personalizeLayout(layout: LayoutServiceData, segment: string): v
 /**
 
  * @param {Array} components components within placeholder
- * @param {string} segment segmentId
+ * @param {string} variantId variant id
  * @returns {Array<ComponentRendering | HtmlElementRendering>} components with personalization applied
  */
 export function personalizePlaceholder(
   components: Array<ComponentRendering | HtmlElementRendering>,
-  segment: string
+  variantId: string
 ): Array<ComponentRendering | HtmlElementRendering> {
   return components
     .map((component) =>
       (component as ComponentRenderingWithExperiences).experiences !== undefined
-        ? (personalizeComponent(component as ComponentRenderingWithExperiences, segment) as
+        ? (personalizeComponent(component as ComponentRenderingWithExperiences, variantId) as
             | ComponentRendering
             | HtmlElementRendering)
         : component
@@ -45,22 +45,22 @@ export function personalizePlaceholder(
 
 /**
  * @param {ComponentRenderingWithExperiences} component component with experiences
- * @param {string} segment segmentId
+ * @param {string} variantId variant id
  * @returns {ComponentRendering | null} component with personalization applied or null if hidden
  */
 export function personalizeComponent(
   component: ComponentRenderingWithExperiences,
-  segment: string
+  variantId: string
 ): ComponentRendering | null {
-  const segmentVariant = component.experiences[segment];
-  if (segmentVariant === undefined && component.componentName === undefined) {
+  const variant = component.experiences[variantId];
+  if (variant === undefined && component.componentName === undefined) {
     // DEFAULT IS HIDDEN
     return null;
-  } else if (Object.keys(segmentVariant ?? {}).length === 0) {
+  } else if (Object.keys(variant ?? {}).length === 0) {
     // HIDDEN
     return null;
-  } else if (segmentVariant) {
-    component = segmentVariant;
+  } else if (variant) {
+    component = variant;
   }
 
   if (!component.placeholders) return component;
@@ -69,7 +69,7 @@ export function personalizeComponent(
     if (component.placeholders) {
       component.placeholders[placeholder] = personalizePlaceholder(
         component.placeholders[placeholder],
-        segment
+        variantId
       );
     }
   });

--- a/packages/sitecore-jss/src/personalize/utils.test.ts
+++ b/packages/sitecore-jss/src/personalize/utils.test.ts
@@ -1,33 +1,34 @@
 ﻿import { expect } from 'chai';
-import * as utils from './utils';
-
-const { getPersonalizedRewrite, getPersonalizedRewriteData, normalizePersonalizedRewrite } = utils;
-
-export const DEFAULT_SEGMENT = '_default';
-export const SEGMENT_PREFIX = '_segmentId_';
+import {
+  getPersonalizedRewrite,
+  getPersonalizedRewriteData,
+  normalizePersonalizedRewrite,
+  VARIANT_PREFIX,
+  DEFAULT_VARIANT,
+} from './utils';
 
 describe('utils', () => {
   describe('getPersonalizedRewrite', () => {
     const data = {
-      segmentId: 'segment-id',
+      variantId: 'variant-id',
     };
     it('should return a string', () => {
       expect(getPersonalizedRewrite('/pathname', data)).to.be.a('string');
     });
-    it('should return the path with the segment id when pathname starts with "/"', () => {
+    it('should return the path with the variant id when pathname starts with "/"', () => {
       const pathname = '/some/path';
       const result = getPersonalizedRewrite(pathname, data);
-      expect(result).to.equal(`/${SEGMENT_PREFIX}${data.segmentId}/some/path`);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/some/path`);
     });
-    it('should return the path with the segment id when pathname not starts with "/"', () => {
+    it('should return the path with the variant id when pathname not starts with "/"', () => {
       const pathname = 'some/path';
       const result = getPersonalizedRewrite(pathname, data);
-      expect(result).to.equal(`/${SEGMENT_PREFIX}${data.segmentId}/some/path`);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/some/path`);
     });
-    it('should return the root path with the segment id', () => {
+    it('should return the root path with the variant id', () => {
       const pathname = '/';
       const result = getPersonalizedRewrite(pathname, data);
-      expect(result).to.equal(`/${SEGMENT_PREFIX}${data.segmentId}/`);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/`);
     });
   });
 
@@ -35,15 +36,20 @@ describe('utils', () => {
     it('should return a PersonalizedRewriteData object', () => {
       expect(getPersonalizedRewriteData('/some/path')).to.be.an('object');
     });
-    it('should return the default segment id when pathname does not contain segment id', () => {
+    it('should return the personalized data from the rewrite path', () => {
+      const pathname = `/some/path/${VARIANT_PREFIX}123/`;
+      const result = getPersonalizedRewriteData(pathname);
+      expect(result.variantId).to.equal('123');
+    });
+    it('should return the default variant id when pathname does not contain variant', () => {
       const pathname = '/some/path';
       const result = getPersonalizedRewriteData(pathname);
-      expect(result.segmentId).to.equal(DEFAULT_SEGMENT);
+      expect(result.variantId).to.equal(DEFAULT_VARIANT);
     });
-    it('should return the personalized data from the rewrite path', () => {
-      const pathname = '/some/path/_segmentId_/';
+    it('should return empty variant id when pathname is missing variant id', () => {
+      const pathname = `/some/path/${VARIANT_PREFIX}/`;
       const result = getPersonalizedRewriteData(pathname);
-      expect(result.segmentId).to.equal('');
+      expect(result.variantId).to.equal('');
     });
   });
 
@@ -51,23 +57,23 @@ describe('utils', () => {
     it('should return a string', () => {
       expect(normalizePersonalizedRewrite('/some/path')).to.be.a('string');
     });
-    it('should return the pathname when it does not contain segment id', () => {
+    it('should return the pathname when it does not contain variant id', () => {
       const pathname = '/some/path';
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal(pathname);
     });
-    it('should return the pathname without the segment id', () => {
-      const pathname = '/_segmentId_foo/some/path';
+    it('should return the pathname without the variant id', () => {
+      const pathname = `/${VARIANT_PREFIX}foo/some/path`;
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal('/some/path');
     });
-    it('should return the root pathname without the segment id', () => {
-      const pathname = '/_segmentId_foo/';
+    it('should return the root pathname without the variant id', () => {
+      const pathname = `/${VARIANT_PREFIX}foo/`;
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal('/');
     });
-    it('should return the root pathname without the segment id when pathname not ends with "/"', () => {
-      const pathname = '/_segmentId_foo';
+    it('should return the root pathname without the variant id when pathname not ends with "/"', () => {
+      const pathname = `/${VARIANT_PREFIX}foo`;
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal('/');
     });

--- a/packages/sitecore-jss/src/personalize/utils.ts
+++ b/packages/sitecore-jss/src/personalize/utils.ts
@@ -1,8 +1,8 @@
-export const DEFAULT_SEGMENT = '_default';
-export const SEGMENT_PREFIX = '_segmentId_';
+export const DEFAULT_VARIANT = '_default';
+export const VARIANT_PREFIX = '_variantId_';
 
 export type PersonalizedRewriteData = {
-  segmentId: string;
+  variantId: string;
 };
 
 /**
@@ -13,7 +13,7 @@ export type PersonalizedRewriteData = {
  */
 export function getPersonalizedRewrite(pathname: string, data: PersonalizedRewriteData): string {
   const path = pathname.startsWith('/') ? pathname : '/' + pathname;
-  return `/${SEGMENT_PREFIX}${data.segmentId}${path}`;
+  return `/${VARIANT_PREFIX}${data.variantId}${path}`;
 }
 
 /**
@@ -23,12 +23,12 @@ export function getPersonalizedRewrite(pathname: string, data: PersonalizedRewri
  */
 export function getPersonalizedRewriteData(pathname: string): PersonalizedRewriteData {
   const data: PersonalizedRewriteData = {
-    segmentId: DEFAULT_SEGMENT,
+    variantId: DEFAULT_VARIANT,
   };
   const path = pathname.endsWith('/') ? pathname : pathname + '/';
-  const result = path.match(`${SEGMENT_PREFIX}(.*?)\\/`);
+  const result = path.match(`${VARIANT_PREFIX}(.*?)\\/`);
   if (result) {
-    data.segmentId = result[1];
+    data.variantId = result[1];
   }
   return data;
 }
@@ -39,9 +39,9 @@ export function getPersonalizedRewriteData(pathname: string): PersonalizedRewrit
  * @returns {string} the pathname with personalize data removed
  */
 export function normalizePersonalizedRewrite(pathname: string): string {
-  if (!pathname.includes(SEGMENT_PREFIX)) {
+  if (!pathname.includes(VARIANT_PREFIX)) {
     return pathname;
   }
-  const result = pathname.match(`${SEGMENT_PREFIX}.*?(?:\\/|$)`);
+  const result = pathname.match(`${VARIANT_PREFIX}.*?(?:\\/|$)`);
   return result === null ? pathname : pathname.replace(result[0], '');
 }

--- a/packages/sitecore-jss/src/test-data/personalizeData.ts
+++ b/packages/sitecore-jss/src/test-data/personalizeData.ts
@@ -100,7 +100,7 @@ export const withoutComponentName = {
   },
 };
 
-export const segmentIsNull = {
+export const variantIsNull = {
   uid: '0b6d23d8-c50e-4e79-9eca-317ec43e82b0',
   componentName: undefined,
   dataSource: 'e020fb58-1be8-4537-aab8-67916452ecf2',


### PR DESCRIPTION
## Description / Motivation
* Updates to reflect latest CDP API specs
* Switch from using "segments" (aka "Streaming Segments") to "variants" (aka "Experience Targeting") terminology
* Also exclude Sitecore API routes in personalize-middleware

## Testing Details
Tested locally using mocked CDP API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
