### PR TITLE
[sitecore-jss-react] Refactored `withComponentFactory` HOC

### DIFF
--- a/packages/sitecore-jss-react/src/enhancers/withComponentFactory.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withComponentFactory.tsx
@@ -17,13 +17,10 @@ export function withComponentFactory<T extends ComponentFactoryProps>(
    * @param {T} props - props to pass to the wrapped component
    * @returns {JSX.Element} - the rendered component
    */
-  function WithComponentFactory(props: T) {
+  function WithComponentFactory(props: T): JSX.Element {
     const context = useContext(ComponentFactoryReactContext);
-    return (
-      <ComponentFactoryReactContext.Consumer>
-        {() => <Component {...props} componentFactory={props.componentFactory || context} />}
-      </ComponentFactoryReactContext.Consumer>
-    );
+
+    return <Component {...props} componentFactory={props.componentFactory || context} />;
   }
 
   WithComponentFactory.displayName = `withComponentFactory(${Component.displayName ||

--- a/packages/sitecore-jss-react/src/enhancers/withComponentFactory.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withComponentFactory.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentFactoryReactContext } from '../components/SitecoreContext';
 import { ComponentFactory } from '../components/sharedTypes';
+import { useContext } from 'react';
 
 export interface ComponentFactoryProps {
   componentFactory?: ComponentFactory;
@@ -12,11 +13,22 @@ export interface ComponentFactoryProps {
 export function withComponentFactory<T extends ComponentFactoryProps>(
   Component: React.ComponentClass<T> | React.FC<T>
 ) {
-  return function WithComponentFactory(props: T) {
+  /**
+   * @param {T} props - props to pass to the wrapped component
+   * @returns {JSX.Element} - the rendered component
+   */
+  function WithComponentFactory(props: T) {
+    const context = useContext(ComponentFactoryReactContext);
     return (
       <ComponentFactoryReactContext.Consumer>
-        {(context) => <Component {...props} componentFactory={props.componentFactory || context} />}
+        {() => <Component {...props} componentFactory={props.componentFactory || context} />}
       </ComponentFactoryReactContext.Consumer>
     );
-  };
+  }
+
+  WithComponentFactory.displayName = `withComponentFactory(${Component.displayName ||
+    Component.name ||
+    'Anonymous'})`;
+
+  return WithComponentFactory;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To get around the missing component issue in nextjs SSR production we need to use the `useContext` hook within the HOC and pass the context down to the children components.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
