### PR TITLE
[Next.js] Correction for `nextjs-sxa` add-on compatibility pre-SXP 10.3 release

### DIFF
--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -51,7 +51,8 @@ export default class NextjsInitializer implements Initializer {
             value: 'nextjs-styleguide-tracking',
           },
           {
-            name: 'nextjs-sxa - Includes example components and setup for Headless SXA projects',
+            name:
+              'nextjs-sxa - Includes example components and setup for Headless SXA projects (only compatible with Sitecore XM Cloud)',
             value: 'nextjs-sxa',
           },
           {


### PR DESCRIPTION
## Description / Motivation
Correction for `nextjs-sxa` add-on compatibility pre-SXP 10.3 release (i.e. only compatible with XM Cloud, not SXP 10.2)

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
