### PR TITLE
 #519347 Change padding styles for Splitters components

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-column-splitter.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/_component-column-splitter.scss
@@ -1,9 +1,14 @@
+@import '@sass/abstracts/vars';
+
 .row.column-splitter {
     margin-left: 0;
     margin-right: 0;
+    padding-left: $default-padding / 2;
+    padding-right: $default-padding / 2;
     max-width: none;
-    >div {
-        padding-left: 0;
-        padding-right: 0
+
+    > div {
+       padding-left: $default-padding;
+       padding-right: $default-padding;
     }
 }


### PR DESCRIPTION
Change padding styles for Splitters components

## Description / Motivation
Paddings for row and column splitter components are not aligned when you are using these 2 components together

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)