### PR TITLE
add async to editing data cache

### DIFF
--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-cache.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-cache.test.ts
@@ -4,17 +4,17 @@ import { EditingDataDiskCache } from './editing-data-cache';
 import { data } from '../test-data/editing-data';
 
 describe('EditingDataDiskCache', () => {
-  it('should write/read editing data', () => {
+  it('should write/read editing data', async () => {
     const key = data.layoutData.sitecore.route.itemId;
     const cache = new EditingDataDiskCache();
     cache.set(key, data as EditingData);
-    const result = cache.get(key) as EditingData;
+    const result = (await cache.get(key)) as EditingData;
     expect(data).to.deep.equal(result);
   });
 
-  it('should return undefined on cache miss', () => {
+  it('should return undefined on cache miss', async () => {
     const cache = new EditingDataDiskCache();
-    const result = cache.get('nope');
+    const result = await cache.get('nope');
     expect(result).to.equal(undefined);
   });
 });

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-cache.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-cache.ts
@@ -8,8 +8,8 @@ import { EditingData } from './editing-data';
  * Defines an editing data cache implementation
  */
 export interface EditingDataCache {
-  set(key: string, editingData: EditingData): void;
-  get(key: string): EditingData | undefined;
+  set(key: string, editingData: EditingData): Promise<void>;
+  get(key: string): Promise<EditingData | undefined>;
 }
 
 /**
@@ -27,22 +27,28 @@ export class EditingDataDiskCache implements EditingDataCache {
     this.cache = new Cache('editing-data', { compression: 'gzip', location: tmpDir });
   }
 
-  set(key: string, editingData: EditingData): void {
+  set(key: string, editingData: EditingData): Promise<void> {
     const filePath = this.cache.set(key, JSON.stringify(editingData));
-    if (!filePath || filePath.length === 0) {
-      throw new Error(`Editing data cache not set for key ${key} at ${this.cache.root}`);
-    }
+    return new Promise((resolve, reject) => {
+      if (!filePath || filePath.length === 0) {
+        reject(new Error(`Editing data cache not set for key ${key} at ${this.cache.root}`));
+      }
+
+      resolve();
+    });
   }
 
-  get(key: string): EditingData | undefined {
+  get(key: string): Promise<EditingData | undefined> {
     const entry = this.cache.get(key);
-    if (!entry.isCached) {
-      console.warn(`Editing data cache miss for key ${key} at ${this.cache.root}`);
-      return undefined;
-    }
-    // Remove to preserve disk-space (as a macrotask so as not to block current execution)
-    setTimeout(() => this.cache.remove(key));
-    return JSON.parse(entry.value) as EditingData;
+    return new Promise<EditingData | undefined>((resolve) => {
+      if (!entry.isCached) {
+        console.warn(`Editing data cache miss for key ${key} at ${this.cache.root}`);
+        resolve(undefined);
+      }
+      // Remove to preserve disk-space (as a macrotask so as not to block current execution)
+      setTimeout(() => this.cache.remove(key));
+      resolve(JSON.parse(entry.value) as EditingData);
+    });
   }
 }
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.ts
@@ -60,7 +60,7 @@ export class EditingDataMiddleware {
     switch (method) {
       case 'GET': {
         // Get cache value
-        const data = this.editingDataCache.get(key as string);
+        const data = await this.editingDataCache.get(key as string);
         res.status(200).json(data);
         break;
       }
@@ -69,7 +69,7 @@ export class EditingDataMiddleware {
           res.status(400).end('Missing or invalid editing data');
         } else {
           // Set cache value
-          this.editingDataCache.set(key as string, body as EditingData);
+          await this.editingDataCache.set(key as string, body as EditingData);
           res.status(200).end();
         }
         break;

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-service.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-service.ts
@@ -88,7 +88,7 @@ export class BasicEditingDataService implements EditingDataService {
     } as EditingPreviewData;
 
     debug.editing('storing editing data for %o: %o', previewData, data);
-    this.editingDataCache.set(key, data);
+    await this.editingDataCache.set(key, data);
     return { key };
   }
 
@@ -101,7 +101,7 @@ export class BasicEditingDataService implements EditingDataService {
     const editingPreviewData = previewData as EditingPreviewData;
 
     debug.editing('retrieving editing data for %o', previewData);
-    return this.editingDataCache.get(editingPreviewData.key);
+    return await this.editingDataCache.get(editingPreviewData.key);
   }
 }
 


### PR DESCRIPTION
## Description / Motivation
For deploying Sitecore JSS Next.js to Azure Static Web Apps I had to provide my own implementation of the EditingDataCache class (using Azure Blobstorage instead of disk cache):

See https://github.com/erwinsmit/swa-jss/blob/master/src/lib/editing/editing-data-cache.ts for an example.
In this example I had to copy more stuff out of the JSS repo to make it work. If async was supported that wouldn't be necessary. 

The problem I had was that the "EditingDataService" was expecting the "EditingDataCache" to be sync, not async. This limits the implementation of the EditingDataCache class, it's not possible for example to write/read stuff to Blobstorage in a sync manner. 

With my suggested changes it's possible to use sync and async EditingDataCache implementations.  

## Testing Details
I've tested my changes on this repo:
https://github.com/erwinsmit/swa-jss/

You can also read my blogpost that explains it further:
https://www.erwinsmit.com/sitecore-jss-nextjs-on-azure-static-web-app/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
