### PR TITLE
#539752 The site can't be opened in the EE and Pages in case the rend…

### DIFF
--- a/packages/sitecore-jss/src/site/graphql-redirects-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-redirects-service.ts
@@ -1,6 +1,7 @@
 import { GraphQLClient, GraphQLRequestClient } from '../graphql';
 import { siteNameError } from '../constants';
 import debug from '../debug';
+import { RestLayoutService } from '../layout';
 
 export const REDIRECT_TYPE_301 = 'REDIRECT_301';
 export const REDIRECT_TYPE_302 = 'REDIRECT_302';
@@ -90,7 +91,15 @@ export class GraphQLRedirectsService {
     });
 
     return redirectsResult
-      .then((result: RedirectsQueryResult) => result.site.siteInfo.redirects)
+      .then((result: RedirectsQueryResult) => {
+        const emptyResult: Array<RedirectInfo> = [];
+
+        if (result.site?.siteInfo?.redirects) {
+          return result.site.siteInfo.redirects;
+        }
+        
+        return emptyResult;
+      })
       .catch((e) => Promise.reject(e));
   }
 


### PR DESCRIPTION
The graphql-redirects-service.ts service needs to be additionally protected in case some data will be removed for the Edge (e.g.: redirects information).

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
