### PR TITLE
[sitecore-jss] `rootItemId` not resolvable for different language versions 

### DIFF
--- a/packages/sitecore-jss/src/graphql/app-root-query.ts
+++ b/packages/sitecore-jss/src/graphql/app-root-query.ts
@@ -1,6 +1,5 @@
 import { GraphQLClient } from './../graphql-request-client';
 import { SitecoreTemplateId } from '../constants';
-import debug from '../debug';
 
 /** @private */
 export const siteNameError = 'The site name must be a non-empty string';
@@ -62,16 +61,13 @@ export async function getAppRootId(
   if (!language) {
     throw new RangeError(languageError);
   }
-
-  debug.dictionary('fetching site root for %s %s', language, siteName);
-
   let fetchResponse = await client.request<AppRootQueryResult>(appRootQuery, {
     jssAppTemplateId: jssAppTemplateId || SitecoreTemplateId.JssApp,
     siteName,
     language,
   });
 
-  if (!fetchResponse?.layout?.homePage?.rootItem?.length) {
+  if (!fetchResponse?.layout?.homePage?.rootItem?.length && language !== 'en') {
     fetchResponse = await client.request<AppRootQueryResult>(appRootQuery, {
       jssAppTemplateId: jssAppTemplateId || SitecoreTemplateId.JssApp,
       siteName,

--- a/packages/sitecore-jss/src/graphql/app-root-query.ts
+++ b/packages/sitecore-jss/src/graphql/app-root-query.ts
@@ -65,11 +65,19 @@ export async function getAppRootId(
 
   debug.dictionary('fetching site root for %s %s', language, siteName);
 
-  const fetchResponse = await client.request<AppRootQueryResult>(appRootQuery, {
+  let fetchResponse = await client.request<AppRootQueryResult>(appRootQuery, {
     jssAppTemplateId: jssAppTemplateId || SitecoreTemplateId.JssApp,
     siteName,
     language,
   });
+
+  if (!fetchResponse?.layout?.homePage?.rootItem?.length) {
+    fetchResponse = await client.request<AppRootQueryResult>(appRootQuery, {
+      jssAppTemplateId: jssAppTemplateId || SitecoreTemplateId.JssApp,
+      siteName,
+      language: 'en',
+    });
+  }
 
   if (!fetchResponse?.layout?.homePage?.rootItem?.length) {
     return null;

--- a/packages/sitecore-jss/src/graphql/graphql.test.ts
+++ b/packages/sitecore-jss/src/graphql/graphql.test.ts
@@ -31,6 +31,64 @@ describe('graphql', () => {
         expect(result).to.equal('GUIDGUIDGUID');
       });
 
+      it('valid root id using fallback language as en', async () => {
+        nock(endpoint, { reqheaders: { sc_apikey: apiKey } })
+          .post('/', (body) => {
+            return body.variables.language === 'language';
+          })
+          .reply(200, {
+            data: {
+              layout: {
+                homePage: {
+                  rootItem: [],
+                },
+              },
+            },
+          });
+
+        nock(endpoint, { reqheaders: { sc_apikey: apiKey } })
+          .post('/', (body) => {
+            return body.variables.language === 'en';
+          })
+          .reply(200, appRootQueryResponse);
+
+        const result = await getAppRootId(client, 'siteName', 'language');
+        expect(result).to.equal('GUIDGUIDGUID');
+      });
+
+      it('null for the passed language and for fallback language en', async () => {
+        nock(endpoint, { reqheaders: { sc_apikey: apiKey } })
+          .post('/', (body) => {
+            return body.variables.language === 'language';
+          })
+          .reply(200, {
+            data: {
+              layout: {
+                homePage: {
+                  rootItem: [],
+                },
+              },
+            },
+          });
+
+        nock(endpoint, { reqheaders: { sc_apikey: apiKey } })
+          .post('/', (body) => {
+            return body.variables.language === 'en';
+          })
+          .reply(200, {
+            data: {
+              layout: {
+                homePage: {
+                  rootItem: [],
+                },
+              },
+            },
+          });
+
+        const result = await getAppRootId(client, 'siteName', 'language');
+        expect(result).to.be.null;
+      });
+
       it('null if no app root found', async () => {
         nock(endpoint, { reqheaders: { sc_apikey: apiKey } })
           .post('/', queryNameFilter)

--- a/packages/sitecore-jss/src/graphql/graphql.test.ts
+++ b/packages/sitecore-jss/src/graphql/graphql.test.ts
@@ -44,7 +44,7 @@ describe('graphql', () => {
             },
           });
 
-        const result = await getAppRootId(client, 'siteName', 'language');
+        const result = await getAppRootId(client, 'siteName', 'en');
         expect(result).to.be.null;
       });
     });

--- a/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
+++ b/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
@@ -114,6 +114,8 @@ export class GraphQLDictionaryService extends DictionaryServiceBase {
       return cachedValue;
     }
 
+    debug.dictionary('fetching site root for %s %s', language, this.options.siteName);
+
     // If the caller does not specify a root item ID, then we try to figure it out
     const rootItemId =
       this.options.rootItemId ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The dictionary service doesn't return `rootItemId` for other language versions other than English.
Added a fix to make another request using language as `en` to get the `rootItemId` as it is same in all versions.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
