### PR TITLE
Exclude index file from jss-vue test coverage

### DIFF
--- a/packages/sitecore-jss-vue/jest.config.coverage.js
+++ b/packages/sitecore-jss-vue/jest.config.coverage.js
@@ -5,6 +5,7 @@ const coverageConfig = {
   collectCoverageFrom: ['**/*.ts'],
   coverageDirectory: './coverage',
   coveragePathIgnorePatterns: [
+    '/index.ts',
     '/node_modules/',
     '/dist/',
     '/test/',


### PR DESCRIPTION
Just a small change to get jss-vue coverage more accurate.