### PR TITLE
[Nexjs] withSitecoreContext HOC doesn't provide context value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 
 ### 🐛 Bug Fixes
 
-* `[sitecore-jss-react]` Refactored withComponentFactory HOC to fix Next.js SSR production issue ([#1086](https://github.com/Sitecore/jss/pull/1086))
+* `[sitecore-jss-react]` Refactored withComponentFactory ([#1086](https://github.com/Sitecore/jss/pull/1086)) and withSitecoreContext ([#1100](https://github.com/Sitecore/jss/pull/1100)) HOCs to fix Next.js SSR production issue on React 17
 * `[sitecore-jss-react]` Fix Placeholder key is not defined error in Sitecore editors ([#970](https://github.com/Sitecore/jss/pull/970))
 * `[sitecore-jss-react]` Make Image handle 'class' prop when it's passed down ([#971](https://github.com/Sitecore/jss/pull/971))
 * `[template/nextjs]` Dynamic components markup is missing in Experience Editor after adding new rendering ([#1019](https://github.com/Sitecore/jss/pull/1019))

--- a/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withSitecoreContext.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import { SitecoreContextReactContext, SitecoreContextValue } from '../components/SitecoreContext';
 
 export interface WithSitecoreContextOptions {
@@ -27,16 +27,13 @@ export function withSitecoreContext(options?: WithSitecoreContextOptions) {
     Component: React.ComponentType<ComponentProps>
   ) {
     return function WithSitecoreContext(props: WithSitecoreContextHocProps<ComponentProps>) {
+      const context = useContext(SitecoreContextReactContext);
       return (
-        <SitecoreContextReactContext.Consumer>
-          {(context) => (
-            <Component
-              {...(props as ComponentProps)}
-              sitecoreContext={context.context}
-              updateSitecoreContext={options && options.updatable && context.setContext}
-            />
-          )}
-        </SitecoreContextReactContext.Consumer>
+        <Component
+          {...(props as ComponentProps)}
+          sitecoreContext={context.context}
+          updateSitecoreContext={options && options.updatable && context.setContext}
+        />
       );
     };
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Provide value using `hook` instead of `Provider` to fix the issue for react 17
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
