### PR TITLE
Rename `Page` template back to `AppRoute`

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/graph-ql-integrated-demo.sitecore.graphql
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/graph-ql-integrated-demo.sitecore.graphql
@@ -42,8 +42,8 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
   # (as long as the GraphQLData helper is used)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -56,7 +56,7 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/routes.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/routes.sitecore.ts
@@ -16,7 +16,7 @@ export default function addRoutesToManifest(manifest: Manifest): Promise<void> {
   // which routes can use by setting `template: YourCustomRouteTypeName` in their definition.
   const appTemplateSection = 'Page Metadata';
   manifest.setDefaultRouteType({
-    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Page',
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>App Route',
     fields: [
       {
         name: 'pageTitle',
@@ -25,7 +25,7 @@ export default function addRoutesToManifest(manifest: Manifest): Promise<void> {
         type: CommonFieldTypes.SingleLineText,
       },
     ],
-    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>Page'],
+    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>App Route'],
   });
 
   return mergeFs('./data/routes') // relative to process invocation (i.e. your package.json)

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/graph-ql-connected-demo/graph-ql-connected-demo.component.graphql
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/graph-ql-connected-demo/graph-ql-connected-demo.component.graphql
@@ -40,8 +40,8 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
   # $contextItem should be set to the ID of the current context item (the route item)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -54,7 +54,7 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/angular/src/graphql-fragment-types.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/src/graphql-fragment-types.ts
@@ -153,7 +153,7 @@ export default {
             name: '<%- helper.getAppPrefix(appPrefix, appName, false) %>ContentBlock',
           },
           {
-            name: 'C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page',
+            name: 'C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute',
           },
           {
             name: 'JsonRendering',
@@ -192,13 +192,13 @@ export default {
       },
       {
         kind: 'INTERFACE',
-        name: '<%- helper.getAppPrefix(appPrefix, appName, false) %>Page',
+        name: '<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute',
         possibleTypes: [
           {
             name: '<%- helper.getAppPrefix(appPrefix, appName, false) %>ExampleCustomRouteType',
           },
           {
-            name: 'C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page',
+            name: 'C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute',
           },
         ],
       },

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/components/graphql/GraphQL-IntegratedDemo.sitecore.graphql
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/components/graphql/GraphQL-IntegratedDemo.sitecore.graphql
@@ -42,8 +42,8 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
   # (as long as the GraphQLData helper is used)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -56,7 +56,7 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/routes.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/routes.sitecore.ts
@@ -24,8 +24,8 @@ export default function addRoutesToManifest(manifest: Manifest): Promise<void> {
   const appTemplateSection = 'Page Metadata';
 
   manifest.setDefaultRouteType({
-    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Page',
-    displayName: 'Page',
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>App Route',
+    displayName: 'App Route',
     fields: [
       {
         name: 'pageTitle',
@@ -34,7 +34,7 @@ export default function addRoutesToManifest(manifest: Manifest): Promise<void> {
         type: CommonFieldTypes.SingleLineText,
       },
     ],
-    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>Page'],
+    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>App Route'],
   });
 
   return mergeFs('./data/routes') // relative to process invocation (i.e. your package.json)

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.graphql
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.graphql
@@ -40,8 +40,8 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
   # $contextItem should be set to the ID of the current context item (the route item)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -54,7 +54,7 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
@@ -12,18 +12,18 @@ import {
 import NextLink from 'next/link';
 import {
   ConnectedDemoQueryDocument,
-  <%- helper.getAppPrefix(appPrefix, appName, false) %>Page as Page,
+  <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute as AppRoute,
   Item,
   <%- helper.getAppPrefix(appPrefix, appName, false) %>GraphQlConnectedDemo as GrapQLConnectedDemoDatasource,
 } from './GraphQL-ConnectedDemo.dynamic.graphql';
 import { ComponentProps } from 'lib/component-props';
 import config from 'temp/config';
 
-type PageItem = Page & Item;
+type RouteItem = AppRoute & Item;
 
 type GraphQLConnectedDemoData = {
   datasource: GrapQLConnectedDemoDatasource;
-  contextItem: PageItem;
+  contextItem: RouteItem;
 };
 
 type GraphQLConnectedDemoProps = ComponentProps & GraphQLConnectedDemoData;
@@ -80,12 +80,12 @@ const GraphQLConnectedDemo = (props: GraphQLConnectedDemoProps): JSX.Element => 
           children:
           <ul>
             {props.contextItem.children.results.map((child) => {
-              const pageItem = child as PageItem;
+              const routeItem = child as RouteItem;
 
               return (
-                <li key={pageItem.id}>
-                  <NextLink href={pageItem.url.path}>{pageItem.pageTitle?.value}</NextLink>
-                  (editable title too! <Text field={pageItem.pageTitle?.jsonValue} />)
+                <li key={routeItem.id}>
+                  <NextLink href={routeItem.url.path}>{routeItem.pageTitle?.value}</NextLink>
+                  (editable title too! <Text field={routeItem.pageTitle?.jsonValue} />)
                 </li>
               );
             })}

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/temp/GraphQLIntrospectionResult.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/temp/GraphQLIntrospectionResult.json
@@ -2179,7 +2179,7 @@
           },
           {
             "kind": "OBJECT",
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
             "ofType": null
           },
           {
@@ -17760,7 +17760,7 @@
         "interfaces": [
           {
             "kind": "INTERFACE",
-            "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+            "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
             "ofType": null
           },
           {
@@ -18219,8 +18219,8 @@
       },
       {
         "kind": "OBJECT",
-        "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
-        "description": "/sitecore/templates/Project/<%- helper.getAppPrefix(appPrefix, appName, false) %>/<%- helper.getAppPrefix(appPrefix, appName, false) %>-Page template (ID: {787584C0-A057-5876-9836-F8B3708F0CAF}). NOTE: This is a concrete type. Favor using interfaces instead of this type (e.g. <%- helper.getAppPrefix(appPrefix, appName, false) %>Page) for reliable querying.",
+        "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
+        "description": "/sitecore/templates/Project/<%- helper.getAppPrefix(appPrefix, appName, false) %>/<%- helper.getAppPrefix(appPrefix, appName, false) %>-App Route template (ID: {787584C0-A057-5876-9836-F8B3708F0CAF}). NOTE: This is a concrete type. Favor using interfaces instead of this type (e.g. <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute) for reliable querying.",
         "fields": [
           {
             "name": "ancestors",
@@ -18643,7 +18643,7 @@
         "interfaces": [
           {
             "kind": "INTERFACE",
-            "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+            "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
             "ofType": null
           },
           {
@@ -21496,8 +21496,8 @@
       },
       {
         "kind": "INTERFACE",
-        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
-        "description": "/sitecore/templates/Project/<%- helper.getAppPrefix(appPrefix, appName, false) %>/<%- helper.getAppPrefix(appPrefix, appName, false) %>-Page template (ID: {787584C0-A057-5876-9836-F8B3708F0CAF}). Also implements Route.",
+        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
+        "description": "/sitecore/templates/Project/<%- helper.getAppPrefix(appPrefix, appName, false) %>/<%- helper.getAppPrefix(appPrefix, appName, false) %>-App Route template (ID: {787584C0-A057-5876-9836-F8B3708F0CAF}). Also implements Route.",
         "fields": [
           {
             "name": "pageTitle",
@@ -21523,7 +21523,7 @@
           },
           {
             "kind": "OBJECT",
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
             "ofType": null
           }
         ]

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/GraphQL-IntegratedDemo.sitecore.graphql
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/GraphQL-IntegratedDemo.sitecore.graphql
@@ -42,8 +42,8 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
   # (as long as the GraphQLData helper is used)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -56,7 +56,7 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/routes.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/routes.sitecore.js
@@ -28,7 +28,7 @@ export default function addRoutesToManifest(manifest) {
   const appTemplateSection = 'Page Metadata';
 
   manifest.setDefaultRouteType({
-    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Page',
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>App Route',
     fields: [
       {
         name: 'pageTitle',
@@ -37,7 +37,7 @@ export default function addRoutesToManifest(manifest) {
         type: CommonFieldTypes.SingleLineText,
       },
     ],
-    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>Page'],
+    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>App Route'],
   });
 
   return mergeFs('./data/routes') // relative to process invocation (i.e. your package.json)

--- a/packages/create-sitecore-jss/src/templates/react/src/components/GraphQL-ConnectedDemo/query.graphql
+++ b/packages/create-sitecore-jss/src/templates/react/src/components/GraphQL-ConnectedDemo/query.graphql
@@ -40,8 +40,8 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
   # $contextItem should be set to the ID of the current context item (the route item)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page  {
+    # Get the page title from the app route template
+    ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute  {
       pageTitle {
         value
       }
@@ -54,7 +54,7 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>Page  {
+        ...on <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute  {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/react/src/temp/GraphQLFragmentTypes.json
+++ b/packages/create-sitecore-jss/src/templates/react/src/temp/GraphQLFragmentTypes.json
@@ -141,7 +141,7 @@
             "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>ContentBlock"
           },
           {
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page"
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute"
           },
           {
             "name": "JsonRendering"
@@ -180,13 +180,13 @@
       },
       {
         "kind": "INTERFACE",
-        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
         "possibleTypes": [
           {
             "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>ExampleCustomRouteType"
           },
           {
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page"
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute"
           }
         ]
       },

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/GraphQL-IntegratedDemo.sitecore.graphql
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/GraphQL-IntegratedDemo.sitecore.graphql
@@ -42,8 +42,8 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
   # (as long as the GraphQLData helper is used)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -56,7 +56,7 @@ query IntegratedDemoQuery($datasource: String!, $contextItem: String!, $language
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/routes.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/routes.sitecore.js
@@ -22,7 +22,7 @@ export default function addRoutesToManifest(manifest) {
   const appTemplateSection = 'Page Metadata';
 
   manifest.setDefaultRouteType({
-    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Page',
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>App Route',
     fields: [
       {
         name: 'pageTitle',
@@ -31,7 +31,7 @@ export default function addRoutesToManifest(manifest) {
         type: CommonFieldTypes.SingleLineText,
       },
     ],
-    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>Page'],
+    insertOptions: ['<%- helper.getAppPrefix(appPrefix, appName) %>App Route'],
   });
 
   return mergeFs('./data/routes') // relative to process invocation (i.e. your package.json)

--- a/packages/create-sitecore-jss/src/templates/vue/src/components/GraphQL/GraphQL-ConnectedDemo.query.graphql
+++ b/packages/create-sitecore-jss/src/templates/vue/src/components/GraphQL/GraphQL-ConnectedDemo.query.graphql
@@ -40,8 +40,8 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
   # $contextItem should be set to the ID of the current context item (the route item)
   contextItem: item(path: $contextItem, language: $language) {
     id
-    # Get the page title from the page template
-    ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+    # Get the page title from the app route template
+    ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
       pageTitle {
         value
       }
@@ -54,7 +54,7 @@ query ConnectedDemoQuery($datasource: String!, $contextItem: String!, $language:
         # typing fragments can be used anywhere!
         # so in this case, we're grabbing the 'pageTitle'
         # field on all child route items.
-        ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>Page {
+        ...on  <%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute {
           pageTitle {
             jsonValue
             value

--- a/packages/create-sitecore-jss/src/templates/vue/src/temp/GraphQLFragmentTypes.json
+++ b/packages/create-sitecore-jss/src/templates/vue/src/temp/GraphQLFragmentTypes.json
@@ -144,7 +144,7 @@
             "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>ContentBlock"
           },
           {
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page"
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute"
           },
           {
             "name": "JsonRendering"
@@ -246,13 +246,13 @@
       },
       {
         "kind": "INTERFACE",
-        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>Page",
+        "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute",
         "possibleTypes": [
           {
             "name": "<%- helper.getAppPrefix(appPrefix, appName, false) %>ExampleCustomRouteType"
           },
           {
-            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>Page"
+            "name": "C__<%- helper.getAppPrefix(appPrefix, appName, false) %>AppRoute"
           }
         ]
       },


### PR DESCRIPTION
This reverts commit e1d1a02737ad562f285d086ab8dbcd7ea0964ea1.

<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
The new `Page` template name conflicts with SXA `Page`.
Typed GraphQL doesn't support duplicate type names, so we have to rename `Page` back to `AppRoute` to resolve the conflict.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
