### PR TITLE
Disable scaffold apps during publish runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,14 +61,17 @@ steps:
 - script: |
     yarn scaffold-samples
   displayName: 'scaffold samples'
+  condition: and(succeeded(), ne(variables.shouldPublish, true))
 - script: |
     yarn install
   displayName: 'yarn install - refresh'
+  condition: and(succeeded(), ne(variables.shouldPublish, true))
   env:
     YARN_ENABLE_IMMUTABLE_INSTALLS: false
 - script: |
     lerna run lint --scope sample-* -- --fix
   displayName: 'lint samples'
+  condition: and(succeeded(), ne(variables.shouldPublish, true))
 
   #
   # LERNA VERSION


### PR DESCRIPTION
Follow up to lint CI pull request

## Description / Motivation
Disable scaffold and lint apps for publish CI runs to avoid git errors.