### PR TITLE
Updating next to 12.2.4 - and reintroducing babel to avoid swc errors

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
@@ -1,0 +1,9 @@
+// This file exists in order to disable Next.js SWC compilation due to
+// current instability. Specifically, when compiling on Windows-based
+// rendering hosts using containers you may see the following error:
+// https://nextjs.org/docs/messages/failed-loading-swc
+//
+// You may wish to remove this file when deploying to Vercel.
+{
+    "presets": ["next/babel"]
+}

--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -32,7 +32,7 @@
     "@sitecore-jss/sitecore-jss-nextjs": "^21.0.0-canary",
     "graphql": "~15.8.0",
     "graphql-tag": "^2.11.0",
-    "next": "^12.2.2",
+    "next": "^12.2.4",
     "next-localization": "^0.12.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "^7.21.5",
     "jsdom": "^15.1.1",
     "mocha": "^9.1.3",
-    "next": "^12.2.2",
+    "next": "^12.2.4",
     "nock": "^13.0.5",
     "nyc": "^15.1.0",
     "react": "^18.1.0",
@@ -64,7 +64,7 @@
     "typescript": "~4.3.5"
   },
   "peerDependencies": {
-    "next": "^12.2.2",
+    "next": "^12.2.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"
   },


### PR DESCRIPTION
Nextjs 12.2.4 fixes some issues - but reintroduces swc exception that happens in containers. This PR reintroduces babelrc file to avoid it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
