### PR TITLE
[NextJs] Specify AppProps generic type in _app.tsx to align with latest changes from Next 12.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project does NOT adhere to [Semantic Versioning](https://semver.org/spec/v2
 * `[create-sitecore-jss]` Add descriptions to add-on list ([#935](https://github.com/Sitecore/jss/pull/935))
 * `[template/nextjs]` Introduced plugins approach for Next.js Middleware ([#945](https://github.com/Sitecore/jss/pull/945))
 * `[sitecore-jss]` Make it clear that `isEditorActive` only works in browser ([#1089](https://github.com/Sitecore/jss/pull/1089))
+* `[template/nextjs]` `[template/nextjs-styleguide]` `[template/nextjs-sxa]` Specify AppProps generic type in _app.tsx to align with latest changes from Next 12.3.0 ([#1155](https://github.com/Sitecore/jss/pull/1155))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import type { AppProps } from 'next/app';
 import Router from 'next/router';
 import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 // Using bootstrap and nprogress are completely optional.
 //  bootstrap is used here to provide a clean layout for samples, without needing extra CSS in the sample app
@@ -18,7 +18,7 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app';
 import Router from 'next/router';
 import { I18nProvider } from 'next-localization';
 import NProgress from 'nprogress';
+import { NextAppProps } from 'lib/page-props';
 
 // Using bootstrap and nprogress are completely optional.
 //  bootstrap is used here to provide a clean layout for samples, without needing extra CSS in the sample app
@@ -17,7 +18,7 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
+import { NextAppProps } from 'lib/page-props';
 
 import 'assets/main.scss';
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 import 'assets/main.scss';
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -6,16 +6,9 @@ import {
 } from '@sitecore-jss/sitecore-jss-nextjs';
 
 /**
- * Nextjs app props
- */
-export type NextAppProps = {
-
-};
-
-/**
  * Sitecore page props
  */
-export type SitecorePageProps = NextAppProps & {
+export type SitecorePageProps = {
   locale: string;
   dictionary: DictionaryPhrases;
   componentProps: ComponentPropsCollection;

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -6,13 +6,19 @@ import {
 } from '@sitecore-jss/sitecore-jss-nextjs';
 
 /**
- * Sitecore page props
+ * Nextjs app props
  */
-export type SitecorePageProps = {
+export type NextAppProps = {
   locale: string;
   dictionary: DictionaryPhrases;
-  componentProps: ComponentPropsCollection;
-  notFound: boolean;
   layoutData: LayoutServiceData;
+  componentProps: ComponentPropsCollection;
+};
+
+/**
+ * Sitecore page props
+ */
+export type SitecorePageProps = NextAppProps & {
+  notFound: boolean;
   redirect?: Redirect;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props.ts
@@ -9,16 +9,17 @@ import {
  * Nextjs app props
  */
 export type NextAppProps = {
-  locale: string;
-  dictionary: DictionaryPhrases;
-  layoutData: LayoutServiceData;
-  componentProps: ComponentPropsCollection;
+
 };
 
 /**
  * Sitecore page props
  */
 export type SitecorePageProps = NextAppProps & {
+  locale: string;
+  dictionary: DictionaryPhrases;
+  componentProps: ComponentPropsCollection;
   notFound: boolean;
+  layoutData: LayoutServiceData;
   redirect?: Redirect;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
@@ -1,10 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
-import { NextAppProps } from 'lib/page-props';
+import { SitecorePageProps } from 'lib/page-props';
 
 import 'assets/app.css';
 
-function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
+function App({ Component, pageProps }: AppProps<SitecorePageProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/pages/_app.tsx
@@ -1,9 +1,10 @@
 import type { AppProps } from 'next/app';
 import { I18nProvider } from 'next-localization';
+import { NextAppProps } from 'lib/page-props';
 
 import 'assets/app.css';
 
-function App({ Component, pageProps }: AppProps): JSX.Element {
+function App({ Component, pageProps }: AppProps<NextAppProps>): JSX.Element {
   const { dictionary, ...rest } = pageProps;
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Next 12.3.0 provides change to `AppPages` type, which requires to provide type for generic
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
