### PR TITLE
[React] Module parse failed: Unexpected token, htmlparser2

### DIFF
--- a/packages/create-sitecore-jss/src/templates/react/server/server.webpack.config.js
+++ b/packages/create-sitecore-jss/src/templates/react/server/server.webpack.config.js
@@ -22,6 +22,15 @@ module.exports = {
     rules: [
       {
         test: /\.m?jsx?$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: ['@babel/plugin-proposal-export-namespace-from'],
+          },
+        },
+      },
+      {
+        test: /\.m?jsx?$/,
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* `html-react-parser` from `sitecore-jss-react` uses `htmlparser2` which uses `export * as ns from`: https://github.com/fb55/htmlparser2/issues/1237
* `webpack 4` doesn't support `export * as ns from`, and it's available by default only using `webpack 5`: https://github.com/webpack/webpack/issues/10460
* we can't upgrade webpack, cause we need to upgrade `create-react-app`, it has peer dep on `webpack`
* [@babel/plugin-proposal-export-namespace-from](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from) plugin allows to use `export * as ns from` in esm

Need to revisit webpack server config after the upgrade
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
