### PR TITLE
[Next.js][Personalize] Unit tests for Personalize Middleware

### DIFF
--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -47,6 +47,7 @@
     "chai-string": "^1.5.0",
     "chalk": "^4.1.2",
     "cheerio": "1.0.0-rc.10",
+    "cross-fetch": "^3.1.5",
     "del-cli": "^5.0.0",
     "enzyme": "^3.11.0",
     "eslint": "^7.15.0",

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
@@ -1,0 +1,465 @@
+/* eslint-disable no-unused-expressions */
+// import React from 'react';
+// import { expect } from 'chai';
+// import { mount } from 'enzyme';
+
+import chai, { use } from 'chai';
+import chaiString from 'chai-string';
+import sinonChai from 'sinon-chai';
+import sinon, { spy } from 'sinon';
+import nock from 'nock';
+
+import { debug } from '@sitecore-jss/sitecore-jss';
+// import { enableDebug } from '@sitecore-jss/sitecore-jss-react';
+
+import { PersonalizeMiddleware } from './personalize-middleware';
+import { NextRequest, NextResponse } from 'next/server';
+
+use(sinonChai);
+const expect = chai.use(chaiString).expect;
+
+describe.only('PersonalizeMiddleware', () => {
+  describe('disabled', () => {
+    const createMiddleware = () =>
+      new PersonalizeMiddleware({
+        cdpConfig: {
+          clientKey: 'cdp-client-key',
+          endpoint: 'cdp-endpoint',
+          pointOfSale: 'cdp-pos',
+        },
+        edgeConfig: {
+          apiKey: 'edge-api-key',
+          endpoint: 'http://edge-endpoint/api/graph/edge',
+          siteName: 'nextjs-app',
+        },
+        disabled: (req, res) => req?.nextUrl.pathname === '/' && req.nextUrl.locale === 'en',
+      });
+
+    const req = {
+      nextUrl: {
+        pathname: '/',
+        locale: 'en',
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
+
+          return cookies[cookieName];
+        },
+      },
+    } as NextRequest;
+
+    const res = {
+      cookies: {},
+    } as NextResponse;
+
+    it('default response returned', async () => {
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const debugSpy = spy(debug, 'personalize');
+
+      const finalRes = await middleware.getHandler()(req);
+
+      expect(debugSpy.callCount).to.equal(2);
+
+      expect(
+        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+          pathname: '/',
+          language: 'en',
+        })
+      ).to.be.true;
+
+      expect(debugSpy.getCall(1).calledWith('skipped (personalize middleware is disabled)')).to.be
+        .true;
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(NextResponse.next());
+
+      getCookiesSpy.restore();
+      debugSpy.restore();
+    });
+
+    it('custom response returned', async () => {
+      const middleware = createMiddleware();
+
+      const debugSpy = spy(debug, 'personalize');
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      expect(
+        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+          pathname: '/',
+          language: 'en',
+        })
+      ).to.be.true;
+
+      expect(debugSpy.getCall(1).calledWith('skipped (personalize middleware is disabled)')).to.be
+        .true;
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+      debugSpy.restore();
+    });
+  });
+
+  it('redirected', async () => {
+    const createMiddleware = () =>
+      new PersonalizeMiddleware({
+        cdpConfig: {
+          clientKey: 'cdp-client-key',
+          endpoint: 'cdp-endpoint',
+          pointOfSale: 'cdp-pos',
+        },
+        edgeConfig: {
+          apiKey: 'edge-api-key',
+          endpoint: 'http://edge-endpoint/api/graph/edge',
+          siteName: 'nextjs-app',
+        },
+      });
+
+    const req = {
+      nextUrl: {
+        pathname: '/',
+        locale: 'en',
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
+
+          return cookies[cookieName];
+        },
+      },
+    } as NextRequest;
+
+    const res = {
+      cookies: {},
+      redirected: true,
+    } as NextResponse;
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(debugSpy.callCount).to.equal(2);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'redirected')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+  });
+
+  describe('preview', () => {
+    it('prerender bypass', async () => {
+      const createMiddleware = () =>
+        new PersonalizeMiddleware({
+          cdpConfig: {
+            clientKey: 'cdp-client-key',
+            endpoint: 'cdp-endpoint',
+            pointOfSale: 'cdp-pos',
+          },
+          edgeConfig: {
+            apiKey: 'edge-api-key',
+            endpoint: 'http://edge-endpoint/api/graph/edge',
+            siteName: 'nextjs-app',
+          },
+        });
+
+      const req = {
+        nextUrl: {
+          pathname: '/',
+          locale: 'en',
+        },
+        cookies: {
+          get(cookieName: string) {
+            const cookies = { 'bid_cdp-client-key': 'browser-id-value', __prerender_bypass: true };
+
+            return cookies[cookieName];
+          },
+        },
+      } as NextRequest;
+
+      const res = {
+        cookies: {},
+      } as NextResponse;
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const debugSpy = spy(debug, 'personalize');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      expect(debugSpy.callCount).to.equal(2);
+
+      expect(
+        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+          pathname: '/',
+          language: 'en',
+        })
+      ).to.be.true;
+
+      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'preview')).to.be.true;
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+      expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+      debugSpy.restore();
+    });
+
+    it('preview data', async () => {
+      const createMiddleware = () =>
+        new PersonalizeMiddleware({
+          cdpConfig: {
+            clientKey: 'cdp-client-key',
+            endpoint: 'cdp-endpoint',
+            pointOfSale: 'cdp-pos',
+          },
+          edgeConfig: {
+            apiKey: 'edge-api-key',
+            endpoint: 'http://edge-endpoint/api/graph/edge',
+            siteName: 'nextjs-app',
+          },
+        });
+
+      const req = {
+        nextUrl: {
+          pathname: '/',
+          locale: 'en',
+        },
+        cookies: {
+          get(cookieName: string) {
+            const cookies = { 'bid_cdp-client-key': 'browser-id-value', __next_preview_data: true };
+
+            return cookies[cookieName];
+          },
+        },
+      } as NextRequest;
+
+      const res = {
+        cookies: {},
+      } as NextResponse;
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const debugSpy = spy(debug, 'personalize');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      expect(debugSpy.callCount).to.equal(2);
+
+      expect(
+        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+          pathname: '/',
+          language: 'en',
+        })
+      ).to.be.true;
+
+      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'preview')).to.be.true;
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+      expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
+      expect(getCookiesSpy.calledWith('__next_preview_data')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+      debugSpy.restore();
+    });
+  });
+
+  describe('excluded route', () => {
+    const res = {
+      cookies: {},
+    } as NextResponse;
+
+    const test = async (pathname: string, middleware) => {
+      const req = {
+        nextUrl: {
+          pathname,
+          locale: 'en',
+        },
+        cookies: {
+          get(cookieName: string) {
+            const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
+
+            return cookies[cookieName];
+          },
+        },
+      } as NextRequest;
+
+      const debugSpy = spy(debug, 'personalize');
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      expect(
+        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+          pathname,
+          language: 'en',
+        })
+      ).to.be.true;
+
+      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'route excluded')).to.be.true;
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+      debugSpy.restore();
+    };
+
+    it('default', async () => {
+      const middleware = new PersonalizeMiddleware({
+        cdpConfig: {
+          clientKey: 'cdp-client-key',
+          endpoint: 'cdp-endpoint',
+          pointOfSale: 'cdp-pos',
+        },
+        edgeConfig: {
+          apiKey: 'edge-api-key',
+          endpoint: 'http://edge-endpoint/api/graph/edge',
+          siteName: 'nextjs-app',
+        },
+      });
+
+      await test('/src/image.png', middleware);
+      await test('/api/layout/render', middleware);
+      await test('/sitecore/render', middleware);
+      await test('/_next/webpack', middleware);
+    });
+
+    it('custom excludeRoute function', async () => {
+      const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
+
+      const middleware = new PersonalizeMiddleware({
+        cdpConfig: {
+          clientKey: 'cdp-client-key',
+          endpoint: 'cdp-endpoint',
+          pointOfSale: 'cdp-pos',
+        },
+        edgeConfig: {
+          apiKey: 'edge-api-key',
+          endpoint: 'http://edge-endpoint/api/graph/edge',
+          siteName: 'nextjs-app',
+        },
+        excludeRoute,
+      });
+
+      await test('/crazypath/luna', middleware);
+    });
+  });
+
+  it.only('personalize info not found', async () => {
+    const personalizeQueryResult = {
+      layout: {},
+    };
+
+    nock('http://edge-endpoint', {
+      reqheaders: {
+        sc_apikey: 'edge-api-key',
+      },
+    })
+      .post('/graphql')
+      .reply(200, {
+        data: personalizeQueryResult,
+      });
+
+    const createMiddleware = () =>
+      new PersonalizeMiddleware({
+        cdpConfig: {
+          clientKey: 'cdp-client-key',
+          endpoint: 'cdp-endpoint',
+          pointOfSale: 'cdp-pos',
+        },
+        edgeConfig: {
+          apiKey: 'edge-api-key',
+          endpoint: 'http://edge-endpoint/graphql',
+          siteName: 'nextjs-app',
+        },
+      });
+
+    const req = {
+      nextUrl: {
+        pathname: '/styleguide',
+        locale: 'en',
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
+
+          return cookies[cookieName];
+        },
+      },
+    } as NextRequest;
+
+    const res = {
+      cookies: {},
+    } as NextResponse;
+
+    // const id = 'item-id';
+    // const version = '1';
+    // const variantIds = ['variant-1', 'variant-2'];
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(debugSpy.callCount).to.equal(3);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('skipped (personalize info not found)')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+  });
+});

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-unused-expressions */
+/* eslint-disable dot-notation */
 import chai, { use } from 'chai';
 import chaiString from 'chai-string';
 import sinonChai from 'sinon-chai';
@@ -131,17 +132,14 @@ describe('PersonalizeMiddleware', () => {
     });
 
     const executeExperience = sinon
-      // eslint-disable-next-line dot-notation
       .stub(middleware['cdpService'], 'executeExperience')
       .returns(Promise.resolve(props.variantId));
 
     const generateBrowserId = sinon
-      // eslint-disable-next-line dot-notation
       .stub(middleware['cdpService'], 'generateBrowserId')
       .returns(Promise.resolve(props.browserId));
 
     const getPersonalizeInfo = sinon
-      // eslint-disable-next-line dot-notation
       .stub(middleware['personalizeService'], 'getPersonalizeInfo')
       .returns(
         Promise.resolve(

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
@@ -1,8 +1,4 @@
 /* eslint-disable no-unused-expressions */
-// import React from 'react';
-// import { expect } from 'chai';
-// import { mount } from 'enzyme';
-
 import chai, { use } from 'chai';
 import chaiString from 'chai-string';
 import sinonChai from 'sinon-chai';
@@ -10,35 +6,40 @@ import sinon, { spy } from 'sinon';
 import nock from 'nock';
 
 import { debug } from '@sitecore-jss/sitecore-jss';
-// import { enableDebug } from '@sitecore-jss/sitecore-jss-react';
 
 import { PersonalizeMiddleware } from './personalize-middleware';
-import { NextRequest, NextResponse } from 'next/server';
+import nextjs, { NextRequest, NextResponse } from 'next/server';
 
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
-describe.only('PersonalizeMiddleware', () => {
-  describe('disabled', () => {
-    const createMiddleware = () =>
-      new PersonalizeMiddleware({
-        cdpConfig: {
-          clientKey: 'cdp-client-key',
-          endpoint: 'cdp-endpoint',
-          pointOfSale: 'cdp-pos',
-        },
-        edgeConfig: {
-          apiKey: 'edge-api-key',
-          endpoint: 'http://edge-endpoint/api/graph/edge',
-          siteName: 'nextjs-app',
-        },
-        disabled: (req, res) => req?.nextUrl.pathname === '/' && req.nextUrl.locale === 'en',
-      });
+describe('PersonalizeMiddleware', () => {
+  const createMiddleware = (
+    props: { [key: string]: unknown; cdpConfig?: any; edgeConfig?: any } = {}
+  ) =>
+    new PersonalizeMiddleware({
+      ...props,
+      cdpConfig: {
+        clientKey: 'cdp-client-key',
+        endpoint: 'http://cdp-endpoint',
+        pointOfSale: 'cdp-pos',
+        ...(props?.cdpConfig || {}),
+      },
+      edgeConfig: {
+        apiKey: 'edge-api-key',
+        endpoint: 'http://edge-endpoint/api/graph/edge',
+        siteName: 'nextjs-app',
+        ...(props?.edgeConfig || {}),
+      },
+    });
 
-    const req = {
+  const createRequest = (props: any = {}) =>
+    ({
+      ...props,
       nextUrl: {
-        pathname: '/',
+        pathname: '/styleguide',
         locale: 'en',
+        ...props?.nextUrl,
       },
       cookies: {
         get(cookieName: string) {
@@ -46,15 +47,62 @@ describe.only('PersonalizeMiddleware', () => {
 
           return cookies[cookieName];
         },
+        ...props?.cookies,
       },
-    } as NextRequest;
+    } as NextRequest);
 
-    const res = {
+  const createResponse = (props: any = {}) =>
+    ({
       cookies: {},
-    } as NextResponse;
+      ...props,
+    } as NextResponse);
+
+  const id = 'item-id';
+  const version = '1';
+  const variantIds = ['variant-1', 'variant-2'];
+  const browserId = 'browser-id';
+  const contentId = `${id}_en_${version}`.toLowerCase();
+  const personalizeQueryResult = {
+    layout: {
+      item: {
+        id,
+        version,
+        personalization: {
+          variantIds,
+        },
+      },
+    },
+  };
+
+  const mockPersonalizeDataRequest = (data: any = personalizeQueryResult) =>
+    nock('http://edge-endpoint', {
+      reqheaders: {
+        sc_apikey: 'edge-api-key',
+      },
+    })
+      .post('/api/graph/edge')
+      .reply(200, {
+        data,
+      });
+
+  const mockBrowserIdGenerationRequest = (ref) =>
+    nock('http://cdp-endpoint')
+      .get('/v1.2/browser/create.json?client_key=cdp-client-key&message={}')
+      .reply(200, {
+        ref,
+      });
+
+  describe('disabled', () => {
+    const props = {
+      disabled: (req) => req?.nextUrl.pathname === '/styleguide' && req.nextUrl.locale === 'en',
+    };
+
+    const req = createRequest();
+
+    const res = createResponse();
 
     it('default response returned', async () => {
-      const middleware = createMiddleware();
+      const middleware = createMiddleware(props);
 
       const getCookiesSpy = spy(req.cookies, 'get');
 
@@ -66,7 +114,7 @@ describe.only('PersonalizeMiddleware', () => {
 
       expect(
         debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/',
+          pathname: '/styleguide',
           language: 'en',
         })
       ).to.be.true;
@@ -83,7 +131,7 @@ describe.only('PersonalizeMiddleware', () => {
     });
 
     it('custom response returned', async () => {
-      const middleware = createMiddleware();
+      const middleware = createMiddleware(props);
 
       const debugSpy = spy(debug, 'personalize');
 
@@ -93,7 +141,7 @@ describe.only('PersonalizeMiddleware', () => {
 
       expect(
         debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/',
+          pathname: '/styleguide',
           language: 'en',
         })
       ).to.be.true;
@@ -111,38 +159,9 @@ describe.only('PersonalizeMiddleware', () => {
   });
 
   it('redirected', async () => {
-    const createMiddleware = () =>
-      new PersonalizeMiddleware({
-        cdpConfig: {
-          clientKey: 'cdp-client-key',
-          endpoint: 'cdp-endpoint',
-          pointOfSale: 'cdp-pos',
-        },
-        edgeConfig: {
-          apiKey: 'edge-api-key',
-          endpoint: 'http://edge-endpoint/api/graph/edge',
-          siteName: 'nextjs-app',
-        },
-      });
+    const req = createRequest();
 
-    const req = {
-      nextUrl: {
-        pathname: '/',
-        locale: 'en',
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
-
-          return cookies[cookieName];
-        },
-      },
-    } as NextRequest;
-
-    const res = {
-      cookies: {},
-      redirected: true,
-    } as NextResponse;
+    const res = createResponse({ redirected: true });
 
     const middleware = createMiddleware();
 
@@ -156,7 +175,7 @@ describe.only('PersonalizeMiddleware', () => {
 
     expect(
       debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/',
+        pathname: '/styleguide',
         language: 'en',
       })
     ).to.be.true;
@@ -173,25 +192,7 @@ describe.only('PersonalizeMiddleware', () => {
 
   describe('preview', () => {
     it('prerender bypass', async () => {
-      const createMiddleware = () =>
-        new PersonalizeMiddleware({
-          cdpConfig: {
-            clientKey: 'cdp-client-key',
-            endpoint: 'cdp-endpoint',
-            pointOfSale: 'cdp-pos',
-          },
-          edgeConfig: {
-            apiKey: 'edge-api-key',
-            endpoint: 'http://edge-endpoint/api/graph/edge',
-            siteName: 'nextjs-app',
-          },
-        });
-
-      const req = {
-        nextUrl: {
-          pathname: '/',
-          locale: 'en',
-        },
+      const req = createRequest({
         cookies: {
           get(cookieName: string) {
             const cookies = { 'bid_cdp-client-key': 'browser-id-value', __prerender_bypass: true };
@@ -199,11 +200,9 @@ describe.only('PersonalizeMiddleware', () => {
             return cookies[cookieName];
           },
         },
-      } as NextRequest;
+      });
 
-      const res = {
-        cookies: {},
-      } as NextResponse;
+      const res = createResponse();
 
       const middleware = createMiddleware();
 
@@ -217,7 +216,7 @@ describe.only('PersonalizeMiddleware', () => {
 
       expect(
         debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/',
+          pathname: '/styleguide',
           language: 'en',
         })
       ).to.be.true;
@@ -234,25 +233,7 @@ describe.only('PersonalizeMiddleware', () => {
     });
 
     it('preview data', async () => {
-      const createMiddleware = () =>
-        new PersonalizeMiddleware({
-          cdpConfig: {
-            clientKey: 'cdp-client-key',
-            endpoint: 'cdp-endpoint',
-            pointOfSale: 'cdp-pos',
-          },
-          edgeConfig: {
-            apiKey: 'edge-api-key',
-            endpoint: 'http://edge-endpoint/api/graph/edge',
-            siteName: 'nextjs-app',
-          },
-        });
-
-      const req = {
-        nextUrl: {
-          pathname: '/',
-          locale: 'en',
-        },
+      const req = createRequest({
         cookies: {
           get(cookieName: string) {
             const cookies = { 'bid_cdp-client-key': 'browser-id-value', __next_preview_data: true };
@@ -260,11 +241,9 @@ describe.only('PersonalizeMiddleware', () => {
             return cookies[cookieName];
           },
         },
-      } as NextRequest;
+      });
 
-      const res = {
-        cookies: {},
-      } as NextResponse;
+      const res = createResponse();
 
       const middleware = createMiddleware();
 
@@ -278,7 +257,7 @@ describe.only('PersonalizeMiddleware', () => {
 
       expect(
         debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/',
+          pathname: '/styleguide',
           language: 'en',
         })
       ).to.be.true;
@@ -297,24 +276,14 @@ describe.only('PersonalizeMiddleware', () => {
   });
 
   describe('excluded route', () => {
-    const res = {
-      cookies: {},
-    } as NextResponse;
+    const res = createResponse();
 
     const test = async (pathname: string, middleware) => {
-      const req = {
+      const req = createRequest({
         nextUrl: {
           pathname,
-          locale: 'en',
         },
-        cookies: {
-          get(cookieName: string) {
-            const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
-
-            return cookies[cookieName];
-          },
-        },
-      } as NextRequest;
+      });
 
       const debugSpy = spy(debug, 'personalize');
 
@@ -340,18 +309,7 @@ describe.only('PersonalizeMiddleware', () => {
     };
 
     it('default', async () => {
-      const middleware = new PersonalizeMiddleware({
-        cdpConfig: {
-          clientKey: 'cdp-client-key',
-          endpoint: 'cdp-endpoint',
-          pointOfSale: 'cdp-pos',
-        },
-        edgeConfig: {
-          apiKey: 'edge-api-key',
-          endpoint: 'http://edge-endpoint/api/graph/edge',
-          siteName: 'nextjs-app',
-        },
-      });
+      const middleware = createMiddleware();
 
       await test('/src/image.png', middleware);
       await test('/api/layout/render', middleware);
@@ -362,74 +320,23 @@ describe.only('PersonalizeMiddleware', () => {
     it('custom excludeRoute function', async () => {
       const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
-      const middleware = new PersonalizeMiddleware({
-        cdpConfig: {
-          clientKey: 'cdp-client-key',
-          endpoint: 'cdp-endpoint',
-          pointOfSale: 'cdp-pos',
-        },
-        edgeConfig: {
-          apiKey: 'edge-api-key',
-          endpoint: 'http://edge-endpoint/api/graph/edge',
-          siteName: 'nextjs-app',
-        },
-        excludeRoute,
-      });
+      const middleware = createMiddleware({ excludeRoute });
 
       await test('/crazypath/luna', middleware);
     });
   });
 
-  it.only('personalize info not found', async () => {
+  it('personalize info not found', async () => {
     const personalizeQueryResult = {
       layout: {},
     };
 
-    nock('http://edge-endpoint', {
-      reqheaders: {
-        sc_apikey: 'edge-api-key',
-      },
-    })
-      .post('/graphql')
-      .reply(200, {
-        data: personalizeQueryResult,
-      });
+    mockPersonalizeDataRequest(personalizeQueryResult);
 
-    const createMiddleware = () =>
-      new PersonalizeMiddleware({
-        cdpConfig: {
-          clientKey: 'cdp-client-key',
-          endpoint: 'cdp-endpoint',
-          pointOfSale: 'cdp-pos',
-        },
-        edgeConfig: {
-          apiKey: 'edge-api-key',
-          endpoint: 'http://edge-endpoint/graphql',
-          siteName: 'nextjs-app',
-        },
-      });
+    const req = createRequest();
 
-    const req = {
-      nextUrl: {
-        pathname: '/styleguide',
-        locale: 'en',
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
+    const res = createResponse();
 
-          return cookies[cookieName];
-        },
-      },
-    } as NextRequest;
-
-    const res = {
-      cookies: {},
-    } as NextResponse;
-
-    // const id = 'item-id';
-    // const version = '1';
-    // const variantIds = ['variant-1', 'variant-2'];
     const middleware = createMiddleware();
 
     const getCookiesSpy = spy(req.cookies, 'get');
@@ -461,5 +368,445 @@ describe.only('PersonalizeMiddleware', () => {
 
     getCookiesSpy.restore();
     debugSpy.restore();
+  });
+
+  it('no personalization configured', async () => {
+    const personalizeQueryResult = {
+      layout: {
+        item: {
+          id,
+          version,
+          personalization: {
+            variantIds: [],
+          },
+        },
+      },
+    };
+
+    mockPersonalizeDataRequest(personalizeQueryResult);
+
+    const req = createRequest();
+
+    const res = createResponse();
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(debugSpy.callCount).to.equal(3);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('skipped (no personalization configured)')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+  });
+
+  it('browser id does not exist and browser id generation failed', async () => {
+    mockPersonalizeDataRequest();
+
+    mockBrowserIdGenerationRequest(undefined);
+
+    const req = createRequest({
+      cookies: {
+        get(cookieName: string) {
+          const cookies = {};
+
+          return cookies[cookieName];
+        },
+      },
+    });
+
+    const res = createResponse();
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
+
+    expect(debugSpy.getCall(5).calledWith('skipped (browser id generation failed)')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+  });
+
+  it('no variant identified', async () => {
+    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
+
+    mockPersonalizeDataRequest();
+
+    mockBrowserIdGenerationRequest(browserId);
+
+    const params = {
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+        latitude: null,
+        longitude: null,
+        region: null,
+      },
+      referrer: 'http://localhost:3000',
+      ua: 'ua',
+      utm: {
+        campaign: 'utm_campaign',
+        content: undefined,
+        medium: undefined,
+        source: undefined,
+      },
+    };
+
+    nock('http://cdp-endpoint')
+      .post('/v2/callFlows', {
+        clientKey: 'cdp-client-key',
+        pointOfSale: 'cdp-pos',
+        params,
+        browserId: 'browser-id',
+        friendlyId: contentId,
+        channel: 'WEB',
+      })
+      .reply(200, {
+        variantId: undefined,
+      });
+
+    const req = createRequest({
+      nextUrl: {
+        searchParams: {
+          get(key) {
+            return { utm_campaign: 'utm_campaign' }[key];
+          },
+        },
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = {};
+
+          return cookies[cookieName];
+        },
+      },
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+      },
+      referrer: 'http://localhost:3000',
+    });
+
+    const res = createResponse();
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(5)
+        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
+    ).to.be.true;
+
+    expect(debugSpy.getCall(8).calledWith('skipped (no variant identified)')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+    userAgentStub.restore();
+  });
+
+  it('invalid variant', async () => {
+    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
+
+    mockPersonalizeDataRequest();
+
+    mockBrowserIdGenerationRequest(browserId);
+
+    const params = {
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+        latitude: null,
+        longitude: null,
+        region: null,
+      },
+      referrer: 'http://localhost:3000',
+      ua: 'ua',
+      utm: {
+        campaign: 'utm_campaign',
+        content: undefined,
+        medium: undefined,
+        source: undefined,
+      },
+    };
+
+    nock('http://cdp-endpoint')
+      .post('/v2/callFlows', {
+        clientKey: 'cdp-client-key',
+        pointOfSale: 'cdp-pos',
+        params,
+        browserId: 'browser-id',
+        friendlyId: contentId,
+        channel: 'WEB',
+      })
+      .reply(200, {
+        variantId: 'invalid-variant',
+      });
+
+    const req = createRequest({
+      nextUrl: {
+        searchParams: {
+          get(key) {
+            return { utm_campaign: 'utm_campaign' }[key];
+          },
+        },
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = {};
+
+          return cookies[cookieName];
+        },
+      },
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+      },
+      referrer: 'http://localhost:3000',
+    });
+
+    const res = createResponse({
+      headers: {
+        set(key, value) {
+          res.headers[key] = value;
+        },
+      },
+    });
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(5)
+        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
+    ).to.be.true;
+
+    expect(debugSpy.getCall(8).calledWith('skipped (invalid variant)')).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+    userAgentStub.restore();
+  });
+
+  it('request handled', async () => {
+    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
+
+    mockPersonalizeDataRequest();
+
+    mockBrowserIdGenerationRequest(browserId);
+
+    const params = {
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+        latitude: null,
+        longitude: null,
+        region: null,
+      },
+      referrer: 'http://localhost:3000',
+      ua: 'ua',
+      utm: {
+        campaign: 'utm_campaign',
+        content: undefined,
+        medium: undefined,
+        source: undefined,
+      },
+    };
+
+    nock('http://cdp-endpoint')
+      .post('/v2/callFlows', {
+        clientKey: 'cdp-client-key',
+        pointOfSale: 'cdp-pos',
+        params,
+        browserId: 'browser-id',
+        friendlyId: contentId,
+        channel: 'WEB',
+      })
+      .reply(200, {
+        variantId: 'variant-2',
+      });
+
+    const req = createRequest({
+      nextUrl: {
+        searchParams: {
+          get(key) {
+            return { utm_campaign: 'utm_campaign' }[key];
+          },
+        },
+        clone() {
+          return Object.assign({}, req.nextUrl);
+        },
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = {};
+
+          return cookies[cookieName];
+        },
+      },
+      geo: {
+        city: 'geo-city',
+        country: 'geo-country',
+      },
+      referrer: 'http://localhost:3000',
+    });
+
+    const res = createResponse({
+      cookies: {
+        set(key, value) {
+          res.cookies[key] = value;
+        },
+      },
+      headers: {
+        set(key, value) {
+          res.headers[key] = value;
+        },
+      },
+    });
+
+    const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+    const middleware = createMiddleware();
+
+    const getCookiesSpy = spy(req.cookies, 'get');
+
+    const debugSpy = spy(debug, 'personalize');
+
+    const finalRes = await middleware.getHandler()(req, res);
+
+    expect(
+      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      })
+    ).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(1)
+        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
+    ).to.be.true;
+
+    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
+
+    expect(
+      debugSpy
+        .getCall(5)
+        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
+    ).to.be.true;
+
+    expect(
+      debugSpy.getCall(8).calledWith('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      })
+    ).to.be.true;
+
+    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+    expect(finalRes).to.deep.equal(res);
+
+    getCookiesSpy.restore();
+    debugSpy.restore();
+    userAgentStub.restore();
+    nextRewriteStub.restore();
   });
 });

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.test.ts
@@ -4,16 +4,21 @@ import chaiString from 'chai-string';
 import sinonChai from 'sinon-chai';
 import sinon, { spy } from 'sinon';
 import nock from 'nock';
-
+import nextjs, { NextRequest, NextResponse } from 'next/server';
 import { debug } from '@sitecore-jss/sitecore-jss';
+import { ExperienceParams } from '@sitecore-jss/sitecore-jss/personalize';
 
 import { PersonalizeMiddleware } from './personalize-middleware';
-import nextjs, { NextRequest, NextResponse } from 'next/server';
 
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
 describe('PersonalizeMiddleware', () => {
+  const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
+  const debugSpy = spy(debug, 'personalize');
+  const validateDebugLog = (message, ...params) =>
+    expect(debugSpy.args.find((log) => log[0] === message)).to.deep.equal([message, ...params]);
+
   const createMiddleware = (
     props: { [key: string]: unknown; cdpConfig?: any; edgeConfig?: any } = {}
   ) =>
@@ -33,30 +38,6 @@ describe('PersonalizeMiddleware', () => {
       },
     });
 
-  const createRequest = (props: any = {}) =>
-    ({
-      ...props,
-      nextUrl: {
-        pathname: '/styleguide',
-        locale: 'en',
-        ...props?.nextUrl,
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = { 'bid_cdp-client-key': 'browser-id-value' };
-
-          return cookies[cookieName];
-        },
-        ...props?.cookies,
-      },
-    } as NextRequest);
-
-  const createResponse = (props: any = {}) =>
-    ({
-      cookies: {},
-      ...props,
-    } as NextResponse);
-
   const id = 'item-id';
   const version = '1';
   const variantIds = ['variant-1', 'variant-2'];
@@ -72,6 +53,79 @@ describe('PersonalizeMiddleware', () => {
         },
       },
     },
+  };
+
+  const referrer = 'http://localhost:3000';
+  const experienceParams: ExperienceParams = {
+    geo: {
+      city: 'geo-city',
+      country: 'geo-country',
+      latitude: 'geo-latitude',
+      longitude: 'geo-longitude',
+      region: 'geo-region',
+    },
+    referrer,
+    ua: 'ua',
+    utm: {
+      campaign: 'utm_campaign',
+      content: null,
+      medium: null,
+      source: null,
+    },
+  };
+
+  const createRequest = (props: any = {}) => {
+    const req = {
+      ...props,
+      nextUrl: {
+        pathname: '/styleguide',
+        locale: 'en',
+        searchParams: {
+          get(key) {
+            return {
+              utm_campaign: 'utm_campaign',
+              utm_content: null,
+              utm_medium: null,
+              utm_source: null,
+            }[key];
+          },
+        },
+        clone() {
+          return Object.assign({}, req.nextUrl);
+        },
+        ...props?.nextUrl,
+      },
+      cookies: {
+        get(cookieName: string) {
+          const cookies = { 'bid_cdp-client-key': 'browser-id', ...props.cookieValues };
+
+          return cookies[cookieName];
+        },
+        ...props?.cookies,
+      },
+      referrer,
+      geo: props?.geo === null ? null : props?.geo || experienceParams.geo,
+    } as NextRequest;
+
+    return req;
+  };
+
+  const createResponse = (props: any = {}) => {
+    const res = {
+      cookies: {
+        set(key, value) {
+          res.cookies[key] = value;
+        },
+      },
+      headers: {
+        set(key, value) {
+          res.headers[key] = value;
+        },
+      },
+      ...props,
+    } as NextResponse;
+
+    return res;
   };
 
   const mockPersonalizeDataRequest = (data: any = personalizeQueryResult) =>
@@ -92,114 +146,278 @@ describe('PersonalizeMiddleware', () => {
         ref,
       });
 
-  describe('disabled', () => {
-    const props = {
-      disabled: (req) => req?.nextUrl.pathname === '/styleguide' && req.nextUrl.locale === 'en',
-    };
+  const mockExecuteExperienceRequest = (
+    variantId,
+    { friendlyId = contentId, params = experienceParams } = {}
+  ) =>
+    nock('http://cdp-endpoint')
+      .post('/v2/callFlows', {
+        clientKey: 'cdp-client-key',
+        pointOfSale: 'cdp-pos',
+        params,
+        browserId: 'browser-id',
+        friendlyId,
+        channel: 'WEB',
+      })
+      .reply(200, {
+        variantId,
+      });
 
-    const req = createRequest();
+  beforeEach(() => {
+    userAgentStub.resetHistory();
+    debugSpy.resetHistory();
+  });
 
-    const res = createResponse();
+  afterEach(() => {
+    userAgentStub.returns({ ua: 'ua' } as any);
+  });
 
-    it('default response returned', async () => {
+  describe('request skipped', () => {
+    it('disabled', async () => {
+      const props = {
+        disabled: (req) => req?.nextUrl.pathname === '/styleguide' && req.nextUrl.locale === 'en',
+      };
+
+      const req = createRequest();
+
+      const res = createResponse();
+
       const middleware = createMiddleware(props);
-
-      const getCookiesSpy = spy(req.cookies, 'get');
-
-      const debugSpy = spy(debug, 'personalize');
-
-      const finalRes = await middleware.getHandler()(req);
-
-      expect(debugSpy.callCount).to.equal(2);
-
-      expect(
-        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/styleguide',
-          language: 'en',
-        })
-      ).to.be.true;
-
-      expect(debugSpy.getCall(1).calledWith('skipped (personalize middleware is disabled)')).to.be
-        .true;
-
-      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-      expect(finalRes).to.deep.equal(NextResponse.next());
-
-      getCookiesSpy.restore();
-      debugSpy.restore();
-    });
-
-    it('custom response returned', async () => {
-      const middleware = createMiddleware(props);
-
-      const debugSpy = spy(debug, 'personalize');
 
       const getCookiesSpy = spy(req.cookies, 'get');
 
       const finalRes = await middleware.getHandler()(req, res);
 
-      expect(
-        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/styleguide',
-          language: 'en',
-        })
-      ).to.be.true;
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
 
-      expect(debugSpy.getCall(1).calledWith('skipped (personalize middleware is disabled)')).to.be
-        .true;
+      validateDebugLog('skipped (personalize middleware is disabled)');
 
       expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
 
       expect(finalRes).to.deep.equal(res);
 
       getCookiesSpy.restore();
-      debugSpy.restore();
     });
-  });
 
-  it('redirected', async () => {
-    const req = createRequest();
+    it('redirected', async () => {
+      const req = createRequest();
 
-    const res = createResponse({ redirected: true });
+      const res = createResponse({ redirected: true });
 
-    const middleware = createMiddleware();
+      const middleware = createMiddleware();
 
-    const getCookiesSpy = spy(req.cookies, 'get');
+      const getCookiesSpy = spy(req.cookies, 'get');
 
-    const debugSpy = spy(debug, 'personalize');
+      const finalRes = await middleware.getHandler()(req, res);
 
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(debugSpy.callCount).to.equal(2);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+      validateDebugLog('personalize middleware start: %o', {
         pathname: '/styleguide',
         language: 'en',
-      })
-    ).to.be.true;
+      });
 
-    expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'redirected')).to.be.true;
+      validateDebugLog('skipped (%s)', 'redirected');
 
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
 
-    expect(finalRes).to.deep.equal(res);
+      expect(finalRes).to.deep.equal(res);
 
-    getCookiesSpy.restore();
-    debugSpy.restore();
-  });
+      getCookiesSpy.restore();
+    });
 
-  describe('preview', () => {
-    it('prerender bypass', async () => {
-      const req = createRequest({
-        cookies: {
-          get(cookieName: string) {
-            const cookies = { 'bid_cdp-client-key': 'browser-id-value', __prerender_bypass: true };
+    describe('preview', () => {
+      it('prerender bypass cookie is present', async () => {
+        const req = createRequest({
+          cookieValues: {
+            __prerender_bypass: true,
+          },
+        });
 
-            return cookies[cookieName];
+        const res = createResponse();
+
+        const middleware = createMiddleware();
+
+        const getCookiesSpy = spy(req.cookies, 'get');
+
+        const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('personalize middleware start: %o', {
+          pathname: '/styleguide',
+          language: 'en',
+        });
+
+        validateDebugLog('skipped (%s)', 'preview');
+
+        expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+        expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
+
+        expect(finalRes).to.deep.equal(res);
+
+        getCookiesSpy.restore();
+      });
+
+      it('preview data cookie is present', async () => {
+        const req = createRequest({
+          cookieValues: {
+            __next_preview_data: true,
+          },
+        });
+
+        const res = createResponse();
+
+        const middleware = createMiddleware();
+
+        const getCookiesSpy = spy(req.cookies, 'get');
+
+        const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('personalize middleware start: %o', {
+          pathname: '/styleguide',
+          language: 'en',
+        });
+
+        validateDebugLog('skipped (%s)', 'preview');
+
+        expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+        expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
+        expect(getCookiesSpy.calledWith('__next_preview_data')).to.be.true;
+
+        expect(finalRes).to.deep.equal(res);
+
+        getCookiesSpy.restore();
+      });
+    });
+
+    describe('excluded route', () => {
+      const res = createResponse();
+
+      const test = async (pathname: string, middleware) => {
+        const req = createRequest({
+          nextUrl: {
+            pathname,
+          },
+        });
+
+        const getCookiesSpy = spy(req.cookies, 'get');
+
+        const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('personalize middleware start: %o', {
+          pathname,
+          language: 'en',
+        });
+
+        validateDebugLog('skipped (%s)', 'route excluded');
+
+        expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+        expect(finalRes).to.deep.equal(res);
+
+        getCookiesSpy.restore();
+        debugSpy.resetHistory();
+      };
+
+      it('default', async () => {
+        const middleware = createMiddleware();
+
+        await test('/src/image.png', middleware);
+        await test('/api/layout/render', middleware);
+        await test('/sitecore/render', middleware);
+        await test('/_next/webpack', middleware);
+      });
+
+      it('custom excludeRoute function', async () => {
+        const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
+
+        const middleware = createMiddleware({ excludeRoute });
+
+        await test('/crazypath/luna', middleware);
+      });
+    });
+
+    it('personalize info not found', async () => {
+      const personalizeQueryResult = {
+        layout: {},
+      };
+
+      mockPersonalizeDataRequest(personalizeQueryResult);
+
+      const req = createRequest();
+
+      const res = createResponse();
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog('skipped (personalize info not found)');
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+    });
+
+    it('no personalization configured', async () => {
+      const personalizeQueryResult = {
+        layout: {
+          item: {
+            id,
+            version,
+            personalization: {
+              variantIds: [],
+            },
           },
         },
+      };
+
+      mockPersonalizeDataRequest(personalizeQueryResult);
+
+      const req = createRequest();
+
+      const res = createResponse();
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog('skipped (no personalization configured)');
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      getCookiesSpy.restore();
+    });
+
+    it('browser id generation failed', async () => {
+      mockPersonalizeDataRequest();
+
+      mockBrowserIdGenerationRequest(undefined);
+
+      const req = createRequest({
+        cookieValues: { 'bid_cdp-client-key': undefined },
       });
 
       const res = createResponse();
@@ -208,40 +426,32 @@ describe('PersonalizeMiddleware', () => {
 
       const getCookiesSpy = spy(req.cookies, 'get');
 
-      const debugSpy = spy(debug, 'personalize');
-
       const finalRes = await middleware.getHandler()(req, res);
 
-      expect(debugSpy.callCount).to.equal(2);
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
 
-      expect(
-        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/styleguide',
-          language: 'en',
-        })
-      ).to.be.true;
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
 
-      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'preview')).to.be.true;
+      validateDebugLog('generating browser id');
+
+      validateDebugLog('skipped (browser id generation failed)');
 
       expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-      expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
 
       expect(finalRes).to.deep.equal(res);
 
       getCookiesSpy.restore();
-      debugSpy.restore();
     });
 
-    it('preview data', async () => {
-      const req = createRequest({
-        cookies: {
-          get(cookieName: string) {
-            const cookies = { 'bid_cdp-client-key': 'browser-id-value', __next_preview_data: true };
+    it('no variant identified', async () => {
+      mockPersonalizeDataRequest();
 
-            return cookies[cookieName];
-          },
-        },
-      });
+      mockExecuteExperienceRequest(undefined);
+
+      const req = createRequest();
 
       const res = createResponse();
 
@@ -249,564 +459,500 @@ describe('PersonalizeMiddleware', () => {
 
       const getCookiesSpy = spy(req.cookies, 'get');
 
-      const debugSpy = spy(debug, 'personalize');
-
       const finalRes = await middleware.getHandler()(req, res);
 
-      expect(debugSpy.callCount).to.equal(2);
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
 
-      expect(
-        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname: '/styleguide',
-          language: 'en',
-        })
-      ).to.be.true;
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
 
-      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'preview')).to.be.true;
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('skipped (no variant identified)');
 
       expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-      expect(getCookiesSpy.calledWith('__prerender_bypass')).to.be.true;
-      expect(getCookiesSpy.calledWith('__next_preview_data')).to.be.true;
 
       expect(finalRes).to.deep.equal(res);
 
       getCookiesSpy.restore();
-      debugSpy.restore();
     });
-  });
 
-  describe('excluded route', () => {
-    const res = createResponse();
+    it('invalid variant', async () => {
+      mockPersonalizeDataRequest();
 
-    const test = async (pathname: string, middleware) => {
-      const req = createRequest({
-        nextUrl: {
-          pathname,
-        },
-      });
+      mockExecuteExperienceRequest('invalid-variant');
 
-      const debugSpy = spy(debug, 'personalize');
+      const req = createRequest();
+
+      const res = createResponse();
+
+      const middleware = createMiddleware();
 
       const getCookiesSpy = spy(req.cookies, 'get');
 
       const finalRes = await middleware.getHandler()(req, res);
 
-      expect(
-        debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-          pathname,
-          language: 'en',
-        })
-      ).to.be.true;
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
 
-      expect(debugSpy.getCall(1).calledWith('skipped (%s)', 'route excluded')).to.be.true;
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('skipped (invalid variant)');
 
       expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
 
       expect(finalRes).to.deep.equal(res);
 
       getCookiesSpy.restore();
-      debugSpy.restore();
-    };
+    });
+  });
 
-    it('default', async () => {
+  describe('request passed', () => {
+    it('browser id is present in cookies', async () => {
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2');
+
+      const req = createRequest({
+        cookieValues: {
+          'bid_cdp-client-key': 'browser-id',
+        },
+      });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
       const middleware = createMiddleware();
 
-      await test('/src/image.png', middleware);
-      await test('/api/layout/render', middleware);
-      await test('/sitecore/render', middleware);
-      await test('/_next/webpack', middleware);
-    });
+      const getCookiesSpy = spy(req.cookies, 'get');
 
-    it('custom excludeRoute function', async () => {
-      const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
+      const finalRes = await middleware.getHandler()(req, res);
 
-      const middleware = createMiddleware({ excludeRoute });
-
-      await test('/crazypath/luna', middleware);
-    });
-  });
-
-  it('personalize info not found', async () => {
-    const personalizeQueryResult = {
-      layout: {},
-    };
-
-    mockPersonalizeDataRequest(personalizeQueryResult);
-
-    const req = createRequest();
-
-    const res = createResponse();
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(debugSpy.callCount).to.equal(3);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
+      validateDebugLog('personalize middleware start: %o', {
         pathname: '/styleguide',
         language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('skipped (personalize info not found)')).to.be.true;
-
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-    expect(finalRes).to.deep.equal(res);
-
-    getCookiesSpy.restore();
-    debugSpy.restore();
-  });
-
-  it('no personalization configured', async () => {
-    const personalizeQueryResult = {
-      layout: {
-        item: {
-          id,
-          version,
-          personalization: {
-            variantIds: [],
-          },
-        },
-      },
-    };
-
-    mockPersonalizeDataRequest(personalizeQueryResult);
-
-    const req = createRequest();
-
-    const res = createResponse();
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(debugSpy.callCount).to.equal(3);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('skipped (no personalization configured)')).to.be.true;
-
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-    expect(finalRes).to.deep.equal(res);
-
-    getCookiesSpy.restore();
-    debugSpy.restore();
-  });
-
-  it('browser id does not exist and browser id generation failed', async () => {
-    mockPersonalizeDataRequest();
-
-    mockBrowserIdGenerationRequest(undefined);
-
-    const req = createRequest({
-      cookies: {
-        get(cookieName: string) {
-          const cookies = {};
-
-          return cookies[cookieName];
-        },
-      },
-    });
-
-    const res = createResponse();
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
-
-    expect(debugSpy.getCall(5).calledWith('skipped (browser id generation failed)')).to.be.true;
-
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-    expect(finalRes).to.deep.equal(res);
-
-    getCookiesSpy.restore();
-    debugSpy.restore();
-  });
-
-  it('no variant identified', async () => {
-    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
-
-    mockPersonalizeDataRequest();
-
-    mockBrowserIdGenerationRequest(browserId);
-
-    const params = {
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-        latitude: null,
-        longitude: null,
-        region: null,
-      },
-      referrer: 'http://localhost:3000',
-      ua: 'ua',
-      utm: {
-        campaign: 'utm_campaign',
-        content: undefined,
-        medium: undefined,
-        source: undefined,
-      },
-    };
-
-    nock('http://cdp-endpoint')
-      .post('/v2/callFlows', {
-        clientKey: 'cdp-client-key',
-        pointOfSale: 'cdp-pos',
-        params,
-        browserId: 'browser-id',
-        friendlyId: contentId,
-        channel: 'WEB',
-      })
-      .reply(200, {
-        variantId: undefined,
       });
 
-    const req = createRequest({
-      nextUrl: {
-        searchParams: {
-          get(key) {
-            return { utm_campaign: 'utm_campaign' }[key];
-          },
-        },
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = {};
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
 
-          return cookies[cookieName];
-        },
-      },
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-      },
-      referrer: 'http://localhost:3000',
-    });
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
 
-    const res = createResponse();
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(5)
-        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
-    ).to.be.true;
-
-    expect(debugSpy.getCall(8).calledWith('skipped (no variant identified)')).to.be.true;
-
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-    expect(finalRes).to.deep.equal(res);
-
-    getCookiesSpy.restore();
-    debugSpy.restore();
-    userAgentStub.restore();
-  });
-
-  it('invalid variant', async () => {
-    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
-
-    mockPersonalizeDataRequest();
-
-    mockBrowserIdGenerationRequest(browserId);
-
-    const params = {
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-        latitude: null,
-        longitude: null,
-        region: null,
-      },
-      referrer: 'http://localhost:3000',
-      ua: 'ua',
-      utm: {
-        campaign: 'utm_campaign',
-        content: undefined,
-        medium: undefined,
-        source: undefined,
-      },
-    };
-
-    nock('http://cdp-endpoint')
-      .post('/v2/callFlows', {
-        clientKey: 'cdp-client-key',
-        pointOfSale: 'cdp-pos',
-        params,
-        browserId: 'browser-id',
-        friendlyId: contentId,
-        channel: 'WEB',
-      })
-      .reply(200, {
-        variantId: 'invalid-variant',
-      });
-
-    const req = createRequest({
-      nextUrl: {
-        searchParams: {
-          get(key) {
-            return { utm_campaign: 'utm_campaign' }[key];
-          },
-        },
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = {};
-
-          return cookies[cookieName];
-        },
-      },
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-      },
-      referrer: 'http://localhost:3000',
-    });
-
-    const res = createResponse({
-      headers: {
-        set(key, value) {
-          res.headers[key] = value;
-        },
-      },
-    });
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(5)
-        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
-    ).to.be.true;
-
-    expect(debugSpy.getCall(8).calledWith('skipped (invalid variant)')).to.be.true;
-
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-    expect(finalRes).to.deep.equal(res);
-
-    getCookiesSpy.restore();
-    debugSpy.restore();
-    userAgentStub.restore();
-  });
-
-  it('request handled', async () => {
-    const userAgentStub = sinon.stub(nextjs, 'userAgent').returns({ ua: 'ua' } as any);
-
-    mockPersonalizeDataRequest();
-
-    mockBrowserIdGenerationRequest(browserId);
-
-    const params = {
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-        latitude: null,
-        longitude: null,
-        region: null,
-      },
-      referrer: 'http://localhost:3000',
-      ua: 'ua',
-      utm: {
-        campaign: 'utm_campaign',
-        content: undefined,
-        medium: undefined,
-        source: undefined,
-      },
-    };
-
-    nock('http://cdp-endpoint')
-      .post('/v2/callFlows', {
-        clientKey: 'cdp-client-key',
-        pointOfSale: 'cdp-pos',
-        params,
-        browserId: 'browser-id',
-        friendlyId: contentId,
-        channel: 'WEB',
-      })
-      .reply(200, {
-        variantId: 'variant-2',
-      });
-
-    const req = createRequest({
-      nextUrl: {
-        searchParams: {
-          get(key) {
-            return { utm_campaign: 'utm_campaign' }[key];
-          },
-        },
-        clone() {
-          return Object.assign({}, req.nextUrl);
-        },
-      },
-      cookies: {
-        get(cookieName: string) {
-          const cookies = {};
-
-          return cookies[cookieName];
-        },
-      },
-      geo: {
-        city: 'geo-city',
-        country: 'geo-country',
-      },
-      referrer: 'http://localhost:3000',
-    });
-
-    const res = createResponse({
-      cookies: {
-        set(key, value) {
-          res.cookies[key] = value;
-        },
-      },
-      headers: {
-        set(key, value) {
-          res.headers[key] = value;
-        },
-      },
-    });
-
-    const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
-
-    const middleware = createMiddleware();
-
-    const getCookiesSpy = spy(req.cookies, 'get');
-
-    const debugSpy = spy(debug, 'personalize');
-
-    const finalRes = await middleware.getHandler()(req, res);
-
-    expect(
-      debugSpy.getCall(0).calledWith('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      })
-    ).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(1)
-        .calledWith('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en')
-    ).to.be.true;
-
-    expect(debugSpy.getCall(2).calledWith('generating browser id')).to.be.true;
-
-    expect(
-      debugSpy
-        .getCall(5)
-        .calledWith('executing experience for %s %s %o', contentId, 'browser-id', params)
-    ).to.be.true;
-
-    expect(
-      debugSpy.getCall(8).calledWith('personalize middleware end: %o', {
+      validateDebugLog('personalize middleware end: %o', {
         rewritePath: '/_variantId_variant-2/styleguide',
         browserId: 'browser-id',
         headers: {
           'x-middleware-cache': 'no-cache',
           set: res.headers.set,
         },
-      })
-    ).to.be.true;
+      });
 
-    expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
 
-    expect(finalRes).to.deep.equal(res);
+      expect(finalRes).to.deep.equal(res);
 
-    getCookiesSpy.restore();
-    debugSpy.restore();
-    userAgentStub.restore();
-    nextRewriteStub.restore();
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('browser id is not present in cookies', async () => {
+      mockPersonalizeDataRequest();
+
+      mockBrowserIdGenerationRequest(browserId);
+
+      mockExecuteExperienceRequest('variant-2');
+
+      const req = createRequest({
+        cookieValues: {
+          'bid_cdp-client-key': undefined,
+        },
+      });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog('generating browser id');
+
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('fallback defaultLocale is used', async () => {
+      const contentId = `${id}_da-dk_${version}`;
+
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2', { friendlyId: contentId });
+
+      const req = createRequest({
+        nextUrl: {
+          locale: undefined,
+          defaultLocale: 'da-DK',
+        },
+      });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'da-DK',
+      });
+
+      validateDebugLog(
+        'fetching personalize info for %s %s %s',
+        'nextjs-app',
+        '/styleguide',
+        'da-DK'
+      );
+
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('fallback locale is used', async () => {
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2', { friendlyId: contentId });
+
+      const req = createRequest({
+        nextUrl: {
+          locale: undefined,
+          defaultLocale: undefined,
+        },
+      });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('custom response object is not provided', async () => {
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2');
+
+      const req = createRequest();
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog(
+        'executing experience for %s %s %o',
+        contentId,
+        'browser-id',
+        experienceParams
+      );
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('optional experiece params are not present', async () => {
+      userAgentStub.returns({ ua: undefined } as any);
+
+      const params = {
+        ...experienceParams,
+        geo: {
+          city: null,
+          country: null,
+          latitude: null,
+          longitude: null,
+          region: null,
+        },
+        ua: null,
+      };
+
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2', { params });
+
+      const req = createRequest({
+        geo: {},
+      });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog('executing experience for %s %s %o', contentId, 'browser-id', {
+        geo: {
+          city: null,
+          country: null,
+          latitude: null,
+          longitude: null,
+          region: null,
+        },
+        referrer,
+        ua: null,
+        utm: {
+          campaign: 'utm_campaign',
+          content: null,
+          medium: null,
+          source: null,
+        },
+      });
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
+
+    it('request geo is not present', async () => {
+      userAgentStub.returns({ ua: undefined } as any);
+
+      const params = {
+        ...experienceParams,
+        geo: {
+          city: null,
+          country: null,
+          latitude: null,
+          longitude: null,
+          region: null,
+        },
+        ua: null,
+      };
+
+      mockPersonalizeDataRequest();
+
+      mockExecuteExperienceRequest('variant-2', { params });
+
+      const req = createRequest({ geo: null });
+
+      const res = createResponse();
+
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+
+      const middleware = createMiddleware();
+
+      const getCookiesSpy = spy(req.cookies, 'get');
+
+      const finalRes = await middleware.getHandler()(req, res);
+
+      validateDebugLog('personalize middleware start: %o', {
+        pathname: '/styleguide',
+        language: 'en',
+      });
+
+      validateDebugLog('fetching personalize info for %s %s %s', 'nextjs-app', '/styleguide', 'en');
+
+      validateDebugLog('executing experience for %s %s %o', contentId, 'browser-id', {
+        geo: {
+          city: null,
+          country: null,
+          latitude: null,
+          longitude: null,
+          region: null,
+        },
+        referrer,
+        ua: null,
+        utm: {
+          campaign: 'utm_campaign',
+          content: null,
+          medium: null,
+          source: null,
+        },
+      });
+
+      validateDebugLog('personalize middleware end: %o', {
+        rewritePath: '/_variantId_variant-2/styleguide',
+        browserId: 'browser-id',
+        headers: {
+          'x-middleware-cache': 'no-cache',
+          set: res.headers.set,
+        },
+      });
+
+      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
+
+      expect(finalRes).to.deep.equal(res);
+
+      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
+
+      getCookiesSpy.restore();
+      nextRewriteStub.restore();
+    });
   });
 });

--- a/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/edge/personalize-middleware.ts
@@ -84,11 +84,9 @@ export class PersonalizeMiddleware {
   }
 
   protected setBrowserId(res: NextResponse, browserId: string) {
-    if (browserId.length > 0) {
-      const expiryDate = new Date(new Date().setFullYear(new Date().getFullYear() + 2));
-      const options = { expires: expiryDate, secure: true };
-      res.cookies.set(this.browserIdCookieName, browserId, options);
-    }
+    const expiryDate = new Date(new Date().setFullYear(new Date().getFullYear() + 2));
+    const options = { expires: expiryDate, secure: true };
+    res.cookies.set(this.browserIdCookieName, browserId, options);
   }
 
   protected getExperienceParams(req: NextRequest): ExperienceParams {

--- a/packages/sitecore-jss-nextjs/src/tests/request.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/request.ts
@@ -1,0 +1,8 @@
+// Mock fetch/types for nextjs middleware
+
+const crossFetch = require('cross-fetch');
+
+global.fetch = crossFetch;
+global.Headers = crossFetch.Headers;
+global.Request = crossFetch.Request;
+global.Response = crossFetch.Response;

--- a/packages/sitecore-jss-nextjs/src/tests/request.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/request.ts
@@ -1,4 +1,4 @@
-// Mock fetch/types for nextjs middleware
+// Mock fetch/Request for nextjs middleware
 
 const crossFetch = require('cross-fetch');
 

--- a/packages/sitecore-jss-nextjs/src/tests/shim.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/shim.ts
@@ -5,15 +5,8 @@
 
 /// <reference types="../../global" />
 
-const crossFetch = require('cross-fetch');
-
 // eslint-disable-next-line no-var
 declare var global: NodeJS.Global;
-
-global.fetch = crossFetch;
-global.Headers = crossFetch.Headers;
-global.Request = crossFetch.Request;
-global.Response = crossFetch.Response;
 
 global.requestAnimationFrame = (callback: () => void) => {
   setTimeout(callback, 0);

--- a/packages/sitecore-jss-nextjs/src/tests/shim.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/shim.ts
@@ -5,8 +5,15 @@
 
 /// <reference types="../../global" />
 
+const crossFetch = require('cross-fetch');
+
 // eslint-disable-next-line no-var
 declare var global: NodeJS.Global;
+
+global.fetch = crossFetch;
+global.Headers = crossFetch.Headers;
+global.Request = crossFetch.Request;
+global.Response = crossFetch.Response;
 
 global.requestAnimationFrame = (callback: () => void) => {
   setTimeout(callback, 0);

--- a/packages/sitecore-jss-nextjs/test/setup.js
+++ b/packages/sitecore-jss-nextjs/test/setup.js
@@ -1,4 +1,5 @@
 require('ts-node/register/transpile-only');
+require('../src/tests/request.ts');
 require('../src/tests/shim.ts');
 require('../src/tests/jsdom-setup.ts');
 require('../src/tests/enzyme-setup.ts');

--- a/packages/sitecore-jss/src/debug.ts
+++ b/packages/sitecore-jss/src/debug.ts
@@ -27,7 +27,7 @@ export const enableDebug = (namespaces: string) => debug.enable(namespaces);
  * Default Sitecore JSS 'debug' module debuggers. Uses namespace prefix 'sitecore-jss:'.
  * See {@link https://www.npmjs.com/package/debug} for details.
  */
-export default Object.freeze({
+export default {
   http: debug(`${rootNamespace}:http`),
   layout: debug(`${rootNamespace}:layout`),
   dictionary: debug(`${rootNamespace}:dictionary`),
@@ -37,4 +37,4 @@ export default Object.freeze({
   redirects: debug(`${rootNamespace}:redirects`),
   personalize: debug(`${rootNamespace}:personalize`),
   errorpages: debug(`${rootNamespace}:errorpages`),
-});
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,6 +4319,7 @@ __metadata:
     chai-string: ^1.5.0
     chalk: ^4.1.2
     cheerio: 1.0.0-rc.10
+    cross-fetch: ^3.1.5
     del-cli: ^5.0.0
     enzyme: ^3.11.0
     eslint: ^7.15.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Unit tests for Personalize middleware
* Make `debug` object extendable for unit tests
* `setBrowserId` no need to check `browserId` anymore, it's always present, in another case request is skipped
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
