### PR TITLE
[React] Resolve duplicate `react` instances issue

### DIFF
--- a/packages/create-sitecore-jss/src/common/index.ts
+++ b/packages/create-sitecore-jss/src/common/index.ts
@@ -16,6 +16,7 @@ export {
   writePackageJson,
   getBaseTemplates,
   saveConfiguration,
+  removeFile,
 } from './utils/helpers';
 
 export { Initializer } from './Initializer';

--- a/packages/create-sitecore-jss/src/common/utils/helpers.ts
+++ b/packages/create-sitecore-jss/src/common/utils/helpers.ts
@@ -99,3 +99,7 @@ export const getAppPrefix = (appPrefix: boolean, appName: string, includeHyphen 
 export const writeFileToPath = (destinationPath: string, content: string) => {
   fs.writeFileSync(destinationPath, content, 'utf8');
 };
+
+export const removeFile = (filePath: string) => {
+  fs.unlinkSync(filePath);
+};

--- a/packages/create-sitecore-jss/src/initializers/react/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react/index.ts
@@ -1,7 +1,14 @@
 ﻿import chalk from 'chalk';
-import path from 'path';
+import path, { sep } from 'path';
 import { prompt } from 'inquirer';
-import { Initializer, transform } from '../../common';
+import {
+  Initializer,
+  isDevEnvironment,
+  openPackageJson,
+  transform,
+  writePackageJson,
+  removeFile,
+} from '../../common';
 import { prompts, ReactAnswer } from './prompts';
 import { ReactArgs } from './args';
 
@@ -20,6 +27,30 @@ export default class ReactInitializer implements Initializer {
 
     const templatePath = path.resolve(__dirname, '../../templates/react');
     await transform(templatePath, mergedArgs);
+
+    const isDev = isDevEnvironment(args.destination);
+    const pkgPath = path.resolve(`${args.destination}${sep}package.json`);
+    const pkg = openPackageJson(pkgPath);
+
+    if (isDev) {
+      Object.entries<string>(pkg.scripts).forEach(([key, value]) => {
+        // Can't rewire `eject` script
+        if (key === 'eject') return;
+
+        // It's required to start each command using `react-app-rewired`, to solve duplicate `react` issue
+        pkg.scripts[key] = value.replace('react-scripts', 'react-app-rewired');
+      });
+
+      writePackageJson(pkg, pkgPath);
+    } else {
+      // Don't need to rewire anything if we are not in the dev env
+      delete pkg.devDependencies['react-app-rewired'];
+
+      // remove webpack overrides
+      removeFile(path.resolve(`${args.destination}${sep}config-overrides.js`));
+
+      writePackageJson(pkg, pkgPath);
+    }
 
     const response = {
       nextSteps: [`* Connect to Sitecore with ${chalk.green('jss setup')} (optional)`],

--- a/packages/create-sitecore-jss/src/initializers/react/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/react/index.ts
@@ -46,7 +46,7 @@ export default class ReactInitializer implements Initializer {
       // Don't need to rewire anything if we are not in the dev env
       delete pkg.devDependencies['react-app-rewired'];
 
-      // remove webpack overrides
+      // Remove webpack overrides
       removeFile(path.resolve(`${args.destination}${sep}config-overrides.js`));
 
       writePackageJson(pkg, pkgPath);

--- a/packages/create-sitecore-jss/src/templates/react/config-overrides.js
+++ b/packages/create-sitecore-jss/src/templates/react/config-overrides.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = function override(config) {
+  // Provide alias to don't have duplicates of `react`
+  config.resolve.alias.react = path.resolve(process.cwd(), '.', 'node_modules', 'react');
+
+  return config;
+};

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -82,6 +82,7 @@
     "npm-run-all": "~4.1.5",
     "null-loader": "~3.0.0",
     "prettier": "^2.0.5",
+    "react-app-rewired": "^2.2.1",
     "speed-measure-webpack-plugin": "^1.3.1",
     "stats-webpack-plugin": "^0.7.0",
     "url-loader": "~2.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* React throws `invalid hook call` error in case multiple `react` instances are used in the sample
* By default `yarn` doesn't solve duplicate `react` dependencies issue
* `react-app-rewire` provides way to customize webpack config for `create-react-app` template
* Provided `alias` for webpack config, to have a single `react` instance
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
