### PR TITLE
Ensure headers from middleare are passed into NativeFetcher

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -60,10 +60,17 @@ export class PersonalizeMiddleware {
     // NOTE: same here, we provide NativeDataFetcher for compatibility on Next.js Edge Runtime
     this.cdpService = new CdpService({
       ...config.cdpConfig,
-      dataFetcherResolver: <T>({ timeout }: { timeout: number }) => {
+      dataFetcherResolver: <T>({
+        timeout,
+        headers,
+      }: {
+        timeout: number;
+        headers?: Record<string, string>;
+      }) => {
         const fetcher = new NativeDataFetcher({
           debugger: debug.personalize,
           timeout,
+          headers,
         });
         return (url: string, data?: unknown) => fetcher.fetch<T>(url, data);
       },

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -15,10 +15,6 @@ type NativeDataFetcherOptions = {
    * Optional request timeout.
    */
   timeout?: number;
-  /**
-   * optional headers to use in fetch calls
-   */
-  headers?: Record<string, string>;
 };
 
 export type NativeDataFetcherConfig = NativeDataFetcherOptions & RequestInit;

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -15,6 +15,10 @@ type NativeDataFetcherOptions = {
    * Optional request timeout.
    */
   timeout?: number;
+  /**
+   * optional headers to use in fetch calls
+   */
+  headers?: Record<string, string>;
 };
 
 export type NativeDataFetcherConfig = NativeDataFetcherOptions & RequestInit;


### PR DESCRIPTION
Fixing the issue when user-agent was ignored in fetcher when executing CDP experience.

## Testing Details
To be further tested on Vercel or with mock.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
