### PR TITLE
[Next.js][React] Link component does not add anchor to the internal links

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -54,7 +54,9 @@ describe('<Link />', () => {
 
     const link = c.find('a');
 
-    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}#foo"`);
+    expect(link.html()).to.contain(
+      `href="${field.value.href}?${field.value.querystring}#${field.value.anchor}"`
+    );
     expect(link.html()).to.contain(`class="${field.value.class}"`);
     expect(link.html()).to.contain(`title="${field.value.title}"`);
     expect(link.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -42,6 +42,7 @@ describe('<Link />', () => {
         title: 'My Link',
         target: '_blank',
         querystring: 'foo=bar',
+        anchor: 'foo',
       },
     };
 
@@ -53,7 +54,7 @@ describe('<Link />', () => {
 
     const link = c.find('a');
 
-    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}"`);
+    expect(link.html()).to.contain(`href="${field.value.href}?${field.value.querystring}#foo"`);
     expect(link.html()).to.contain(`class="${field.value.class}"`);
     expect(link.html()).to.contain(`title="${field.value.title}"`);
     expect(link.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -41,7 +41,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       if (internalLinkMatcher.test(href)) {
         return (
           <NextLink
-            href={{ pathname: href, query: querystring, hash: anchor as string }}
+            href={{ pathname: href, query: querystring, hash: anchor }}
             key="link"
             locale={false}
           >

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -31,7 +31,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
     const value = ((field as LinkFieldValue).href
       ? field
       : (field as LinkField).value) as LinkFieldValue;
-    const { href, querystring } = value;
+    const { href, querystring, anchor } = value;
     const isEditing = editable && (field as LinkFieldValue).editable;
 
     if (href && !isEditing) {
@@ -40,7 +40,11 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       // determine if a link is a route or not.
       if (internalLinkMatcher.test(href)) {
         return (
-          <NextLink href={{ pathname: href, query: querystring }} key="link" locale={false}>
+          <NextLink
+            href={{ pathname: href, query: querystring, hash: anchor as string }}
+            key="link"
+            locale={false}
+          >
             <a
               title={value.title}
               target={value.target}

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -64,6 +64,7 @@ describe('<Link />', () => {
     const field = {
       value: {
         href: '/lorem',
+        anchor: 'foo',
         text: 'ipsum',
         class: 'my-link',
         title: 'My Link',
@@ -72,7 +73,9 @@ describe('<Link />', () => {
       },
     };
     const rendered = mount(<Link field={field} />).find('a');
-    expect(rendered.html()).to.contain(`href="${field.value.href}?${field.value.querystring}"`);
+    expect(rendered.html()).to.contain(
+      `href="${field.value.href}?${field.value.querystring}#${field.value.anchor}"`
+    );
     expect(rendered.html()).to.contain(`class="${field.value.class}"`);
     expect(rendered.html()).to.contain(`title="${field.value.title}"`);
     expect(rendered.html()).to.contain(`target="${field.value.target}"`);

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -96,11 +96,10 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
     }
 
     const anchor = link.anchor ? `#${link.anchor}` : '';
+    const querystring = link.querystring ? `?${link.querystring}` : '';
 
     const anchorAttrs: { [attr: string]: unknown } = {
-      href: link.querystring
-        ? `${link.href}?${link.querystring}${anchor}`
-        : `${link.href}${anchor}`,
+      href: `${link.href}${querystring}${anchor}`,
       className: link.class,
       title: link.title,
       target: link.target,

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -10,6 +10,7 @@ export interface LinkFieldValue {
   title?: string;
   target?: string;
   text?: string;
+  anchor?: string;
   querystring?: string;
 }
 

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -95,8 +95,12 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       return null;
     }
 
+    const anchor = link.anchor ? `#${link.anchor}` : '';
+
     const anchorAttrs: { [attr: string]: unknown } = {
-      href: link.querystring ? `${link.href}?${link.querystring}` : link.href,
+      href: link.querystring
+        ? `${link.href}?${link.querystring}${anchor}`
+        : `${link.href}${anchor}`,
       className: link.class,
       title: link.title,
       target: link.target,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Add support for `anchor` attribute for:
* sitecore-jss-react
* sitecore-jss-nextjs

Pulled nextjs part from #1220 
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
