### PR TITLE
 #556667: [SXA] fixed urls(using PUBLIC_URL) for generating sitemap.xml

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -1,5 +1,6 @@
 import { AxiosResponse } from 'axios';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPublicUrl } from '@sitecore-jss/sitecore-jss-nextjs';
 import config from 'temp/config';
 import { AxiosDataFetcher, GraphQLSitemapXmlService } from '@sitecore-jss/sitecore-jss-nextjs';
 
@@ -47,13 +48,14 @@ const sitemapApi = async (
   }
 
   const SitemapLinks = sitemaps
-    .map(
-      (item) =>
-        `<sitemap>
-            <loc>${item}</loc>
-          </sitemap>
-        `
-    )
+    .map((item) => {
+      const parseUrl = item.split('/');
+      const lastSegment = parseUrl[parseUrl.length - 1];
+
+      return `<sitemap>
+        <loc>${getPublicUrl()}/${lastSegment}</loc>
+      </sitemap>`;
+    })
     .join('');
 
   res.setHeader('Content-Type', 'text/xml;charset=utf-8');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Fixed functional of generating of sitemap.xml if there isn't from GRAPHQL request. 
The last version used absolute path to sitemap.xml's.
Now we are using public_url path.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
