### PR TITLE
[Vue] Fix compilers proxy options in template

### DIFF
--- a/packages/create-sitecore-jss/src/templates/vue/scripts/disconnected-mode-proxy.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/disconnected-mode-proxy.js
@@ -25,7 +25,7 @@ const proxyOptions = {
   watchPaths: ['./data'],
   language: config.defaultLanguage,
   port: process.env.PROXY_PORT || 3042,
-  compilers: ['@babel/register'],
+  requireArg: '@babel/register',
   onManifestUpdated: () => {
     // if we can resolve the config file, we can alter it to force reloading the app automatically
     // instead of waiting for a manual reload. We must materially alter the _contents_ of the file to trigger


### PR DESCRIPTION
## Description / Motivation

After some analysis of the project, it seems the `compilers` option is not used anymore.  
It was renamed to `requireArg?: string | null;`

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

In general, I see that the Vue template is very outdated.
I'm working on a new template that uses Vite and supports TypeScript
https://github.com/jagaad/create-sitecore-jss-vue