### PR TITLE
[Next.js][Multi-site] Multi-site path utils

### DIFF
--- a/packages/sitecore-jss/src/site/index.ts
+++ b/packages/sitecore-jss/src/site/index.ts
@@ -24,3 +24,5 @@ export {
   GraphQLErrorPagesService,
   GraphQLErrorPagesServiceConfig,
 } from './graphql-error-pages-service';
+
+export { getSiteRewrite, getSiteRewriteData, normalizeSiteRewrite, SiteRewriteData } from './utils';

--- a/packages/sitecore-jss/src/site/utils.test.ts
+++ b/packages/sitecore-jss/src/site/utils.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { getSiteRewrite, getSiteRewriteData, normalizeSiteRewrite, SITE_PREFIX } from './utils';
+
+describe('utils', () => {
+  describe('getSiteRewrite', () => {
+    const data = {
+      siteName: 'jss',
+    };
+
+    it('should return a string', () => {
+      expect(getSiteRewrite('/pathname', data)).to.be.a('string');
+    });
+
+    it('should return the path with the site name when pathname starts with "/"', () => {
+      const pathname = '/some/path';
+      const result = getSiteRewrite(pathname, data);
+      expect(result).to.equal(`/${SITE_PREFIX}${data.siteName}/some/path`);
+    });
+
+    it('should return the path with the site name when pathname not starts with "/"', () => {
+      const pathname = 'some/path';
+      const result = getSiteRewrite(pathname, data);
+      expect(result).to.equal(`/${SITE_PREFIX}${data.siteName}/some/path`);
+    });
+
+    it('should return the root path with the site name', () => {
+      const pathname = '/';
+      const result = getSiteRewrite(pathname, data);
+      expect(result).to.equal(`/${SITE_PREFIX}${data.siteName}/`);
+    });
+  });
+
+  describe('getSiteRewriteData', () => {
+    const defaultSiteName = 'foo';
+
+    it('should return a MultiSiteRewriteData object', () => {
+      expect(getSiteRewriteData('/some/path', defaultSiteName)).to.be.an('object');
+    });
+
+    it('should return the multisite data from the rewrite path', () => {
+      const pathname = `/some/path/${SITE_PREFIX}bar/`;
+      const result = getSiteRewriteData(pathname, defaultSiteName);
+      expect(result.siteName).to.equal('bar');
+    });
+
+    it('should return the default site name when pathname does not contain site name', () => {
+      const pathname = '/some/path';
+      const result = getSiteRewriteData(pathname, defaultSiteName);
+      expect(result.siteName).to.equal(defaultSiteName);
+    });
+
+    it('should return empty site name when pathname is missing site name', () => {
+      const pathname = `/some/path/${SITE_PREFIX}/`;
+      const result = getSiteRewriteData(pathname, defaultSiteName);
+      expect(result.siteName).to.equal(defaultSiteName);
+    });
+  });
+
+  describe('normalizeSiteRewrite', () => {
+    it('should return a string', () => {
+      expect(normalizeSiteRewrite('/some/path')).to.be.a('string');
+    });
+
+    it('should return the pathname when it does not contain site prefix', () => {
+      const pathname = '/some/path';
+      const result = normalizeSiteRewrite(pathname);
+      expect(result).to.equal(pathname);
+    });
+
+    it('should return the pathname without the site name', () => {
+      const pathname = `/${SITE_PREFIX}foo/some/path`;
+      const result = normalizeSiteRewrite(pathname);
+      expect(result).to.equal('/some/path');
+    });
+
+    it('should return the root pathname without the site name', () => {
+      const pathname = `/${SITE_PREFIX}foo/`;
+      const result = normalizeSiteRewrite(pathname);
+      expect(result).to.equal('/');
+    });
+
+    it('should return the root pathname without the site name when pathname not ends with "/"', () => {
+      const pathname = `/${SITE_PREFIX}foo`;
+      const result = normalizeSiteRewrite(pathname);
+      expect(result).to.equal('/');
+    });
+  });
+});

--- a/packages/sitecore-jss/src/site/utils.ts
+++ b/packages/sitecore-jss/src/site/utils.ts
@@ -22,7 +22,7 @@ export function getSiteRewrite(pathname: string, data: SiteRewriteData): string 
  * @param {string} defaultSiteName the default site name
  * @returns {SiteRewriteData} the site data from the rewrite
  */
-export function getSiteRewriteData(pathname: string, defaultSiteName: string) {
+export function getSiteRewriteData(pathname: string, defaultSiteName: string): SiteRewriteData {
   const data: SiteRewriteData = {
     siteName: defaultSiteName,
   };

--- a/packages/sitecore-jss/src/site/utils.ts
+++ b/packages/sitecore-jss/src/site/utils.ts
@@ -1,0 +1,49 @@
+export const SITE_PREFIX = '_site_';
+
+export type SiteRewriteData = {
+  siteName: string;
+};
+
+/**
+ * Get a site rewrite path for given pathname
+ * @param {string} pathname the pathname
+ * @param {SiteRewriteData} data the site data to include in the rewrite
+ * @returns {string} the rewrite path
+ */
+export function getSiteRewrite(pathname: string, data: SiteRewriteData): string {
+  const path = pathname.startsWith('/') ? pathname : '/' + pathname;
+
+  return `/${SITE_PREFIX}${data.siteName}${path}`;
+}
+
+/**
+ * Get site data from the rewrite path
+ * @param {string} pathname the pathname
+ * @param {string} defaultSiteName the default site name
+ * @returns {SiteRewriteData} the site data from the rewrite
+ */
+export function getSiteRewriteData(pathname: string, defaultSiteName: string) {
+  const data: SiteRewriteData = {
+    siteName: defaultSiteName,
+  };
+
+  const path = pathname.endsWith('/') ? pathname : pathname + '/';
+  const result = path.match(`${SITE_PREFIX}(.*?)\\/`);
+
+  if (result && result[1] !== '') {
+    data.siteName = result[1];
+  }
+
+  return data;
+}
+
+/**
+ * Normalize a site rewrite path (remove site data)
+ * @param {string} pathname the pathname
+ * @returns {string} the pathname with site data removed
+ */
+export function normalizeSiteRewrite(pathname: string): string {
+  const result = pathname.match(`${SITE_PREFIX}.*?(?:\\/|$)`);
+
+  return result === null ? pathname : pathname.replace(result[0], '');
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
Includes required utils for site rewrite path resolution:
 * getSiteRewrite
 * getSiteRewriteData
 * normalizeSiteRewrite

Format is `_site_<sitename>/<path>`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
Unit tests are added
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
