### PR TITLE
[NextJs] Specify AppProps generic type in _app.tsx to align with latest changes from Next 12.3.0

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import type { AppProps } from 'next/app';
 import Router from 'next/router';
 import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 // Using bootstrap and nprogress are completely optional.
 //  bootstrap is used here to provide a clean layout for samples, without needing extra CSS in the sample app
@@ -18,7 +18,7 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app';
 import Router from 'next/router';
 import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
+import { NextAppProps } from 'lib/page-props';
 
 // Using bootstrap and nprogress are completely optional.
 //  bootstrap is used here to provide a clean layout for samples, without needing extra CSS in the sample app
@@ -17,7 +18,7 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
+import { NextAppProps } from 'lib/page-props';
 
 import 'assets/main.scss';
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 import 'assets/main.scss';
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -9,10 +9,10 @@ import {
  * Sitecore page props
  */
 export type SitecorePageProps = {
-  notFound: boolean;
-  redirect?: Redirect;
   locale: string;
   dictionary: DictionaryPhrases;
-  layoutData: LayoutServiceData;
   componentProps: ComponentPropsCollection;
+  notFound: boolean;
+  layoutData: LayoutServiceData;
+  redirect?: Redirect;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -6,13 +6,19 @@ import {
 } from '@sitecore-jss/sitecore-jss-nextjs';
 
 /**
- * Sitecore page props
+ * Nextjs app props
  */
-export type SitecorePageProps = {
+export type NextAppProps = {
   locale: string;
   dictionary: DictionaryPhrases;
-  componentProps: ComponentPropsCollection;
-  notFound: boolean;
   layoutData: LayoutServiceData;
+  componentProps: ComponentPropsCollection;
+};
+
+/**
+ * Sitecore page props
+ */
+export type SitecorePageProps = NextAppProps & {
+  notFound: boolean;
   redirect?: Redirect;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -6,19 +6,13 @@ import {
 } from '@sitecore-jss/sitecore-jss-nextjs';
 
 /**
- * Nextjs app props
+ * Sitecore page props
  */
-export type NextAppProps = {
+export type SitecorePageProps = {
+  notFound: boolean;
+  redirect?: Redirect;
   locale: string;
   dictionary: DictionaryPhrases;
   layoutData: LayoutServiceData;
   componentProps: ComponentPropsCollection;
-};
-
-/**
- * Sitecore page props
- */
-export type SitecorePageProps = NextAppProps & {
-  notFound: boolean;
-  redirect?: Redirect;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 import 'assets/app.css';
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
+import { NextAppProps } from 'lib/page-props';
 
 import 'assets/app.css';
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Next 12.3.0 provides change to `AppPages` type, which requires to provide type for generic
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
