### PR TITLE
[Personalize] Middleware does not fallback to default variantID when route is not `/`

### DIFF
--- a/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
@@ -9,7 +9,7 @@ import {
   componentWithExperiences,
   layoutDataWithoutPlaceholder,
   withoutComponentName,
-  variantIsNull,
+  variantIsHidden,
 } from '../test-data/personalizeData';
 
 const { personalizeLayout, personalizePlaceholder, personalizeComponent } = personalize;
@@ -47,10 +47,19 @@ describe('layout-personalizer', () => {
       expect(personalizedComponentResult).to.deep.equal(componentWithExperiences);
     });
 
-    it('should return null when variantVariant is null', () => {
+    it('should return default component when variant is undefined', () => {
+      const variant = '_default';
+      const personalizedComponentResult = personalizeComponent(
+        (component as unknown) as ComponentRenderingWithExperiences,
+        variant
+      );
+      expect(personalizedComponentResult).to.deep.equal(component);
+    });
+
+    it('should return null when variantVariant is hidden', () => {
       const variant = 'mountain_bike_audience';
       const personalizedComponentResult = personalizeComponent(
-        (variantIsNull as unknown) as ComponentRenderingWithExperiences,
+        (variantIsHidden as unknown) as ComponentRenderingWithExperiences,
         variant
       );
       expect(personalizedComponentResult).to.equal(null);

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -1,6 +1,5 @@
 import { LayoutServiceData, ComponentRendering, HtmlElementRendering } from './../layout/models';
 
-// NULL means Hidden by this experience
 export type ComponentRenderingWithExperiences = ComponentRendering & {
   experiences: { [name: string]: ComponentRenderingWithExperiences };
 };

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -2,7 +2,7 @@ import { LayoutServiceData, ComponentRendering, HtmlElementRendering } from './.
 
 // NULL means Hidden by this experience
 export type ComponentRenderingWithExperiences = ComponentRendering & {
-  experiences: { [name: string]: ComponentRenderingWithExperiences | null };
+  experiences: { [name: string]: ComponentRenderingWithExperiences };
 };
 
 /**
@@ -56,7 +56,7 @@ export function personalizeComponent(
   if (variant === undefined && component.componentName === undefined) {
     // DEFAULT IS HIDDEN
     return null;
-  } else if (Object.keys(variant ?? {}).length === 0) {
+  } else if (variant && variant.componentName === null && variant.dataSource === null) {
     // HIDDEN
     return null;
   } else if (variant) {

--- a/packages/sitecore-jss/src/test-data/personalizeData.ts
+++ b/packages/sitecore-jss/src/test-data/personalizeData.ts
@@ -100,12 +100,16 @@ export const withoutComponentName = {
   },
 };
 
-export const variantIsNull = {
+export const variantIsHidden = {
   uid: '0b6d23d8-c50e-4e79-9eca-317ec43e82b0',
   componentName: undefined,
   dataSource: 'e020fb58-1be8-4537-aab8-67916452ecf2',
   fields: { content: { value: '' }, heading: { value: 'Default Content' } },
   experiences: {
-    mountain_bike_audience: {},
+    mountain_bike_audience: {
+      componentName: null,
+      dataSource: null,
+      uid: '0b6d23d8-c50e-4e79-9eca-317ec43e82b1',
+    },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* When variant is hidden it will have next structure
![image](https://user-images.githubusercontent.com/23364749/181365164-f0099c1e-6bde-4d6e-bdfc-e556b256373c.png)
* Variant can't be null, so if we have `_default` variant, then component data will be used as a fallback
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
