### PR TITLE
Add Scripts component to SXA layout

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/Layout.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/Layout.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 import Head from 'next/head';
 import {
   Placeholder,
-  VisitorIdentification,
   getPublicUrl,
   LayoutServiceData,
   Field,
 } from '@sitecore-jss/sitecore-jss-nextjs';
+import Scripts from 'src/Scripts';
 
 // Prefix public assets with a public URL to enable compatibility with Sitecore Experience Editor.
 // If you're not supporting the Experience Editor, you can remove this.
@@ -32,19 +32,11 @@ const Layout = ({ layoutData }: LayoutProps): JSX.Element => {
 
   return (
     <>
+      <Scripts />      
       <Head>
         <title>{fields?.Title?.value?.toString() || 'Page'}</title>
         <link rel="icon" href={`${publicUrl}/favicon.ico`} />
       </Head>
-
-      {/*
-        VisitorIdentification is necessary for Sitecore Analytics to determine if the visitor is a robot.
-        If Sitecore XP (with xConnect/xDB) is used, this is required or else analytics will not be collected for the JSS app.
-        For XM (CMS-only) apps, this should be removed.
-
-        VI detection only runs once for a given analytics ID, so this is not a recurring operation once cookies are established.
-      */}
-      <VisitorIdentification />
 
       {/* root placeholder for the app, which we add components to using route data */}
       <div className={mainClassPageEditing}>


### PR DESCRIPTION
Aligns Layout output between nexjs and sxa app templates so that Scripts component is used in both (instead of adding VisitorIdentification by default).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
