### PR TITLE
Error boundaries for dynamic components

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/assets/app.css
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/assets/app.css
@@ -13,7 +13,8 @@ a[target='_blank']:after {
   Styles for default JSS error components
 */
 .sc-jss-editing-error,
-.sc-jss-placeholder-error {
+.sc-jss-placeholder-error 
+.sc-jss-component-error {
   padding: 1em;
   background-color: lightyellow;
 }

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -83,6 +83,7 @@
     "null-loader": "~3.0.0",
     "prettier": "^2.0.5",
     "react-app-rewired": "^2.2.1",
+    "react-error-overlay": "^6.0.11",
     "speed-measure-webpack-plugin": "^1.3.1",
     "stats-webpack-plugin": "^0.7.0",
     "url-loader": "~2.1.0",

--- a/packages/create-sitecore-jss/src/templates/react/src/assets/app.css
+++ b/packages/create-sitecore-jss/src/templates/react/src/assets/app.css
@@ -17,3 +17,13 @@ a[target='_blank']:after {
   font-weight: 300;
   line-height: 1.2;
 }
+
+/*
+  Styles for default JSS error components
+*/
+.sc-jss-editing-error,
+.sc-jss-placeholder-error
+.sc-jss-component-error {
+  padding: 1em;
+  background-color: lightyellow;
+}

--- a/packages/create-sitecore-jss/src/templates/react/src/index.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/index.js
@@ -9,6 +9,14 @@ import AppRoot from './AppRoot';
 import GraphQLClientFactory from './lib/GraphQLClientFactory';
 import config from './temp/config';
 import i18ninit from './i18n';
+import { stopReportingRuntimeErrors } from 'react-error-overlay';
+
+/* as we handle and show errors via error boundaries and console we want to avoid error overlay showing up */
+/* in part because it's not working correctly at the moment: https://github.com/facebook/create-react-app/issues/11773 */
+/* please feel free to disable this if overlay is needed for your dev environments */
+if (process.env.NODE_ENV === 'development') {
+  stopReportingRuntimeErrors();
+}
 
 if (process.env.REACT_APP_DEBUG) {
   enableDebug(process.env.REACT_APP_DEBUG);

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -142,4 +142,5 @@ export {
   WithSitecoreContextProps,
   withErrorBoundary,
   ErrorBoundary,
+  ErrorBoundaryProps,
 } from '@sitecore-jss/sitecore-jss-react';

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -140,4 +140,6 @@ export {
   ComponentConsumerProps,
   WithSitecoreContextOptions,
   WithSitecoreContextProps,
+  withErrorBoundary,
+  ErrorBoundary,
 } from '@sitecore-jss/sitecore-jss-react';

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -21,6 +21,7 @@ export interface ErrorBoundaryProps {
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
+    this.state = {};
   }
 
   previousError: Error;

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorState {
+  hasError?: boolean;
+  error?: Error;
+  errorInfo?: ErrorInfo;
+}
+
+type ErrorComponentProps = {
+  [prop: string]: unknown;
+};
+
+export interface ErrorBoundaryProps {
+  errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
+  children?: ReactNode;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  defaultErrorComponent: React.FC<{ error: Error; errorInfo: ErrorInfo }> = ({
+    error,
+    errorInfo,
+  }) => {
+    return (
+        <div className="sc-jss-component-error">
+          <p>A rendering error occurred: {error.message}.</p>
+          <p>Stack trace: {errorInfo.componentStack}</p>
+        </div>
+    );
+  };
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({ error, errorInfo });
+  }
+
+  render() {
+    if (this.state.hasError || this.state.error) {
+      if (this.props.errorComponent) {
+        return (
+          <this.props.errorComponent
+            errorMessage={this.state.error.message}
+            errorStack={this.state.errorInfo.componentStack}
+          />
+        );
+      } else {
+        return (
+          <this.defaultErrorComponent error={this.state.error} errorInfo={this.state.errorInfo} />
+        );
+      }
+    }
+    return this.props.children;
+  }
+}

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -26,14 +26,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
     this.state = {};
   }
 
-  defaultErrorComponent: React.FC<{ error: Error; errorInfo: ErrorInfo }> = ({
+  defaultErrorComponent: React.FC<{ error: Error; errorStack: string }> = ({
     error,
-    errorInfo,
+    errorStack,
   }) => {
     return (
       <div className="sc-jss-component-error">
         <p>A rendering error occurred: {error.message}.</p>
-        <p>Stack trace: {errorInfo.componentStack}</p>
+        <p>Stack trace: {errorStack}</p>
       </div>
     );
   };
@@ -50,13 +50,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
       if (this.props.errorComponent) {
         return (
           <this.props.errorComponent
-            errorMessage={this.state.error.message}
+            error={this.state.error}
             errorStack={this.state.errorInfo.componentStack}
           />
         );
       } else {
         return (
-          <this.defaultErrorComponent error={this.state.error} errorInfo={this.state.errorInfo} />
+          <this.defaultErrorComponent error={this.state.error} errorStack={this.state.errorInfo.componentStack} />
         );
       }
     }

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -14,34 +14,34 @@ export interface ErrorBoundaryProps {
   children?: ReactNode;
 }
 
-//**
+//* *
 // * This component will simply wrap any other component passed down to it and contain an error that could be thrown
 // * So that all other components on page would still be displayed
 //*
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
+  previousError: Error;
+
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = {};
   }
-
-  previousError: Error;
 
   defaultErrorComponent: React.FC<{ error: Error; errorInfo: ErrorInfo }> = ({
     error,
     errorInfo,
   }) => {
     return (
-        <div className="sc-jss-component-error">
-          <p>A rendering error occurred: {error.message}.</p>
-          <p>Stack trace: {errorInfo.componentStack}</p>
-        </div>
+      <div className="sc-jss-component-error">
+        <p>A rendering error occurred: {error.message}.</p>
+        <p>Stack trace: {errorInfo.componentStack}</p>
+      </div>
     );
   };
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    if (JSON.stringify(error) !== JSON.stringify(this.previousError)){
-        this.previousError = error;
-        this.setState({ error, errorInfo });
+    if (JSON.stringify(error) !== JSON.stringify(this.previousError)) {
+      this.previousError = error;
+      this.setState({ error, errorInfo });
     }
   }
 

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 
 interface ErrorState {
-  hasError?: boolean;
   error?: Error;
   errorInfo?: ErrorInfo;
 }
@@ -15,11 +14,16 @@ export interface ErrorBoundaryProps {
   children?: ReactNode;
 }
 
+//**
+// * This component will simply wrap any other component passed down to it and contain an error that could be thrown
+// * So that all other components on page would still be displayed
+//*
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false };
   }
+
+  previousError: Error;
 
   defaultErrorComponent: React.FC<{ error: Error; errorInfo: ErrorInfo }> = ({
     error,
@@ -34,11 +38,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorState> {
   };
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    this.setState({ error, errorInfo });
+    if (JSON.stringify(error) !== JSON.stringify(this.previousError)){
+        this.previousError = error;
+        this.setState({ error, errorInfo });
+    }
   }
 
   render() {
-    if (this.state.hasError || this.state.error) {
+    if (this.state.error) {
       if (this.props.errorComponent) {
         return (
           <this.props.errorComponent

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -11,6 +11,8 @@ import {
 } from '@sitecore-jss/sitecore-jss/layout';
 import { convertAttributesToReactProps } from '../utils';
 import { HiddenRendering, HIDDEN_RENDERING_NAME } from './HiddenRendering';
+import { withErrorBoundary } from '../enhancers/withErrorBoundary';
+import { ErrorBoundaryProps } from './ErrorBoundary';
 
 /** [SXA] common marker by which we find container fo replacing **/
 const PREFIX_PLACEHOLDER = 'container-{*}';
@@ -73,6 +75,12 @@ export interface PlaceholderProps {
    * the placeholder
    */
   errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
+
+  /**
+   * Optional error boundary component that can replace the default JSS implementation when needed.
+   * Error boundary is an HOC that would wrap every dynamic component/rendering added to a placeholder
+   */
+  errorBoundaryComponent?: React.ComponentClass<ErrorBoundaryProps> | React.FC<ErrorBoundaryProps>;
 }
 
 export class PlaceholderCommon<T extends PlaceholderProps> extends React.Component<T> {
@@ -245,13 +253,15 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
 
     // Render SXA Rendering Variant
     if (renderingDefinition.params?.FieldNames) {
-      return componentFactory(
-        renderingDefinition.componentName,
-        renderingDefinition.params.FieldNames
-      );
+      return withErrorBoundary(
+        this.props.errorComponent,
+        this.props.errorBoundaryComponent
+      )(componentFactory(renderingDefinition.componentName, renderingDefinition.params.FieldNames));
     }
 
-    return componentFactory(renderingDefinition.componentName);
+    return withErrorBoundary(this.props.errorComponent)(
+      componentFactory(renderingDefinition.componentName)
+    );
   }
 
   addRef(nodeRef: Element) {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -205,7 +205,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         if (componentRendering.componentName === HIDDEN_RENDERING_NAME) {
           component = hiddenRenderingComponent ?? HiddenRendering;
         } else {
-          component = this.getComponentForRendering(componentRendering);
+          component = withErrorBoundary(
+            this.props.errorComponent,
+            this.props.errorBoundaryComponent
+          )(this.getComponentForRendering(componentRendering));
         }
 
         if (!component) {
@@ -253,15 +256,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
 
     // Render SXA Rendering Variant
     if (renderingDefinition.params?.FieldNames) {
-      return withErrorBoundary(
-        this.props.errorComponent,
-        this.props.errorBoundaryComponent
-      )(componentFactory(renderingDefinition.componentName, renderingDefinition.params.FieldNames));
+      return componentFactory(renderingDefinition.componentName, renderingDefinition.params.FieldNames);
     }
 
-    return withErrorBoundary(this.props.errorComponent)(
-      componentFactory(renderingDefinition.componentName)
-    );
+    return componentFactory(renderingDefinition.componentName);
   }
 
   addRef(nodeRef: Element) {

--- a/packages/sitecore-jss-react/src/enhancers/withErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ErrorBoundary, ErrorBoundaryProps } from '../components/ErrorBoundary';
+
+/**
+ * @param errorComponent
+ * @param errorBoundaryComponent
+ */
+export function withErrorBoundary(
+  errorComponent?: React.ComponentClass | React.FC,
+  errorBoundaryComponent?: React.ComponentClass<ErrorBoundaryProps> | React.FC<ErrorBoundaryProps>
+) {
+  return function withErrorBoundaryHOC<TComponentProps>(
+    BoundComponent: React.ComponentType<TComponentProps>
+  ) {
+    return BoundComponent === null
+      ? null
+      : function errorWrapper(props: TComponentProps) {
+          const ErrorBoundaryInternal = errorBoundaryComponent ?? ErrorBoundary;
+          return (
+            <ErrorBoundaryInternal errorComponent={errorComponent}>
+              <BoundComponent {...props} />
+            </ErrorBoundaryInternal>
+          );
+        };
+  };
+}

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -65,7 +65,6 @@ export {
   WithSitecoreContextProps,
   WithSitecoreContextHocProps,
 } from './enhancers/withSitecoreContext';
-export { withErrorBoundary } from './enhancers/withErrorBoundary';
 export { withEditorChromes } from './enhancers/withEditorChromes';
 export { withPlaceholder } from './enhancers/withPlaceholder';
 export { withDatasourceCheck } from './enhancers/withDatasourceCheck';

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -47,6 +47,7 @@ export {
 export { RichText, RichTextProps, RichTextPropTypes, RichTextField } from './components/RichText';
 export { Text, TextField } from './components/Text';
 export { DateField } from './components/Date';
+export { ErrorBoundary, ErrorBoundaryProps } from './components/ErrorBoundary';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';
 export { VisitorIdentification } from './components/VisitorIdentification';
@@ -64,6 +65,7 @@ export {
   WithSitecoreContextProps,
   WithSitecoreContextHocProps,
 } from './enhancers/withSitecoreContext';
+export { withErrorBoundary } from './enhancers/withErrorBoundary';
 export { withEditorChromes } from './enhancers/withEditorChromes';
 export { withPlaceholder } from './enhancers/withPlaceholder';
 export { withDatasourceCheck } from './enhancers/withDatasourceCheck';


### PR DESCRIPTION
Adds error boundary component that wraps around dynamic components under placeholders

## Description / Motivation
Error boundaries would allow to contain rendering errors to one component only - making sure other renderings under a placeholder are displayed fine.
This update adds an out of the box default error boundary component, as well as the possibility to pass down custom error boundaries and error components (displayed on error) into a placeholder.

## Testing Details
Works in connected, disconnected modes. An extra unit test added, with tweaks to existing ones.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
