### PR TITLE
#546839: handle _blank target on links in rich text

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -201,4 +201,41 @@ describe('RichText', () => {
 
     expect(c.find(ReactRichText).length).to.equal(1);
   });
+
+  it('should not initialize links when target set to "_blank"', () => {
+    const app = document.createElement('main');
+
+    document.body.appendChild(app);
+
+    const router = Router();
+
+    const props = {
+      field: {
+        value: '<div id="test"><h1>Hello!</h1><a href="/t1" target="_blank">t1</a></div>',
+      },
+    };
+
+    const c = mount(
+      <Page value={router}>
+        <RichText {...props} />
+      </Page>,
+      { attachTo: app }
+    );
+
+    expect(c.html()).contains('<div id="test">');
+    expect(c.html()).contains('<h1>Hello!</h1>');
+    expect(c.html()).contains('<a href="/t1" target="_blank">t1</a>');
+
+    const main = document.querySelector('main');
+    const links = main && main.querySelectorAll('a');
+    const link = links && links[0];
+
+    expect(router.prefetch).callCount(0);
+
+    link && link.click();
+
+    expect(router.push).callCount(0);
+
+    expect(c.find(ReactRichText).length).to.equal(1);
+  });
 });

--- a/packages/sitecore-jss-nextjs/src/components/RichText.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.tsx
@@ -51,12 +51,13 @@ export const RichText = (props: RichTextProps): JSX.Element => {
     if (!internalLinks || !internalLinks.length) return;
 
     internalLinks.forEach((link) => {
-      if (!prefetched[link.pathname]) {
-        router.prefetch(link.pathname, undefined, { locale: false });
-        prefetched[link.pathname] = true;
+      if (link.target !== '_blank') {
+        if (!prefetched[link.pathname]) {
+          router.prefetch(link.pathname, undefined, { locale: false });
+          prefetched[link.pathname] = true;
+        }
+        link.addEventListener('click', routeHandler, false);
       }
-
-      link.addEventListener('click', routeHandler, false);
     });
   };
 


### PR DESCRIPTION
Fix for _blank target in rich text links

## Description / Motivation
Links in rich text fields will now correctly open new tab.

## Testing Details
One extra unit test added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
