### PR TITLE
[Next.js][Multi-site] Dynamic site resolver

### DIFF
--- a/packages/sitecore-jss/src/site/index.ts
+++ b/packages/sitecore-jss/src/site/index.ts
@@ -24,3 +24,5 @@ export {
   GraphQLErrorPagesService,
   GraphQLErrorPagesServiceConfig,
 } from './graphql-error-pages-service';
+
+export { SiteResolver, HostInfo } from './site-resolver';

--- a/packages/sitecore-jss/src/site/site-resolver.test.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { HostInfo, SiteResolver } from './site-resolver';
 
-describe('SiteResolver', () => {
+describe.only('SiteResolver', () => {
   const hostInfo: HostInfo = {
     hostName: 'foo.com',
   };
@@ -90,14 +90,46 @@ describe('SiteResolver', () => {
       expect(siteName).to.equal('foo');
     });
 
-    it('should return site name when multi-value hostnames are provided', () => {
-      const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
-        { hostName: 'bar.net', language: '', name: 'bar' },
-        { hostName: 'test.com|foo.net|foo.com', language: 'en', name: 'foo' },
-        { hostName: 'var.com', language: '', name: 'var' },
-      ]);
+    describe('should return site name when multi-value hostnames are provided', () => {
+      it('hostname contains whitespaces', () => {
+        const siteName = SiteResolver.resolve(hostInfo, [
+          { hostName: 'bar.net', language: '', name: 'bar' },
+          { hostName: 'test.com | foo.net | foo.com', language: '', name: 'foo' },
+          { hostName: 'var.com', language: '', name: 'var' },
+        ]);
 
-      expect(siteName).to.equal('foo');
+        expect(siteName).to.equal('foo');
+      });
+
+      it('comma delimiter is used', () => {
+        const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+          { hostName: 'bar.net', language: '', name: 'bar' },
+          { hostName: 'test.com,foo.net,foo.com', language: 'en', name: 'foo' },
+          { hostName: 'var.com', language: '', name: 'var' },
+        ]);
+
+        expect(siteName).to.equal('foo');
+      });
+
+      it('semicolon delimiter is used', () => {
+        const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+          { hostName: 'bar.net', language: '', name: 'bar' },
+          { hostName: 'test.com;foo.net;foo.com', language: 'en', name: 'foo' },
+          { hostName: 'var.com', language: '', name: 'var' },
+        ]);
+
+        expect(siteName).to.equal('foo');
+      });
+
+      it('pipe delimiter is used', () => {
+        const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+          { hostName: 'bar.net', language: '', name: 'bar' },
+          { hostName: 'test.com|foo.net|foo.com', language: 'en', name: 'foo' },
+          { hostName: 'var.com', language: '', name: 'var' },
+        ]);
+
+        expect(siteName).to.equal('foo');
+      });
     });
   });
 });

--- a/packages/sitecore-jss/src/site/site-resolver.test.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.test.ts
@@ -58,6 +58,17 @@ describe.only('SiteResolver', () => {
       expect(siteName).to.equal('foo');
     });
 
+    it('should return site name when hostname includes wildcard', () => {
+      const siteName = SiteResolver.resolve(hostInfo, [
+        { hostName: 'var.com', language: 'da-DK', name: 'var' },
+        { hostName: 'bar.net', language: 'en', name: 'bar' },
+        { hostName: '*.com', language: '', name: 'foo' },
+        { hostName: 'foo.com', language: 'en', name: 'foo-en' },
+      ]);
+
+      expect(siteName).to.equal('foo');
+    });
+
     it('should return site name when wildcard is provided', () => {
       const siteName = SiteResolver.resolve(hostInfo, [
         { hostName: 'bar.net', language: '', name: 'bar' },
@@ -91,10 +102,26 @@ describe.only('SiteResolver', () => {
     });
 
     describe('should return site name when multi-value hostnames are provided', () => {
+      it('hostnames include wildcard characters', () => {
+        expect(
+          SiteResolver.resolve({ hostName: 'test.foo.bar.com' }, [
+            { hostName: '*.bat.com|foo.bar.com', language: '', name: 'bar' },
+            { hostName: 'test.com|*.foo.*.com|foo.com', language: '', name: 'foo' },
+          ])
+        ).to.equal('foo');
+
+        expect(
+          SiteResolver.resolve({ hostName: 'xfoo.bar.com.en' }, [
+            { hostName: 'foo.bar.com', language: '', name: 'bar' },
+            { hostName: 'test.com|*foo.*.com*|foo.com', language: '', name: 'foo' },
+          ])
+        ).to.equal('foo');
+      });
+
       it('hostname contains whitespaces', () => {
         const siteName = SiteResolver.resolve(hostInfo, [
           { hostName: 'bar.net', language: '', name: 'bar' },
-          { hostName: 'test.com | foo.net | foo.com', language: '', name: 'foo' },
+          { hostName: 'test.com; foo.net | foo.com', language: '', name: 'foo' },
           { hostName: 'var.com', language: '', name: 'var' },
         ]);
 

--- a/packages/sitecore-jss/src/site/site-resolver.test.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { HostInfo, SiteResolver } from './site-resolver';
+
+describe('SiteResolver', () => {
+  const hostInfo: HostInfo = {
+    hostName: 'foo.com',
+  };
+
+  const hostInfoWithLanguage: HostInfo = {
+    ...hostInfo,
+    language: 'en',
+  };
+
+  describe('resolve', () => {
+    describe('fallback site name', () => {
+      it('should return default when sites info is empty', () => {
+        const siteName = SiteResolver.resolve(hostInfo, []);
+
+        expect(siteName).to.equal('website');
+      });
+
+      it('should return default when there is no appropriate site info', () => {
+        const siteName = SiteResolver.resolve(hostInfo, [
+          { hostName: 'bar.com', language: '', name: 'bar' },
+          { hostName: 'var.com', language: '', name: 'var' },
+        ]);
+
+        expect(siteName).to.equal('website');
+      });
+
+      it('should return custom when sites info is empty', () => {
+        const siteName = SiteResolver.resolve(hostInfo, [], 'sample');
+
+        expect(siteName).to.equal('sample');
+      });
+
+      it('should return custom when there is no appropriate site info', () => {
+        const siteName = SiteResolver.resolve(
+          hostInfo,
+          [
+            { hostName: 'bar.com', language: '', name: 'bar' },
+            { hostName: 'var.com', language: '', name: 'var' },
+          ],
+          'sample'
+        );
+
+        expect(siteName).to.equal('sample');
+      });
+    });
+
+    it('should return site name when only hostname is provided', () => {
+      const siteName = SiteResolver.resolve(hostInfo, [
+        { hostName: 'bar.net', language: '', name: 'bar' },
+        { hostName: 'foo.com', language: '', name: 'foo' },
+        { hostName: 'var.com', language: '', name: 'var' },
+      ]);
+
+      expect(siteName).to.equal('foo');
+    });
+
+    it('should return site name when wildcard is provided', () => {
+      const siteName = SiteResolver.resolve(hostInfo, [
+        { hostName: 'bar.net', language: '', name: 'bar' },
+        { hostName: '*', language: '', name: 'wildcard' },
+        { hostName: 'foo.com', language: '', name: 'foo' },
+      ]);
+
+      expect(siteName).to.equal('wildcard');
+    });
+
+    it('should return site name when language is provided', () => {
+      const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+        { hostName: 'foo.com', language: 'ca', name: 'foo-ca' },
+        { hostName: 'var.com', language: 'da-DK', name: 'var' },
+        { hostName: 'bar.net', language: 'en', name: 'bar' },
+        { hostName: 'foo.com', language: 'en', name: 'foo-en' },
+      ]);
+
+      expect(siteName).to.equal('foo-en');
+    });
+
+    it('should return site name when language is omit', () => {
+      const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+        { hostName: 'var.com', language: 'da-DK', name: 'var' },
+        { hostName: 'bar.net', language: 'en', name: 'bar' },
+        { hostName: 'foo.com', language: '', name: 'foo' },
+        { hostName: 'foo.com', language: 'en', name: 'foo-en' },
+      ]);
+
+      expect(siteName).to.equal('foo');
+    });
+
+    it('should return site name when multi-value hostnames are provided', () => {
+      const siteName = SiteResolver.resolve(hostInfoWithLanguage, [
+        { hostName: 'bar.net', language: '', name: 'bar' },
+        { hostName: 'test.com|foo.net|foo.com', language: 'en', name: 'foo' },
+        { hostName: 'var.com', language: '', name: 'var' },
+      ]);
+
+      expect(siteName).to.equal('foo');
+    });
+  });
+});

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -17,9 +17,6 @@ export type HostInfo = {
 // Delimiters for multi-value hostnames
 const DELIMITERS = /\||,|\;/g;
 
-// Wildcard hostname
-const WILDCARD = '*';
-
 /**
  * Determines site name based on the provided host information
  */
@@ -29,7 +26,7 @@ export class SiteResolver {
    * @param {HostInfo} hostInfo information about current host
    * @param {SiteInfo[]} sitesInfo list of available sites
    * @param {string} [fallbackSiteName] siteName to be returned in case siteName is not found
-   * @returns {string} siteName
+   * @returns {string} siteName resolved site name
    */
   static resolve = (
     hostInfo: HostInfo,
@@ -43,15 +40,22 @@ export class SiteResolver {
         info.language === '' || !hostInfo.language || hostInfo.language === info.language;
 
       return hostnames.some(
-        (value) => languageMatches && (hostInfo.hostName === value || value === WILDCARD)
+        (hostname) =>
+          languageMatches &&
+          (hostInfo.hostName === hostname ||
+            SiteResolver.matchesPattern(hostInfo.hostName, hostname))
       );
     });
 
     return siteInfo?.name || fallbackSiteName;
   };
 
-  private matchesPattern(hostname: string, pattern: string): boolean {
-    const regExp = new RegExp(pattern.replace(/\./g, '.').replace(/\*/g, '.*'), 'g');
+  private static matchesPattern(hostname: string, pattern: string): boolean {
+    // dots should be treated as chars
+    // stars should be treated as wildcards
+    const regExpPattern = pattern.replace(/\./g, '\\.').replace(/\*/g, '.*');
+
+    const regExp = new RegExp(`^${regExpPattern}$`, 'g');
 
     return !!hostname.match(regExp);
   }

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -1,10 +1,4 @@
-// import { SiteInfo } from './graphql-siteinfo-service';
-
-type SiteInfo = {
-  hostName: string;
-  language?: string;
-  name: string;
-};
+import { SiteInfo } from './graphql-siteinfo-service';
 
 /**
  * Information about the current host

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -9,7 +9,7 @@ export type HostInfo = {
 };
 
 // Delimiters for multi-value hostnames
-const DELIMITERS = /\||,|\;/g;
+const DELIMITERS = /\||,|;/g;
 
 /**
  * Determines site name based on the provided host information

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -1,4 +1,10 @@
-import { SiteInfo } from './graphql-siteinfo-service';
+// import { SiteInfo } from './graphql-siteinfo-service';
+
+type SiteInfo = {
+  hostName: string;
+  language?: string;
+  name: string;
+};
 
 /**
  * Information about the current host
@@ -9,19 +15,19 @@ export type HostInfo = {
 };
 
 // Delimiters for multi-value hostnames
-const DELIMITERS = /\|/g;
+const DELIMITERS = /\||,|\;/g;
 
 // Wildcard hostname
 const WILDCARD = '*';
 
 /**
- * Determines site name based on the provided hostname
+ * Determines site name based on the provided host information
  */
 export class SiteResolver {
   /**
-   * Resolve siteName by hostName
-   * @param {HostInfo} hostInfo
-   * @param {SiteInfo[]} sitesInfo
+   * Resolve siteName by host information
+   * @param {HostInfo} hostInfo information about current host
+   * @param {SiteInfo[]} sitesInfo list of available sites
    * @param {string} [fallbackSiteName] siteName to be returned in case siteName is not found
    * @returns {string} siteName
    */
@@ -31,7 +37,7 @@ export class SiteResolver {
     fallbackSiteName = 'website'
   ): string => {
     const siteInfo = sitesInfo.find((info) => {
-      const hostnames = info.hostName.split(DELIMITERS);
+      const hostnames = info.hostName.replace(/\s/g, '').split(DELIMITERS);
 
       const languageMatches =
         info.language === '' || !hostInfo.language || hostInfo.language === info.language;
@@ -43,4 +49,10 @@ export class SiteResolver {
 
     return siteInfo?.name || fallbackSiteName;
   };
+
+  private matchesPattern(hostname: string, pattern: string): boolean {
+    const regExp = new RegExp(pattern.replace(/\./g, '.').replace(/\*/g, '.*'), 'g');
+
+    return !!hostname.match(regExp);
+  }
 }

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -1,0 +1,46 @@
+import { SiteInfo } from './graphql-siteinfo-service';
+
+/**
+ * Information about the current host
+ */
+export type HostInfo = {
+  hostName: string;
+  language?: string;
+};
+
+// Delimiters for multi-value hostnames
+const DELIMITERS = /\|/g;
+
+// Wildcard hostname
+const WILDCARD = '*';
+
+/**
+ * Determines site name based on the provided hostname
+ */
+export class SiteResolver {
+  /**
+   * Resolve siteName by hostName
+   * @param {HostInfo} hostInfo
+   * @param {SiteInfo[]} sitesInfo
+   * @param {string} [fallbackSiteName] siteName to be returned in case siteName is not found
+   * @returns {string} siteName
+   */
+  static resolve = (
+    hostInfo: HostInfo,
+    sitesInfo: SiteInfo[],
+    fallbackSiteName = 'website'
+  ): string => {
+    const siteInfo = sitesInfo.find((info) => {
+      const hostnames = info.hostName.split(DELIMITERS);
+
+      const languageMatches =
+        info.language === '' || !hostInfo.language || hostInfo.language === info.language;
+
+      return hostnames.some(
+        (value) => languageMatches && (hostInfo.hostName === value || value === WILDCARD)
+      );
+    });
+
+    return siteInfo?.name || fallbackSiteName;
+  };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Provides site resolver, that resolves site name based on provided hostname, language of the current host and sites info
* Supports:
  * wildcard '*', '*.foo.com' hostnames
  * multi-value hostnames, e.g. _test.com|foo.com_, _test.com; foo.com_
  * language
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
Unit tests are added
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
