### PR TITLE
sitecore-jss extra unit test coverage

### DIFF
--- a/packages/sitecore-jss/.nycrc
+++ b/packages/sitecore-jss/.nycrc
@@ -3,6 +3,7 @@
     ".ts"
   ],
   "exclude": [
+    "**/index.ts",
     "**/*.d.ts",
     "**/*.test.ts",
     "src/test-data",
@@ -11,7 +12,9 @@
     "src/index.ts",
     "src/dataModels.ts",
     "./*.js",
-    "./*.d.ts"
+    "./*.d.ts",
+    "**/layout/models.ts",
+    "*.js"
   ],
   "all": true,
   "reporter": [

--- a/packages/sitecore-jss/src/graphql/graphql.test.ts
+++ b/packages/sitecore-jss/src/graphql/graphql.test.ts
@@ -163,7 +163,7 @@ describe('graphql', () => {
         language: 'en',
       });
       await result.catch((error: RangeError) => {
-        expect(error.message).to.equal('"rootItemId" must be a non-empty string');
+        expect(error.message).to.equal('"rootItemId" and "language" must be non-empty strings');
       });
     });
   });

--- a/packages/sitecore-jss/src/graphql/graphql.test.ts
+++ b/packages/sitecore-jss/src/graphql/graphql.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
 import { getAppRootId, siteNameError, languageError } from './app-root-query';
+import { SearchQueryService } from './search-service';
 import { GraphQLRequestClient } from './../graphql-request-client';
 import appRootQueryResponse from '../test-data/mockAppRootQueryResponse.json';
 import nock from 'nock';
@@ -147,6 +148,22 @@ describe('graphql', () => {
 
         await getAppRootId(client, 'siteName', 'language');
         expect(nock.isDone()).to.be.true;
+      });
+    });
+  });
+
+  describe('search-service', () => {
+    const endpoint = 'http://site';
+    const apiKey = 'api-key';
+    const client = new GraphQLRequestClient(endpoint, { apiKey });
+    const searchService = new SearchQueryService(client);
+
+    it('should throw when rootItemId is missing', async () => {
+      const result = searchService.fetch('mockQuery', {
+        language: 'en',
+      });
+      await result.catch((error: RangeError) => {
+        expect(error.message).to.equal('"rootItemId" must be a non-empty string');
       });
     });
   });

--- a/packages/sitecore-jss/src/layout/utils.test.ts
+++ b/packages/sitecore-jss/src/layout/utils.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import { ComponentRendering } from '../../layout';
+import { getFieldValue, getChildPlaceholder } from './utils';
+
+describe('sitecore-jss layout utils', () => {
+  describe('getFieldValue', () => {
+    const fields = {
+      crop: {
+        value: 'rice',
+      },
+    };
+
+    it('should read field from ComponentRendering type', () => {
+      const componentRendering: ComponentRendering = {
+        componentName: 'uTest',
+        fields: fields,
+      };
+
+      const result = getFieldValue(componentRendering, 'crop');
+      expect(result).to.be.equal('rice');
+    });
+
+    it('should read field from Fields type', () => {
+      expect(getFieldValue(fields, 'crop')).to.be.equal('rice');
+    });
+
+    it('should return default value when field is not found', () => {
+      const defaultYield = '1000 tn';
+      expect(getFieldValue(fields, 'yield', defaultYield)).to.be.equal(defaultYield);
+    });
+  });
+
+  describe('getChildPlaceholder', () => {
+    it('should return child placeholder', () => {
+      const testRendering: ComponentRendering = {
+        componentName: 'test',
+        placeholders: {
+          place: [
+            {
+              componentName: 'placed',
+            },
+          ],
+          holder: [
+            {
+              componentName: 'held',
+            },
+          ],
+        },
+      };
+      const result = getChildPlaceholder(testRendering, 'place');
+      expect(result.length).to.be.equal(1);
+      expect((result[0] as ComponentRendering).componentName).to.be.equal('placed');
+    });
+  });
+});


### PR DESCRIPTION
Small increase for base package unit test coverage

- Ignore files that don't have executable logic
- Add tests where it makes sense
