### PR TITLE
[Next.js][Personalize] Finalize targeting experience call

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -27,13 +27,6 @@ describe('PersonalizeMiddleware', () => {
 
   const referrer = 'http://localhost:3000';
   const experienceParams: ExperienceParams = {
-    geo: {
-      city: 'geo-city',
-      country: 'geo-country',
-      latitude: 'geo-latitude',
-      longitude: 'geo-longitude',
-      region: 'geo-region',
-    },
     referrer,
     ua: 'ua',
     utm: {
@@ -74,7 +67,6 @@ describe('PersonalizeMiddleware', () => {
         ...props?.cookies,
       },
       referrer,
-      geo: props?.geo === null ? null : props?.geo || experienceParams.geo,
     } as NextRequest;
 
     return req;
@@ -744,9 +736,7 @@ describe('PersonalizeMiddleware', () => {
     it('optional experiece params are not present', async () => {
       userAgentStub.returns({ ua: undefined } as any);
 
-      const req = createRequest({
-        geo: {},
-      });
+      const req = createRequest();
 
       const res = createResponse();
 
@@ -771,13 +761,6 @@ describe('PersonalizeMiddleware', () => {
         executeExperience.calledWith(
           contentId,
           {
-            geo: {
-              city: null,
-              country: null,
-              latitude: null,
-              longitude: null,
-              region: null,
-            },
             referrer,
             ua: null,
             utm: {
@@ -790,72 +773,6 @@ describe('PersonalizeMiddleware', () => {
           browserId
         )
       ).to.be.true;
-
-      validateDebugLog('personalize middleware end: %o', {
-        rewritePath: '/_variantId_variant-2/styleguide',
-        browserId: 'browser-id',
-        headers: {
-          'x-middleware-cache': 'no-cache',
-        },
-      });
-
-      expect(getCookiesSpy.calledWith('bid_cdp-client-key')).to.be.true;
-
-      expect(finalRes).to.deep.equal(res);
-
-      expect(finalRes.cookies['bid_cdp-client-key']).to.equal(browserId);
-
-      getCookiesSpy.restore();
-      nextRewriteStub.restore();
-    });
-
-    it('request geo is not present', async () => {
-      userAgentStub.returns({ ua: undefined } as any);
-
-      const req = createRequest({ geo: null });
-
-      const res = createResponse();
-
-      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
-
-      const { middleware, getPersonalizeInfo, executeExperience } = createMiddleware({
-        variantId: 'variant-2',
-      });
-
-      const getCookiesSpy = spy(req.cookies, 'get');
-
-      const finalRes = await middleware.getHandler()(req, res);
-
-      expect(getPersonalizeInfo.calledWith('/styleguide', 'en')).to.be.true;
-
-      expect(
-        executeExperience.calledWith(
-          contentId,
-          {
-            geo: {
-              city: null,
-              country: null,
-              latitude: null,
-              longitude: null,
-              region: null,
-            },
-            referrer,
-            ua: null,
-            utm: {
-              campaign: 'utm_campaign',
-              content: null,
-              medium: null,
-              source: null,
-            },
-          },
-          browserId
-        )
-      ).to.be.true;
-
-      validateDebugLog('personalize middleware start: %o', {
-        pathname: '/styleguide',
-        language: 'en',
-      });
 
       validateDebugLog('personalize middleware end: %o', {
         rewritePath: '/_variantId_variant-2/styleguide',

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -100,13 +100,6 @@ export class PersonalizeMiddleware {
   protected getExperienceParams(req: NextRequest): ExperienceParams {
     const { ua } = userAgent(req);
     return {
-      geo: {
-        city: req.geo?.city ?? null,
-        country: req.geo?.country ?? null,
-        latitude: req.geo?.latitude ?? null,
-        longitude: req.geo?.longitude ?? null,
-        region: req.geo?.region ?? null,
-      },
       referrer: req.referrer,
       ua: ua ?? null,
       utm: {

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -98,10 +98,8 @@ export class PersonalizeMiddleware {
   }
 
   protected getExperienceParams(req: NextRequest): ExperienceParams {
-    const { ua } = userAgent(req);
     return {
       referrer: req.referrer,
-      ua: ua ?? null,
       utm: {
         campaign: req.nextUrl.searchParams.get('utm_campaign'),
         content: req.nextUrl.searchParams.get('utm_content'),
@@ -193,11 +191,13 @@ export class PersonalizeMiddleware {
     }
 
     // Execute targeted experience in CDP
+    const { ua } = userAgent(req);
     const params = this.getExperienceParams(req);
     const variantId = await this.cdpService.executeExperience(
       personalizeInfo.contentId,
-      params,
-      browserId
+      browserId,
+      ua,
+      params
     );
 
     if (!variantId) {

--- a/packages/sitecore-jss/src/personalize/cdp-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/cdp-service.test.ts
@@ -17,6 +17,7 @@ describe('CdpService', () => {
   const channel = DEFAULT_CHANNEL;
   const browserId = 'browser-id';
   const ref = browserId;
+  const ua = 'user-agent-string';
   const params = {
     referrer: 'about:client',
     utm: {
@@ -39,21 +40,25 @@ describe('CdpService', () => {
 
   describe('executeExperience', () => {
     it('should return variant data for a route', async () => {
-      nock(endpoint)
+      nock(endpoint, {
+        reqheaders: {
+          'User-Agent': ua,
+        },
+      })
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel,
           browserId,
           friendlyId,
-          channel,
+          params,
         })
         .reply(200, {
           variantId,
         });
 
       const service = new CdpService(config);
-      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+      const actualVariantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(actualVariantId).to.deep.equal(variantId);
     });
@@ -63,17 +68,17 @@ describe('CdpService', () => {
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel,
           browserId,
           friendlyId,
-          channel,
+          params,
         })
         .reply(200, {
           variantId: '',
         });
 
       const service = new CdpService(config);
-      const variantId = await service.executeExperience(contentId, params, browserId);
+      const variantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(variantId).to.be.undefined;
     });
@@ -84,17 +89,17 @@ describe('CdpService', () => {
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel: channelOverride,
           browserId,
           friendlyId,
-          channel: channelOverride,
+          params,
         })
         .reply(200, {
           variantId,
         });
 
       const service = new CdpService({ ...config, channel: channelOverride });
-      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+      const actualVariantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(actualVariantId).to.deep.equal(variantId);
     });
@@ -108,17 +113,17 @@ describe('CdpService', () => {
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel,
           browserId,
           friendlyId,
-          channel,
+          params,
         })
         .reply(200, {
           variantId,
         });
 
       const service = new CdpService({ ...config, dataFetcherResolver: () => fetcherSpy });
-      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+      const actualVariantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(actualVariantId).to.deep.equal(variantId);
       expect(fetcherSpy).to.be.called.once;
@@ -134,16 +139,16 @@ describe('CdpService', () => {
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel,
           browserId,
           friendlyId,
-          channel,
+          params,
         })
         .delay(50)
         .reply(408);
 
       const service = new CdpService({ ...config, dataFetcherResolver: () => fetcherSpy });
-      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+      const actualVariantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(actualVariantId).to.deep.equal(undefined);
     });
@@ -152,15 +157,15 @@ describe('CdpService', () => {
       nock(endpoint)
         .post('/v2/callFlows', {
           clientKey,
-          browserId,
-          params,
           pointOfSale,
-          friendlyId,
           channel,
+          browserId,
+          friendlyId,
+          params,
         })
         .replyWithError('error_test');
       const service = new CdpService(config);
-      await service.executeExperience(contentId, params, browserId).catch((error) => {
+      await service.executeExperience(contentId, browserId, ua, params).catch((error) => {
         expect(error.message).to.contain('error_test');
       });
     });
@@ -170,15 +175,15 @@ describe('CdpService', () => {
         .post('/v2/callFlows', {
           clientKey,
           pointOfSale,
-          params,
+          channel,
           browserId,
           friendlyId,
-          channel,
+          params,
         })
         .reply(408);
 
       const service = new CdpService(config);
-      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+      const actualVariantId = await service.executeExperience(contentId, browserId, ua, params);
 
       expect(actualVariantId).to.deep.equal(undefined);
     });

--- a/packages/sitecore-jss/src/personalize/cdp-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/cdp-service.test.ts
@@ -1,5 +1,5 @@
 ﻿/* eslint-disable no-unused-expressions */
-import { CdpService, ExperienceParams } from './cdp-service';
+import { CdpService, ExperienceParams, DEFAULT_CHANNEL } from './cdp-service';
 import { expect, spy, use } from 'chai';
 import spies from 'chai-spies';
 import nock from 'nock';
@@ -14,19 +14,10 @@ describe('CdpService', () => {
   const variantId = 'variant-1';
   const pointOfSale = 'pos-1';
   const friendlyId = contentId;
-  const channel = 'WEB';
+  const channel = DEFAULT_CHANNEL;
   const browserId = 'browser-id';
   const ref = browserId;
   const params = {
-    geo: {
-      city: 'Testville',
-      country: 'US',
-      latitude: '43.1475',
-      longitude: '-87.905',
-      region: 'CA',
-    },
-    ua:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67 Safari/537.36',
     referrer: 'about:client',
     utm: {
       campaign: 'test',
@@ -85,6 +76,27 @@ describe('CdpService', () => {
       const variantId = await service.executeExperience(contentId, params, browserId);
 
       expect(variantId).to.be.undefined;
+    });
+
+    it('should fetch using specified channel', async () => {
+      const channelOverride = 'TEST';
+      nock(endpoint)
+        .post('/v2/callFlows', {
+          clientKey,
+          pointOfSale,
+          params,
+          browserId,
+          friendlyId,
+          channel: channelOverride,
+        })
+        .reply(200, {
+          variantId,
+        });
+
+      const service = new CdpService({ ...config, channel: channelOverride });
+      const actualVariantId = await service.executeExperience(contentId, params, browserId);
+
+      expect(actualVariantId).to.deep.equal(variantId);
     });
 
     it('should fetch using custom fetcher resolver and respond with data', async () => {

--- a/packages/sitecore-jss/src/personalize/cdp-service.ts
+++ b/packages/sitecore-jss/src/personalize/cdp-service.ts
@@ -3,6 +3,8 @@ import { HttpDataFetcher } from '../data-fetcher';
 import { AxiosDataFetcher } from '../axios-fetcher';
 import { isTimeoutError } from '../utils';
 
+export const DEFAULT_CHANNEL = 'WEB';
+
 /**
  * Object model of CDP execute experience result
  */
@@ -34,6 +36,10 @@ export type CdpServiceConfig = {
    */
   pointOfSale: string;
   /**
+   * The Sitecore CDP channel to use for events. Uses 'WEB' by default.
+   */
+  channel?: string;
+  /**
    * Custom data fetcher resolver. Uses @see AxiosDataFetcher by default.
    */
   dataFetcherResolver?: DataFetcherResolver;
@@ -52,15 +58,7 @@ export type DataFetcherResolver = <T>({ timeout }: { timeout: number }) => HttpD
  * Object model of Experience Context data
  */
 export type ExperienceParams = {
-  geo: {
-    city: string | null;
-    country: string | null;
-    latitude: string | null;
-    longitude: string | null;
-    region: string | null;
-  };
   referrer: string;
-  ua: string | null;
   utm: {
     [key: string]: string | null;
     campaign: string | null;
@@ -103,7 +101,7 @@ export class CdpService {
         pointOfSale: this.config.pointOfSale,
         browserId,
         friendlyId: contentId,
-        channel: 'WEB',
+        channel: this.config.channel ?? DEFAULT_CHANNEL,
         params,
       });
       response.data.variantId === '' && (response.data.variantId = undefined);


### PR DESCRIPTION
## Description / Motivation
We need to make some adjustments to the CDP callFlows call (which occurs in personalize middleware) according to final specs.

- Removed `geo` from `params` (this is now being handled entirely on CDP-side via Cloudflare)
- Removed `ua` from `params` (moved to headers - see next)
- Added user agent to the callFlows fetch request headers ('User-Agent')
- Added ability to configure `channel` (default to 'WEB')

## Testing Details
Local testing using mock CDP

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
