### PR TITLE
[sitecore-jss-proxy] Provide headers to response when config.onError is called

### DIFF
--- a/packages/sitecore-jss-proxy/src/ProxyConfig.ts
+++ b/packages/sitecore-jss-proxy/src/ProxyConfig.ts
@@ -59,7 +59,11 @@ export interface ProxyConfig {
         statusCode?: number;
         content?: string;
       }
-    | Promise<{ statusCode?: number; content?: string }>;
+    | Promise<{
+        statusCode?: number;
+        content?: string;
+        headers?: Record<string, string | string[]>;
+      }>;
   /** Enables transforming SSR'ed HTML after it is rendered, i.e. to replace paths. */
   transformSSRContent?: (
     response: RenderResponse,

--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -158,6 +158,7 @@ async function renderAppToResponse(
     let errorResponse = {
       statusCode: proxyResponse.statusCode || HttpStatus.INTERNAL_SERVER_ERROR,
       content: proxyResponse.statusMessage || 'Internal Server Error',
+      headers: {},
     };
 
     if (config.onError) {
@@ -165,7 +166,11 @@ async function renderAppToResponse(
       errorResponse = { ...errorResponse, ...onError };
     }
 
-    completeProxyResponse(Buffer.from(errorResponse.content), errorResponse.statusCode, {});
+    completeProxyResponse(
+      Buffer.from(errorResponse.content),
+      errorResponse.statusCode,
+      errorResponse.headers
+    );
   }
 
   // callback handles the result of server-side rendering


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Provide headers returned from `onError` to the response
* Using headers it's possible to enable redirect using `location` header

Related to issue #479 

[Repo](https://github.com/illiakovalenko/headless-proxy-authentication) that contains the reproduction of the authentication issue
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
