### PR TITLE
Fix middleware activating for favicon.ico and other paths

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -332,7 +332,7 @@ describe('PersonalizeMiddleware', () => {
         const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
         const { middleware } = createMiddleware({ excludeRoute });
-        
+
         await test('/src/image.png', middleware);
         await test('/api/layout/render', middleware);
         await test('/sitecore/render', middleware);

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -328,11 +328,15 @@ describe('PersonalizeMiddleware', () => {
         await test('/_next/webpack', middleware);
       });
 
-      it('custom excludeRoute function', async () => {
+      it('should apply both default and custom rules when custom excludeRoute function provided', async () => {
         const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
         const { middleware } = createMiddleware({ excludeRoute });
-
+        
+        await test('/src/image.png', middleware);
+        await test('/api/layout/render', middleware);
+        await test('/sitecore/render', middleware);
+        await test('/_next/webpack', middleware);
         await test('/crazypath/luna', middleware);
       });
     });

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -162,7 +162,8 @@ export class PersonalizeMiddleware {
     if (
       response.redirected || // Don't attempt to personalize a redirect
       this.isPreview(req) || // No need to personalize for preview (layout data is already prepared for preview)
-      (this.excludeRoute(pathname) || (this.config.excludeRoute && this.config.excludeRoute(pathname)))
+      this.excludeRoute(pathname) ||
+      (this.config.excludeRoute && this.config.excludeRoute(pathname))
     ) {
       debug.personalize(
         'skipped (%s)',

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -162,7 +162,7 @@ export class PersonalizeMiddleware {
     if (
       response.redirected || // Don't attempt to personalize a redirect
       this.isPreview(req) || // No need to personalize for preview (layout data is already prepared for preview)
-      (this.config.excludeRoute || this.excludeRoute)(pathname)
+      (this.excludeRoute(pathname) || (this.config.excludeRoute && this.config.excludeRoute(pathname)))
     ) {
       debug.personalize(
         'skipped (%s)',


### PR DESCRIPTION
Making sure the excludeRoutes from middleware constructor only adds exclude routes and doesn't override the default ones.

## Testing Details
One unit test changed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
