### PR TITLE
[React] Fix `eslint` compilation error

### DIFF
--- a/packages/create-sitecore-jss/src/templates/react/.eslintrc
+++ b/packages/create-sitecore-jss/src/templates/react/.eslintrc
@@ -4,7 +4,6 @@
     "prettier",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:react/recommended",
     "plugin:yaml/recommended",
     "plugin:prettier/recommended"
   ],
@@ -20,7 +19,6 @@
   },
   "plugins": [
     "import",
-    "react",
     "yaml"
   ],
   "settings": {

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -72,7 +72,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-yaml": "^0.5.0",
     "express": "^4.18.2",
     "fs-extra": "^11.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Issue Description**: The react plugin was conflicted between ".eslintrc" and "BaseConfig(in `react-scripts` module) i.e 2 copies are being fed to the ESLint.
**Fix**: Remove `eslint-plugin-react` and its configuration.

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
