### PR TITLE
 #544714: reverted changes

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-container.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-container.scss
@@ -2,8 +2,6 @@
 
 .container {
   padding: 0;
-  margin-right: unset;
-  margin-left: unset;
 
   &.fullwidth-container {
     max-width: unset;

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
@@ -21,6 +21,7 @@ export const Default = (props: ComponentProps): JSX.Element => {
   const containerStyles = props.params && props.params.Styles ? props.params.Styles : '';
   const styles = `${props.params.GridParameters} ${containerStyles}`.trimEnd();
   const phKey = `container-${props.params.DynamicPlaceholderId}`;
+  const id = props.params.RenderingIdentifier;
   let backgroundImage = props.params.BackgroundImage as string;
   let backgroundStyle: { [key: string]: string } = {};
 
@@ -36,7 +37,7 @@ export const Default = (props: ComponentProps): JSX.Element => {
   }
 
   return (
-    <div className={`component container ${styles}`}>
+    <div className={`component container ${styles}`} id={id ? id : undefined}>
       <div className="component-content" style={backgroundStyle}>
         <div className="row">
           <Placeholder name={phKey} rendering={props.rendering} />

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
@@ -54,9 +54,10 @@ export const Default = (props: ImageProps): JSX.Element => {
 
   if (props.fields) {
     const Image = () => <JssImage field={props.fields.Image} />;
+	const id = props.params.RenderingIdentifier;
 
     return (
-      <div className={`component image ${props.params.styles}`}>
+      <div className={`component image ${props.params.styles}`} id={id ? id : undefined}>
         <div className="component-content">
           {sitecoreContext.pageState === 'edit' ? (
             <Image />


### PR DESCRIPTION
reverted changes for class of Container
Containers are a fundamental building block of bootstrap and they are not being used to specify width using col-{x} class names.