### PR TITLE
Replace abortController.signal with promises timeout in native and graphql fetchers

### DIFF
--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -53,7 +53,6 @@
     "typescript": "~4.3.5"
   },
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "debug": "^4.3.1",

--- a/packages/sitecore-jss/src/utils/timeout-promise.ts
+++ b/packages/sitecore-jss/src/utils/timeout-promise.ts
@@ -5,7 +5,7 @@
 export default class TimeoutPromise {
   timeoutId: NodeJS.Timeout | undefined;
 
-  constructor(private timeout: number | undefined) {
+  constructor(private timeout: number) {
     this.timeoutId = undefined;
   }
 

--- a/packages/sitecore-jss/src/utils/timeout-promise.ts
+++ b/packages/sitecore-jss/src/utils/timeout-promise.ts
@@ -3,32 +3,29 @@
  * Useful in nextjs middleware until fetch.signal is fully supported by Vercel edge functions
  */
 export default class TimeoutPromise {
-  timeoutID: NodeJS.Timeout | undefined;
+  timeoutId: NodeJS.Timeout | undefined;
 
   constructor(private timeout: number | undefined) {
-    this.timeoutID = undefined;
+    this.timeoutId = undefined;
   }
 
   /**
    * Creates a timeout promise
    */
-  get start(): Promise<any> {
-    if (this.timeout) {
-      return new Promise((_, reject) => {
-        this.timeoutID = setTimeout(() => {
-          const abortError = new Error('Request timed out');
-          abortError.name = 'AbortError';
-          reject(abortError);
-        }, this.timeout);
-      });
-    }
-    return new Promise((_, reject) => reject('Timeout promise created with no timeout value'));
+  get start(): Promise<unknown> {
+    return new Promise((_, reject) => {
+      this.timeoutId = setTimeout(() => {
+        const abortError = new Error('Request timed out');
+        abortError.name = 'AbortError';
+        reject(abortError);
+      }, this.timeout);
+    });
   }
 
   /**
    * Clears the timeout from timeout promise
    */
   clear() {
-    this.timeoutID && clearTimeout(this.timeoutID);
+    this.timeoutId && clearTimeout(this.timeoutId);
   }
 }

--- a/packages/sitecore-jss/src/utils/timeout-promise.ts
+++ b/packages/sitecore-jss/src/utils/timeout-promise.ts
@@ -1,0 +1,34 @@
+/**
+ * A helper to assign timeouts to fetch or other promises
+ * Useful in nextjs middleware until fetch.signal is fully supported by Vercel edge functions
+ */
+export default class TimeoutPromise {
+  timeoutID: NodeJS.Timeout | undefined;
+  
+  constructor(private timeout: number | undefined) {
+    this.timeoutID = undefined;
+  }
+
+  /**
+   * Creates a timeout promise
+   */
+  get start(): Promise<any> {
+    if (this.timeout) {
+      return new Promise((_, reject) => {
+        this.timeoutID = setTimeout(() => {
+          const abortError = new Error('Request timed out');
+          abortError.name = 'AbortError';
+          reject(abortError);
+        }, this.timeout);
+      });
+    }
+    return new Promise((_, reject) => reject('Timeout promise created with no timeout value'));
+  }
+
+  /**
+   * Clears the timeout from timeout promise
+   */
+  clear() {
+    this.timeoutID && clearTimeout(this.timeoutID);
+  }
+}

--- a/packages/sitecore-jss/src/utils/timeout-promise.ts
+++ b/packages/sitecore-jss/src/utils/timeout-promise.ts
@@ -4,7 +4,7 @@
  */
 export default class TimeoutPromise {
   timeoutID: NodeJS.Timeout | undefined;
-  
+
   constructor(private timeout: number | undefined) {
     this.timeoutID = undefined;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4555,7 +4555,6 @@ __metadata:
     "@types/mocha": ^9.0.0
     "@types/node": ^16.11.6
     "@types/url-parse": 1.4.8
-    abort-controller: ^3.0.0
     axios: ^0.21.1
     chai: ^4.2.0
     chai-spies: ^1.0.0


### PR DESCRIPTION
This is a workaround to make sure GraphQL and other outgoing requests used by JSS are working in edge middleware.

## Description / Motivation
This approach addresses the unexpected behavior discussed here:
https://github.com/vercel/vercel/discussions/8668

## Testing Details
Manual tests are promising :)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
