### PR TITLE
#549829: Title rendering has an indent in the header placeholder - updated fix

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/basic/_header.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/basic/_header.scss
@@ -16,7 +16,9 @@
 
 header {
   #header {
-    .title {
+    .bs-title {
+      padding-left: 50px;
+
       h1 {
         font-size: $text-size-24;
         font-weight: 600;


### PR DESCRIPTION
Return padding needed for basic site, change the "title" class to "bs-title" to not affect Title rendering on non-basic sites.