### PR TITLE
[sitecore-jss-react] Allow defer prop on VisitorIdentification component

### DIFF
--- a/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
+++ b/packages/sitecore-jss-react/src/components/VisitorIdentification.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { useSitecoreContext } from '../enhancers/withSitecoreContext';
 
+interface VisitorIdentificationProps {
+  defer?: boolean;
+}
+
 let emittedVI = false;
-const VIComponent: React.FC = () => {
+const VIComponent: React.FC<VisitorIdentificationProps> = (props) => {
   const { sitecoreContext } = useSitecoreContext();
 
   if (
@@ -19,6 +23,7 @@ const VIComponent: React.FC = () => {
   const script = document.createElement('script');
   script.src = '/layouts/system/VisitorIdentification.js';
   script.type = 'text/javascript';
+  script.defer = props.defer;
 
   const meta = document.createElement('meta');
   meta.name = 'VIcurrentDateTime';


### PR DESCRIPTION
Add support for the `defer` prop to the `VisitorIdentification` component to support non-blocking script loading.

>This attribute allows the elimination of parser-blocking JavaScript where the browser would have to load and evaluate scripts before continuing to parse. async has a similar effect in this case.

## Description / Motivation
Opt-in to make `VisitorIdentification` non-blocking.

## Testing Details
Component does not have any tests.
Setting `defer` to `true` will render `<script defer ...></script>`.
Setting `defer` to `false` or `undefined` will render `<script ...></script>`.

Making the prop optional makes this a non-breaking change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
