### PR TITLE
Add a friendly message when building nextjs app and site items are missing

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -10,6 +10,9 @@ import {
   SitecoreContext,
   ComponentPropsContext,
   handleEditorFastRefresh,
+  <% if (prerender === 'SSG') { -%>
+  StaticPath,
+  <% } -%>
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import { SitecorePageProps } from 'lib/page-props';
 import { sitecorePagePropsFactory } from 'lib/page-props-factory';
@@ -17,6 +20,7 @@ import { sitecorePagePropsFactory } from 'lib/page-props-factory';
 import { componentFactory, editingComponentFactory } from 'temp/componentFactory';
 <% if (prerender === 'SSG') { -%>
 import { sitemapFetcher } from 'lib/sitemap-fetcher';
+
 <% } -%>
 
 const SitecorePage = ({ notFound, componentProps, layoutData }: SitecorePageProps): JSX.Element => {
@@ -56,19 +60,24 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   // ahead of time (non-development mode in this example).
   // See https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration
 
-  if (process.env.NODE_ENV !== 'development') {
-    // Note: Next.js runs export in production mode
-    const paths = await sitemapFetcher.fetch(context);
+  let paths: StaticPath[] = [];
+  let fallback: boolean | 'blocking' = 'blocking';
 
-    return {
-      paths,
-      fallback: process.env.EXPORT_MODE ? false : 'blocking',
-    };
+  if (process.env.NODE_ENV !== 'development') {
+    try {
+      // Note: Next.js runs export in production mode
+      paths = await sitemapFetcher.fetch(context);
+    } catch (rError) {
+      console.log('Error occurred while generating paths');
+      console.log(rError);
+    }
+
+    fallback = process.env.EXPORT_MODE ? false : fallback;
   }
 
   return {
-    paths: [],
-    fallback: 'blocking',
+    paths,
+    fallback,
   };
 };
 

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import nock from 'nock';
 import {
+  getSiteEmptyError,
   GraphQLSitemapService,
   GraphQLSitemapServiceConfig,
   languageError,
@@ -360,6 +361,24 @@ describe('GraphQLSitemapService', () => {
       });
     });
 
+    it('should throw error if query returns nothing for a provided site name', async () => {
+      const service = new GraphQLSitemapService({ endpoint, apiKey, siteName });
+      nock(endpoint)
+        .post('/', (body) => {
+          return body.variables.siteName === siteName;
+        })
+        .reply(200, {
+          data: {
+            site: {
+              siteInfo: null,
+            },
+          },
+        });
+      await service.fetchSSGSitemap(['en']).catch((error: RangeError) => {
+        expect(error.message).to.equal(getSiteEmptyError(siteName));
+      });
+    });
+
     it('should throw error if empty language is provided', async () => {
       mockPathsRequest();
 
@@ -500,6 +519,24 @@ describe('GraphQLSitemapService', () => {
       });
 
       return expect(nock.isDone()).to.be.false;
+    });
+  });
+
+  it('should throw error if query returns nothing for a provided site name', async () => {
+    const service = new GraphQLSitemapService({ endpoint, apiKey, siteName });
+    nock(endpoint)
+      .post('/', (body) => {
+        return body.variables.siteName === siteName;
+      })
+      .reply(200, {
+        data: {
+          site: {
+            siteInfo: null,
+          },
+        },
+      });
+    await service.fetchSSGSitemap(['en']).catch((error: RangeError) => {
+      expect(error.message).to.equal(getSiteEmptyError(siteName));
     });
   });
 

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.ts
@@ -4,6 +4,12 @@ import { getPersonalizedRewrite } from '@sitecore-jss/sitecore-jss/personalize';
 
 /** @private */
 export const languageError = 'The list of languages cannot be empty';
+/**
+ * @param siteName
+ */
+export function getSiteEmptyError(siteName: string) {
+  return `Site "${siteName}" does not exist or site item tree is missing`;
+}
 
 const languageEmptyError = 'The language must be a non-empty string';
 
@@ -275,9 +281,13 @@ export class GraphQLSitemapService {
         after,
       });
 
-      results = results.concat(fetchResponse?.site?.siteInfo?.routes?.results);
-      hasNext = fetchResponse.site.siteInfo.routes.pageInfo.hasNext;
-      after = fetchResponse.site.siteInfo.routes.pageInfo.endCursor;
+      if (!fetchResponse?.site?.siteInfo) {
+        throw new RangeError(getSiteEmptyError(this.options.siteName));
+      } else {
+        results = results.concat(fetchResponse?.site?.siteInfo?.routes?.results);
+        hasNext = fetchResponse.site?.siteInfo?.routes?.pageInfo.hasNext;
+        after = fetchResponse.site?.siteInfo?.routes?.pageInfo.endCursor;
+      }
     }
     return results;
   }


### PR DESCRIPTION
npm run build will no longer fail when building an app for a site that doesn't have items on the Sitecore side - a friendly message with some explanation will be shown.

## Description / Motivation
Small changes to graphql-sitemap-service and to the catch-all page in nextjs template.

## Testing Details
Extra unit tests added for graphql-sitemap-service to ensure the error is thrown.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
