### PR TITLE
Performance improvements for personalize service and middleware

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
@@ -43,9 +43,8 @@ class PersonalizePlugin implements MiddlewarePlugin {
       },
       // This function determines if the middleware should be turned off.
       // IMPORTANT: You should implement based on your cookie consent management solution of choice.
-      // You may also wish to disable in development mode (process.env.NODE_ENV === 'development').
-      // By default it is always enabled.
-      disabled: () => false,
+      // You may wish to keep it disabled while in development mode.
+      disabled: () => process.env.NODE_ENV === 'development',
       // This function determines if a route should be excluded from personalization.
       // Certain paths are ignored by default (e.g. files and Next.js API routes), but you may wish to exclude more.
       // This is an important performance consideration since Next.js Edge middleware runs on every request.

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -156,8 +156,6 @@ describe('GraphQLPersonalizeService', () => {
       variantIds,
     });
 
-    // nock.cleanAll();
-
     mockEmptyResponse();
 
     const secondResult = await service.getPersonalizeInfo(itemPath, lang);
@@ -182,8 +180,6 @@ describe('GraphQLPersonalizeService', () => {
       variantIds,
     });
 
-    // nock.cleanAll();
-
     mockEmptyResponse();
 
     const secondResult = await service.getPersonalizeInfo(itemPath, lang);
@@ -205,16 +201,28 @@ describe('GraphQLPersonalizeService', () => {
 
     mockEmptyResponse();
 
+    const cacheNonUpdate = new Promise((resolve) => {
+      setTimeout(
+        () =>
+          service.getPersonalizeInfo(itemPath, lang).then((newResult) => {
+            expect(newResult).to.deep.equal(firstResult);
+            resolve(undefined);
+          }),
+        100
+      );
+    });
+
     const cacheUpdate = new Promise((resolve) => {
       setTimeout(
         () =>
           service.getPersonalizeInfo(itemPath, lang).then((newResult) => {
-            expect(newResult).to.not.deep.equal(firstResult);
+            expect(newResult).to.deep.equal(undefined);
             resolve(undefined);
           }),
         250
       );
     });
+    await cacheNonUpdate;
 
     await cacheUpdate;
   });

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -203,21 +203,19 @@ describe('GraphQLPersonalizeService', () => {
     });
     const firstResult = await service.getPersonalizeInfo(itemPath, lang);
 
-    // nock.cleanAll();
     mockEmptyResponse();
 
-    const waitCacheUpdate = new Promise((resolve) => {
+    const cacheUpdate = new Promise((resolve) => {
       setTimeout(
         () =>
           service.getPersonalizeInfo(itemPath, lang).then((newResult) => {
             expect(newResult).to.not.deep.equal(firstResult);
             resolve(undefined);
           }),
-        100
+        250
       );
     });
-
-    // await waitCached;
-    await waitCacheUpdate;
+    
+    await cacheUpdate;
   });
 });

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -215,7 +215,7 @@ describe('GraphQLPersonalizeService', () => {
         250
       );
     });
-    
+
     await cacheUpdate;
   });
 });

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -191,7 +191,7 @@ describe('GraphQLPersonalizeService', () => {
 
     const service = new GraphQLPersonalizeService({
       ...config,
-      cacheSettings: { cacheEnabled: false },
+      cacheEnabled: false,
     });
     const firstResult = await service.getPersonalizeInfo(itemPath, lang);
 

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -2,6 +2,7 @@ import { GraphQLClient, GraphQLRequestClient } from '../graphql-request-client';
 import debug from '../debug';
 import { isTimeoutError } from '../utils';
 import { CdpHelper } from './utils';
+import { MemoryCacheClient } from '../cache-client';
 
 export type GraphQLPersonalizeServiceConfig = {
   /**
@@ -46,6 +47,7 @@ type PersonalizeQueryResult = {
 
 export class GraphQLPersonalizeService {
   private graphQLClient: GraphQLClient;
+  private memoryCache: MemoryCacheClient<PersonalizeQueryResult>;
   protected get query(): string {
     return /* GraphQL */ `
       query($siteName: String!, $language: String!, $itemPath: String!) {
@@ -68,6 +70,7 @@ export class GraphQLPersonalizeService {
   constructor(protected config: GraphQLPersonalizeServiceConfig) {
     this.config.timeout = config.timeout || 250;
     this.graphQLClient = this.getGraphQLClient();
+    this.memoryCache = new MemoryCacheClient({ cacheTimeout: 10 });
   }
 
   /**
@@ -87,27 +90,36 @@ export class GraphQLPersonalizeService {
       language
     );
 
-    try {
-      const data = await this.graphQLClient.request<PersonalizeQueryResult>(this.query, {
-        siteName: this.config.siteName,
-        itemPath,
-        language,
-      });
+    const cacheKey = this.getCacheKey(itemPath, language);
+    let data = this.memoryCache.getCacheValue(cacheKey);
 
-      return data?.layout?.item
-        ? {
-            // CDP expects content id format `embedded_<id>_<lang>` (lowercase)
-            contentId: CdpHelper.getContentId(data.layout.item.id, language),
-            variantIds: data.layout.item.personalization.variantIds,
-          }
-        : undefined;
-    } catch (error) {
-      if (isTimeoutError(error)) {
-        return undefined;
+    if (!data) {
+      try {
+        data = await this.graphQLClient.request<PersonalizeQueryResult>(this.query, {
+          siteName: this.config.siteName,
+          itemPath,
+          language,
+        });
+        this.memoryCache.setCacheValue(cacheKey, data);
+      } catch (error) {
+        if (isTimeoutError(error)) {
+          return undefined;
+        }
+
+        throw error;
       }
-
-      throw error;
     }
+    return data?.layout?.item
+      ? {
+          // CDP expects content id format `embedded_<id>_<lang>` (lowercase)
+          contentId: CdpHelper.getContentId(data.layout.item.id, language),
+          variantIds: data.layout.item.personalization.variantIds,
+        }
+      : undefined;
+  }
+
+  protected getCacheKey(itemPath: string, language: string) {
+    return `${this.config.siteName}-${itemPath}-${language}`;
   }
 
   /**

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -76,7 +76,7 @@ export class GraphQLPersonalizeService {
   constructor(protected config: GraphQLPersonalizeServiceConfig) {
     this.config.timeout = config.timeout || 250;
     this.graphQLClient = this.getGraphQLClient();
-    this.memoryCache = this.getCacheClient();
+    this.cache = this.getCacheClient();
   }
 
   /**
@@ -97,7 +97,7 @@ export class GraphQLPersonalizeService {
     );
 
     const cacheKey = this.getCacheKey(itemPath, language);
-    let data = this.memoryCache.getCacheValue(cacheKey);
+    let data = this.cache.getCacheValue(cacheKey);
 
     if (!data) {
       try {
@@ -106,7 +106,7 @@ export class GraphQLPersonalizeService {
           itemPath,
           language,
         });
-        this.memoryCache.setCacheValue(cacheKey, data);
+        this.cache.setCacheValue(cacheKey, data);
       } catch (error) {
         if (isTimeoutError(error)) {
           return undefined;

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -53,7 +53,7 @@ type PersonalizeQueryResult = {
 
 export class GraphQLPersonalizeService {
   private graphQLClient: GraphQLClient;
-  private memoryCache: CacheClient<PersonalizeQueryResult>;
+  private cache: CacheClient<PersonalizeQueryResult>;
   protected get query(): string {
     return /* GraphQL */ `
       query($siteName: String!, $language: String!, $itemPath: String!) {

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -4,7 +4,7 @@ import { isTimeoutError } from '../utils';
 import { CdpHelper } from './utils';
 import { CacheClient, CacheOptions, MemoryCacheClient } from '../cache-client';
 
-export type GraphQLPersonalizeServiceConfig = {
+export type GraphQLPersonalizeServiceConfig = CacheOptions & {
   /**
    * Your Graphql endpoint
    */
@@ -21,12 +21,6 @@ export type GraphQLPersonalizeServiceConfig = {
    * Timeout (ms) for the Personalize request. Default is 250.
    */
   timeout?: number;
-  /**
-   * Cache settings
-   * Specified the cache timeout and whether cache is enabled
-   * If not provided cache will be enabled with timeout of 10 seconds
-   */
-  cacheSettings?: CacheOptions;
   /**
    * Override fetch method. Uses 'GraphQLRequestClient' default otherwise.
    */
@@ -131,8 +125,8 @@ export class GraphQLPersonalizeService {
    */
   protected getCacheClient(): CacheClient<PersonalizeQueryResult> {
     return new MemoryCacheClient<PersonalizeQueryResult>({
-      cacheEnabled: this.config.cacheSettings?.cacheEnabled ?? true,
-      cacheTimeout: this.config.cacheSettings?.cacheTimeout ?? 10,
+      cacheEnabled: this.config.cacheEnabled ?? true,
+      cacheTimeout: this.config.cacheTimeout ?? 10,
     });
   }
 


### PR DESCRIPTION
## Description / Motivation
1) Memory cache usage added to personalize graphql service to cut the number of requests to Sitecore Edge endpoint.
2) Personalize middleware will be disabled by default in development environment - the disabled() delegate passed to middleware still can be changed when needed. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
