### PR TITLE
Ensure site and variant prefixes are position agnostic

### DIFF
--- a/packages/sitecore-jss/src/personalize/utils.test.ts
+++ b/packages/sitecore-jss/src/personalize/utils.test.ts
@@ -87,8 +87,10 @@ describe('utils', () => {
     });
     it('should normalize path with other prefixes present', () => {
       const pathname = `/_site_mysite/${VARIANT_PREFIX}foo`;
+      const pathNameInversed = `/${VARIANT_PREFIX}foo/_site_mysite/`;
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal('/_site_mysite/');
+      expect(normalizePersonalizedRewrite(pathNameInversed)).to.equal(result);
     });
   });
 

--- a/packages/sitecore-jss/src/personalize/utils.test.ts
+++ b/packages/sitecore-jss/src/personalize/utils.test.ts
@@ -52,6 +52,13 @@ describe('utils', () => {
       const result = getPersonalizedRewriteData(pathname);
       expect(result.variantId).to.equal('');
     });
+    it('should return varinat id from any position in pathname', () => {
+      const testId = '0451';
+      const path1 = `/${VARIANT_PREFIX}${testId}/some/path/`;
+      const path2 = `/_site_mysite/${VARIANT_PREFIX}${testId}/some/path/`;
+
+      expect(getPersonalizedRewriteData(path1)).to.deep.equal(getPersonalizedRewriteData(path2));
+    });
   });
 
   describe('normalizePersonalizedRewrite', () => {
@@ -77,6 +84,11 @@ describe('utils', () => {
       const pathname = `/${VARIANT_PREFIX}foo`;
       const result = normalizePersonalizedRewrite(pathname);
       expect(result).to.equal('/');
+    });
+    it('should normalize path with other prefixes present', () => {
+      const pathname = `/_site_mysite/${VARIANT_PREFIX}foo`;
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal('/_site_mysite/');
     });
   });
 

--- a/packages/sitecore-jss/src/site/utils.test.ts
+++ b/packages/sitecore-jss/src/site/utils.test.ts
@@ -54,6 +54,14 @@ describe('utils', () => {
       const result = getSiteRewriteData(pathname, defaultSiteName);
       expect(result.siteName).to.equal(defaultSiteName);
     });
+
+    it('should return site name from anywhere in the path', () => {
+      const siteName = 'fiftyone';
+      const path1 = `/${SITE_PREFIX}${siteName}/some/path/`;
+      const path2 = `/_variantId_0451/${SITE_PREFIX}${siteName}/some/path/`;
+
+      expect(getSiteRewriteData(path1, defaultSiteName)).to.deep.equal(getSiteRewriteData(path2, defaultSiteName));
+    });
   });
 
   describe('normalizeSiteRewrite', () => {
@@ -83,6 +91,15 @@ describe('utils', () => {
       const pathname = `/${SITE_PREFIX}foo`;
       const result = normalizeSiteRewrite(pathname);
       expect(result).to.equal('/');
+    });
+
+    it('should normalize path with other prefixes present', () => {
+      const pathnameWithPrefix = `/_variantId_0451/${SITE_PREFIX}foo`;
+      const pathnameWithPostfix = `/${SITE_PREFIX}foo/_variantId_0451/`;
+      const resultPrefix = normalizeSiteRewrite(pathnameWithPrefix);
+      const resultPostfix = normalizeSiteRewrite(pathnameWithPostfix);
+      expect(resultPrefix).to.equal('/_variantId_0451/');
+      expect(resultPrefix).to.equal(resultPostfix);
     });
   });
 });


### PR DESCRIPTION
With multisite feature adding another prefix, we need to ensure the program will understand and correctly handle path prefixes regardless of the order they go in, or their position. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
