### PR TITLE
[EE] Timeout error on CM when calling Next.js rendering host

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/middleware.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/middleware.ts
@@ -5,3 +5,8 @@ import middleware from 'lib/middleware';
 export default async function (req: NextRequest, ev: NextFetchEvent) {
   return middleware(req, ev);
 }
+
+export const config = {
+  // Exclude Sitecore editing API routes
+  matcher: ['/', '/((?!api/editing/).*)'],
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes the timeout error in EE by excluding the middleware paths.

NOTE: Should reverse this change once this gets fixed: https://github.com/vercel/next.js/issues/39262

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
