### PR TITLE
#544785: The title rendering is underlined with two lines

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/title/_component-title.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/title/_component-title.scss
@@ -5,7 +5,7 @@
   background: $title-bg;
   h1,
   .field-title {
-    a, span {
+    >a, >span {
       @include border-basic(bottom, $border-basic-color);
       font-size: $font-extrabig;
       margin-bottom: $small-margin;


### PR DESCRIPTION
Experience Editor added it's markup in a `<span>`, which caused double underline. Changed the CSS to underline only immediate `<span>` and `<a>` children.