### PR TITLE
[Next.js] Add environment variable to allow disable of sitemap fetch in getStaticPaths

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -41,12 +41,12 @@ DEFAULT_LANGUAGE=
 
 # The way in which layout and dictionary data is fetched from Sitecore
 FETCH_WITH=<%- fetchWith %>
-
+<% if (prerender === 'SSG') { -%>
 # Indicates whether SSG `getStaticPaths` pre-render any pages
 # Set the environment variable DISABLE_SSG_FETCH=true
 # to enable full ISR (Incremental Static Regeneration) flow 
 DISABLE_SSG_FETCH=
-
+<% } -%>
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'sitecore-jss:*' to see all logs:

--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -43,9 +43,9 @@ DEFAULT_LANGUAGE=
 FETCH_WITH=<%- fetchWith %>
 
 # Indicates whether SSG `getStaticPaths` pre-render any pages
-# Set the environment variable DISABLE_SSG_STATIC_PATH_FETCH=true
-# to enable full ISR (Incremental Static Regeneration) flow, pre-fetch static paths 
-DISABLE_SSG_STATIC_PATH_FETCH=
+# Set the environment variable DISABLE_SSG_FETCH=true
+# to enable full ISR (Incremental Static Regeneration) flow 
+DISABLE_SSG_FETCH=
 
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug

--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -42,6 +42,11 @@ DEFAULT_LANGUAGE=
 # The way in which layout and dictionary data is fetched from Sitecore
 FETCH_WITH=<%- fetchWith %>
 
+# Indicates whether SSG `getStaticPaths` pre-render any pages
+# Set the environment variable DISABLE_SSG_FETCH=true
+# to enable full ISR (Incremental Static Regeneration) flow, pre-fetch static paths 
+DISABLE_SSG_FETCH=
+
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'sitecore-jss:*' to see all logs:

--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -43,9 +43,9 @@ DEFAULT_LANGUAGE=
 FETCH_WITH=<%- fetchWith %>
 
 # Indicates whether SSG `getStaticPaths` pre-render any pages
-# Set the environment variable DISABLE_SSG_FETCH=true
+# Set the environment variable DISABLE_SSG_STATIC_PATH_FETCH=true
 # to enable full ISR (Incremental Static Regeneration) flow, pre-fetch static paths 
-DISABLE_SSG_FETCH=
+DISABLE_SSG_STATIC_PATH_FETCH=
 
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -63,7 +63,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   let paths: StaticPath[] = [];
   let fallback: boolean | 'blocking' = 'blocking';
 
-  if (process.env.NODE_ENV !== 'development' && !process.env.DISABLE_SSG_FETCH) {
+  if (process.env.NODE_ENV !== 'development' && !process.env.DISABLE_SSG_STATIC_PATH_FETCH) {
     try {
       // Note: Next.js runs export in production mode
       paths = await sitemapFetcher.fetch(context);

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -63,7 +63,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   let paths: StaticPath[] = [];
   let fallback: boolean | 'blocking' = 'blocking';
 
-  if (process.env.NODE_ENV !== 'development' && !process.env.DISABLE_SSG_STATIC_PATH_FETCH) {
+  if (process.env.NODE_ENV !== 'development' && !process.env.DISABLE_SSG_FETCH) {
     try {
       // Note: Next.js runs export in production mode
       paths = await sitemapFetcher.fetch(context);

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/[[...path]].tsx
@@ -63,7 +63,7 @@ export const getStaticPaths: GetStaticPaths = async (context) => {
   let paths: StaticPath[] = [];
   let fallback: boolean | 'blocking' = 'blocking';
 
-  if (process.env.NODE_ENV !== 'development') {
+  if (process.env.NODE_ENV !== 'development' && !process.env.DISABLE_SSG_FETCH) {
     try {
       // Note: Next.js runs export in production mode
       paths = await sitemapFetcher.fetch(context);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Disable pages pre-render based on environment variable `DISABLE_SSG_FETCH` value
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
