### PR TITLE
[React] Switched back to use  `withSitecoreContext` for  `VisitorIdentification` component.

### DIFF
--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { useSitecoreContext } from '../enhancers/withSitecoreContext';
+import { withSitecoreContext } from '../enhancers/withSitecoreContext';
+import { SitecoreContextValue } from './SitecoreContext';
 
 let emittedVI = false;
-const VIComponent: React.FC = () => {
-  const { sitecoreContext } = useSitecoreContext();
 
+interface VIProps {
+  sitecoreContext: SitecoreContextValue;
+}
+const VIComponent: React.FC<VIProps> = ({ sitecoreContext }) => {
   if (
     emittedVI ||
     typeof document === 'undefined' ||
@@ -33,4 +36,4 @@ const VIComponent: React.FC = () => {
 
 VIComponent.displayName = 'VisitorIdentification';
 
-export const VisitorIdentification = VIComponent;
+export const VisitorIdentification = withSitecoreContext()(VIComponent);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Switching back to use the withSitecoreContext hook clears the console warnings in the browser.
The react18 upgrade fixed the previous issue which made us switch to using a custom hook.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
