### PR TITLE
GraphQL site info service

### DIFF
--- a/packages/sitecore-jss/src/constants.ts
+++ b/packages/sitecore-jss/src/constants.ts
@@ -16,4 +16,6 @@ export const JSS_MODE = {
   DISCONNECTED: 'disconnected',
 };
 
+export const headlessSiteGroupingTemplate = 'E46F3AF2-39FA-4866-A157-7017C4B2A40C';
+
 export const siteNameError = 'The siteName cannot be empty';

--- a/packages/sitecore-jss/src/debug.ts
+++ b/packages/sitecore-jss/src/debug.ts
@@ -33,6 +33,7 @@ export default {
   dictionary: debug(`${rootNamespace}:dictionary`),
   editing: debug(`${rootNamespace}:editing`),
   sitemap: debug(`${rootNamespace}:sitemap`),
+  multisite: debug(`${rootNamespace}:multisite`),
   robots: debug(`${rootNamespace}:robots`),
   redirects: debug(`${rootNamespace}:redirects`),
   personalize: debug(`${rootNamespace}:personalize`),

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
@@ -101,7 +101,7 @@ describe('GraphQLSiteInfoService', () => {
     const service = new GraphQLSiteInfoService({
       apiKey: apiKey,
       endpoint: endpoint,
-      cacheSettings: { cacheEnabled: false },
+      cacheEnabled: false,
     });
     const result = await service.fetchSiteInfo();
     expect(result).to.be.deep.equal([

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import { GraphQLSiteInfoService } from './graphql-siteinfo-service';
+
+describe('GraphQLSiteInfoService', () => {
+  const endpoint = 'http://site';
+  const apiKey = 'some-api-key';
+  const nonEmptyResponse = {
+    data: {
+      search: {
+        results: [
+          {
+            name: 'site 51',
+            hostName: {
+              value: 'restricted.gov',
+            },
+            virtualFolder: {
+              value: '/aliens',
+            },
+            language: {
+              value: 'en',
+            },
+          },
+          {
+            name: 'public',
+            hostName: {
+              value: 'pr.showercurtains.org',
+            },
+            virtualFolder: {
+              value: '/we-are-open',
+            },
+            language: {
+              value: '',
+            },
+          },
+        ],
+      },
+    },
+  };
+  const emptyResponse = {
+    data: {
+      search: {
+        results: [],
+      },
+    },
+  };
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  const mockSiteInfoRequest = () => {
+    nock(endpoint)
+      .post('/')
+      .reply(200, nonEmptyResponse);
+  };
+
+  it('should return correct result', async () => {
+    mockSiteInfoRequest();
+    const service = new GraphQLSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+    const result = await service.fetchSiteInfo();
+    expect(result).to.be.deep.equal([
+      {
+        name: 'site 51',
+        hostName: 'restricted.gov',
+        virtualFolder: '/aliens',
+        language: 'en',
+      },
+      {
+        name: 'public',
+        hostName: 'pr.showercurtains.org',
+        virtualFolder: '/we-are-open',
+        language: '',
+      },
+    ]);
+  });
+
+  it('should return empty array when empty result received', async () => {
+    nock(endpoint)
+      .post('/')
+      .reply(200, emptyResponse);
+    const service = new GraphQLSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+    const result = await service.fetchSiteInfo();
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should use caching by default', async () => {
+    mockSiteInfoRequest();
+    const service = new GraphQLSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+    const result = await service.fetchSiteInfo();
+    nock.cleanAll();
+    nock(endpoint)
+      .post('/')
+      .reply(200, emptyResponse);
+    const resultCached = await service.fetchSiteInfo();
+    expect(resultCached).to.deep.equal(result);
+  });
+
+  it('should be possible to disable cache', async () => {
+    mockSiteInfoRequest();
+    const service = new GraphQLSiteInfoService({
+      apiKey: apiKey,
+      endpoint: endpoint,
+      cacheSettings: { cacheEnabled: false },
+    });
+    const result = await service.fetchSiteInfo();
+    expect(result).to.be.deep.equal([
+      {
+        name: 'site 51',
+        hostName: 'restricted.gov',
+        virtualFolder: '/aliens',
+        language: 'en',
+      },
+      {
+        name: 'public',
+        hostName: 'pr.showercurtains.org',
+        virtualFolder: '/we-are-open',
+        language: '',
+      },
+    ]);
+    nock.cleanAll();
+    nock(endpoint)
+      .post('/')
+      .reply(200, emptyResponse);
+    const resultCached = await service.fetchSiteInfo();
+    expect(resultCached).to.deep.equal([]);
+  });
+});

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -1,0 +1,137 @@
+import { GraphQLClient, GraphQLRequestClient } from '../graphql';
+import debug from 'debug';
+import { CacheClient, CacheOptions, MemoryCacheClient } from '../cache-client';
+
+const siteGroupingTemplate = 'EDA823FC-BC7E-4EF6-B498-CD09EC6FDAEF';
+
+const defaultQuery = /* GraphQL */ `
+  {
+    search(
+      where: { name: "_template", value: "${siteGroupingTemplate}", operator: EQ }
+    ) {
+      results {
+        ... on SiteDefinition {
+          name
+          hostName {
+            value
+          }
+          virtualFolder {
+            value
+          }
+          language: language_f19277fe1b854b0a8c265e74d766b3a3 {
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+export type SiteInfo = {
+  name: string;
+  hostName: string;
+  virtualFolder: string;
+  language: string;
+};
+
+type GraphQLSiteInfoServiceOptions = {
+  /**
+   * Your Graphql endpoint
+   */
+  endpoint: string;
+  /**
+   * The API key to use for authentication
+   */
+  apiKey: string;
+  /**
+   * Settings for internal cache.
+   * Cache is enabled by default with timout set to 10
+   */
+  cacheSettings?: CacheOptions;
+};
+
+type GraphQLSiteInfoResponse = {
+  search: {
+    results: GraphQLSiteInfoResult[];
+  };
+};
+
+type GraphQLSiteInfoResult = {
+  name: string;
+  hostName: {
+    value: string;
+  };
+  virtualFolder: {
+    value: string;
+  };
+  language: {
+    value: string;
+  };
+};
+
+export class GraphQLSiteInfoService {
+  private graphQLClient: GraphQLClient;
+  private memoryCache: CacheClient<SiteInfo[]>;
+
+  protected get query(): string {
+    return defaultQuery;
+  }
+
+  /**
+   * Creates an instance of graphQL service to retrieve site configuration list from Sitecore
+   * @param {GraphQLSiteInfoServiceOptions} options instance
+   */
+  constructor(private options: GraphQLSiteInfoServiceOptions) {
+    this.graphQLClient = this.getGraphQLClient();
+    this.memoryCache = this.getCacheClient();
+  }
+
+  async fetchSiteInfo(): Promise<SiteInfo[]> {
+    const cachedResult = this.memoryCache.getCacheValue(this.getCacheKey());
+    if (cachedResult) {
+      return cachedResult;
+    }
+
+    const response = await this.graphQLClient.request<GraphQLSiteInfoResponse>(this.query);
+    const result = response?.search?.results?.reduce<SiteInfo[]>((result, current) => {
+      result.push({
+        name: current.name,
+        hostName: current.hostName.value,
+        virtualFolder: current.virtualFolder.value,
+        language: current.language.value,
+      });
+      return result;
+    }, []);
+    this.memoryCache.setCacheValue(this.getCacheKey(), result);
+    return result;
+  }
+
+  /**
+   * Gets cache client implementation
+   * Override this method if custom cache needs to be used
+   * @returns CacheClient instance
+   */
+  protected getCacheClient(): CacheClient<SiteInfo[]> {
+    return new MemoryCacheClient<SiteInfo[]>({
+      cacheEnabled: this.options.cacheSettings?.cacheEnabled ?? true,
+      cacheTimeout: this.options.cacheSettings?.cacheTimeout ?? 10,
+    });
+  }
+
+  /**
+   * Gets a GraphQL client that can make requests to the API. Uses graphql-request as the default
+   * library for fetching graphql data (@see GraphQLRequestClient). Override this method if you
+   * want to use something else.
+   * @returns {GraphQLClient} implementation
+   */
+  protected getGraphQLClient(): GraphQLClient {
+    return new GraphQLRequestClient(this.options.endpoint, {
+      apiKey: this.options.apiKey,
+      debugger: debug('multi-site'), // TODO replace with global from debug
+    });
+  }
+
+  private getCacheKey(): string {
+    return 'sitenfo-service-cachedSiteInfo';
+  }
+}

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -7,7 +7,7 @@ const headlessSiteGroupingTemplate = 'E46F3AF2-39FA-4866-A157-7017C4B2A40C';
 const defaultQuery = /* GraphQL */ `
   {
     search(
-      where: { name: "_template", value: "${headlessSiteGroupingTemplate}", operator: EQ }
+      where: { name: "_templates", value: "${headlessSiteGroupingTemplate}", operator: CONTAINS }
     ) {
       results {
       ... on Item {

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient, GraphQLRequestClient } from '../graphql';
-import debug from 'debug';
+import debug from '../debug';
 import { CacheClient, CacheOptions, MemoryCacheClient } from '../cache-client';
 
 const headlessSiteGroupingTemplate = 'E46F3AF2-39FA-4866-A157-7017C4B2A40C';
@@ -10,12 +10,12 @@ const defaultQuery = /* GraphQL */ `
       where: { name: "_template", value: "${headlessSiteGroupingTemplate}", operator: EQ }
     ) {
       results {
-      ... on Site_e46f3af239fa4866a1577017c4b2a40c {
+      ... on Item {
         name
-        hostName {
+        hostName: field(name: "Hostname") {
           value
         }
-        virtualFolder {
+        virtualFolder: field(name: "VirtualFolder") {
           value
         }
         language: field(name: "Language") {
@@ -122,7 +122,7 @@ export class GraphQLSiteInfoService {
   protected getGraphQLClient(): GraphQLClient {
     return new GraphQLRequestClient(this.config.endpoint, {
       apiKey: this.config.apiKey,
-      debugger: debug('multi-site'), // TODO replace with global from debug
+      debugger: debug.multisite,
     });
   }
 

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -1,8 +1,7 @@
 import { GraphQLClient, GraphQLRequestClient } from '../graphql';
 import debug from '../debug';
 import { CacheClient, CacheOptions, MemoryCacheClient } from '../cache-client';
-
-const headlessSiteGroupingTemplate = 'E46F3AF2-39FA-4866-A157-7017C4B2A40C';
+import { headlessSiteGroupingTemplate } from '../constants';
 
 const defaultQuery = /* GraphQL */ `
   {

--- a/packages/sitecore-jss/src/site/index.ts
+++ b/packages/sitecore-jss/src/site/index.ts
@@ -24,3 +24,9 @@ export {
   GraphQLErrorPagesService,
   GraphQLErrorPagesServiceConfig,
 } from './graphql-error-pages-service';
+
+export {
+  SiteInfo,
+  GraphQLSiteInfoService,
+  GraphQLSiteInfoServiceConfig,
+} from './graphql-siteinfo-service';


### PR DESCRIPTION
Multi site service to retrieve site data from Sitecore, to be used for dynamic site resolving on JSS side.

- Uses search GraphQL to get Site Grouping SXA items;
- Reads hostname, virtual folder, site language;
- Returns an array of site data with the above;
- Uses in-memory caching