### PR TITLE
feat: pass anchor field from sitecore to hash prop on nextlink

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -54,7 +54,9 @@ describe('<Link />', () => {
 
     const link = c.find('a');
 
-    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}#foo"`);
+    expect(link.html()).to.contain(
+      `href="${field.value.href}?${field.value.querystring}#${field.value.anchor}"`
+    );
     expect(link.html()).to.contain(`class="${field.value.class}"`);
     expect(link.html()).to.contain(`title="${field.value.title}"`);
     expect(link.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -42,6 +42,7 @@ describe('<Link />', () => {
         title: 'My Link',
         target: '_blank',
         querystring: 'foo=bar',
+        anchor: 'foo',
       },
     };
 
@@ -53,7 +54,7 @@ describe('<Link />', () => {
 
     const link = c.find('a');
 
-    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}"`);
+    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}#foo"`);
     expect(link.html()).to.contain(`class="${field.value.class}"`);
     expect(link.html()).to.contain(`title="${field.value.title}"`);
     expect(link.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -41,7 +41,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       if (internalLinkMatcher.test(href)) {
         return (
           <NextLink
-            href={{ pathname: href, query: querystring, hash: anchor as string }}
+            href={{ pathname: href, query: querystring, hash: anchor }}
             key="link"
             locale={false}
           >

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -31,7 +31,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
     const value = ((field as LinkFieldValue).href
       ? field
       : (field as LinkField).value) as LinkFieldValue;
-    const { href, querystring } = value;
+    const { href, querystring, anchor } = value;
     const isEditing = editable && (field as LinkFieldValue).editable;
 
     if (href && !isEditing) {
@@ -40,7 +40,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       // determine if a link is a route or not.
       if (internalLinkMatcher.test(href)) {
         return (
-          <NextLink href={{ pathname: href, query: querystring }} key="link" locale={false}>
+          <NextLink
+            href={{ pathname: href, query: querystring, hash: anchor as string }}
+            key="link"
+            locale={false}
+          >
             <a
               title={value.title}
               target={value.target}

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -10,6 +10,7 @@ export interface LinkFieldValue {
   title?: string;
   target?: string;
   text?: string;
+  anchor?: string;
   querystring?: string;
 }
 


### PR DESCRIPTION
## Description / Motivation
Currently, the anchor property that comes from Sitecore is ignored, this PR passes it to the hash property of the NextLink

## Testing Details
Added to the Link.test.tsx with a simple check for the anchor.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
