### PR TITLE
[sitecore-jss] Update models: Add url and id property to item type

### DIFF
--- a/packages/sitecore-jss/src/layout/models.ts
+++ b/packages/sitecore-jss/src/layout/models.ts
@@ -140,6 +140,8 @@ export interface Field<T = GenericFieldValue> {
 export interface Item {
   name: string;
   displayName?: string;
+  id?: string;
+  url?: string;
   fields: {
     [name: string]: Field | Item | Item[] | undefined;
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
<!--- Describe your changes in detail -->
Adding two extra fields (`id` & `url`) to the **Item** interface in models to be able to properly type incoming data.

The data that is coming from Sitecore seems to have these extra 2 fields on it, see example:

```js
  paymentFrequencies: [
      {
        id: '7b7ff13f-f7af-4dc7-8612-baf46a61659a',
        url: '/data/reference-data/payment-frequencies/fortnightly',
        name: 'Fortnightly',
        displayName: 'Fortnightly',
        fields: {
          label: {
            value: 'due on {date}',
          },
          value: {
            value: 'Fortnightly',
          },
          name: {
            value: 'Fortnightly',
          },
        },
      },
      {
        id: '63e0d50e-b123-4783-8817-b42ebbdc4d0e',
        url: '/data/reference-data/payment-frequencies/four-weekly',
        name: 'Four weekly',
        displayName: 'Four weekly',
        fields: {
          label: {
            value: 'due on {date}',
          },
          value: {
            value: 'Four weekly',
          },
          name: {
            value: '4Weekly',
          },
        },
      },
]
```

Having these 2 extra fields allows to properly type the rendering props:
```ts
export interface ComponentProps {
  fields: {
    paymentFrequencies: Item[];
  };
  rendering: ComponentRendering;
}
```

## Testing Details
No effects on other data as the fields are marked optional.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

