### PR TITLE
#544714: Wrong alignment for the Container component

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-container.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-container.scss
@@ -2,6 +2,8 @@
 
 .container {
   padding: 0;
+  margin-right: unset;
+  margin-left: unset;
 
   &.fullwidth-container {
     max-width: unset;


### PR DESCRIPTION
Bootstrap 5 has a class named "container", which interferes with SXA Container rendering. I've set the `margin-right` and `margin-left` properties to `unset` in the Container rendering SCSS to fix this.