### PR TITLE
 #hotfix: fixed return data of redirects

### DIFF
--- a/packages/sitecore-jss/src/site/graphql-redirects-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-redirects-service.ts
@@ -89,13 +89,9 @@ export class GraphQLRedirectsService {
       siteName,
     });
 
-    try {
-      return redirectsResult.then((result: RedirectsQueryResult) => {
-        return result?.site?.siteInfo?.redirects;
-      });
-    } catch (e) {
-      return Promise.reject(e);
-    }
+    return redirectsResult
+      .then((result: RedirectsQueryResult) => result.site.siteInfo.redirects)
+      .catch((e) => Promise.reject(e));
   }
 
   /**


### PR DESCRIPTION
There was error 'undefined .find method' on the redirects-middleware