### PR TITLE
[React] export DateFieldProps

### DIFF
--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -46,7 +46,7 @@ export {
 } from './components/Image';
 export { RichText, RichTextProps, RichTextPropTypes, RichTextField } from './components/RichText';
 export { Text, TextField } from './components/Text';
-export { DateField } from './components/Date';
+export { DateField, DateFieldProps } from './components/Date';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';
 export { VisitorIdentification } from './components/VisitorIdentification';


### PR DESCRIPTION
Export DataFieldProps for React DateField component.

Description / Motivation
DataFieldProps have been added to the index fil for export, so that I mirrors all the other components in the jss-React. Then It can be used along side the DataField component. 

Change type
BugFix