### PR TITLE
Ensure multisite response is persisted in rewrite middleware

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/middleware/plugins/redirects.ts
@@ -32,8 +32,8 @@ class RedirectsPlugin implements MiddlewarePlugin {
    * @param req<NextRequest>
    * @returns Promise<NextResponse>
    */
-  async exec(req: NextRequest): Promise<NextResponse> {
-    return this.redirectsMiddleware.getHandler()(req);
+  async exec(req: NextRequest, res?:NextResponse): Promise<NextResponse> {
+    return this.redirectsMiddleware.getHandler()(req, res);
   }
 }
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -292,7 +292,7 @@ describe('RedirectsMiddleware', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes).to.deep.equal(res);
-      });
+      });      
 
       it('should rewrite path when redirect type is server transfer', async () => {
         const res = NextResponse.rewrite('http://localhost:3000/found');
@@ -350,6 +350,67 @@ describe('RedirectsMiddleware', () => {
         expect(fetchRedirects).to.be.calledWith(siteName);
         expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);
+      });
+
+      it('should preserve site name from response data when provided, if no redirect type defined', async () => {
+        const res = NextResponse.next();
+        const site = 'learn2grow';
+        res.cookies.set('sc_site', site);
+        const req = createRequest({
+          nextUrl: {
+            pathname: '/not-found',
+            locale: 'en',
+            clone() {
+              return Object.assign({}, req.nextUrl);
+            },
+          },
+        });
+
+        const { middleware, fetchRedirects, getSite } = createMiddleware({
+          pattern: 'not-found',
+          target: 'http://localhost:3000/found',
+          redirectType: 'default',
+          isQueryStringPreserved: true,
+          locale: 'en',
+        });
+
+        const finalRes = await middleware.getHandler()(req, res);
+
+        expect(getSite).to.not.be.called;
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.cookies.get('sc_site')).to.equal(site);
+      });
+
+      it('should preserve site name from response data when provided, if handler is disabled', async () => {
+        const res = NextResponse.next();
+        const site = 'learn2grow';
+        res.cookies.set('sc_site', site);
+        const req = createRequest({
+          nextUrl: {
+            pathname: '/not-found',
+            locale: 'en',
+            clone() {
+              return Object.assign({}, req.nextUrl);
+            },
+          },
+        });
+
+        const { middleware, fetchRedirects, getSite } = createMiddleware({
+          pattern: 'not-found',
+          target: 'http://localhost:3000/found',
+          redirectType: 'default',
+          isQueryStringPreserved: true,
+          locale: 'en',
+          disabled: () => true,
+        });
+
+        const finalRes = await middleware.getHandler()(req, res);
+
+        expect(getSite).to.not.be.called;
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.false;
+        expect(finalRes.cookies.get('sc_site')).to.equal(site);
       });
 
       it('default fallback hostname is used', async () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -292,7 +292,7 @@ describe('RedirectsMiddleware', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes).to.deep.equal(res);
-      });      
+      });
 
       it('should rewrite path when redirect type is server transfer', async () => {
         const res = NextResponse.rewrite('http://localhost:3000/found');
@@ -375,7 +375,7 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req, res);
-
+        // eslint-disable-next-line no-unused-expressions
         expect(getSite).to.not.be.called;
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
@@ -406,7 +406,7 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req, res);
-
+        // eslint-disable-next-line no-unused-expressions
         expect(getSite).to.not.be.called;
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.false;

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -135,7 +135,7 @@ export class RedirectsMiddleware {
       }
     };
 
-    const response = await createResponse(res);
+    const response = await createResponse();
 
     // Share site name with the following executed middlewares
     response.cookies.set('sc_site', siteName);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -89,7 +89,7 @@ export class RedirectsMiddleware {
     const hostname = this.getHostname(req);
     const siteName = res?.cookies.get('sc_site') || this.config.getSite(hostname).name;
 
-    const createResponse = async (res?: NextResponse) => {
+    const createResponse = async () => {
       if (
         (this.config.disabled && this.config.disabled(req, NextResponse.next())) ||
         this.excludeRoute(req.nextUrl.pathname) ||

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -89,19 +89,19 @@ export class RedirectsMiddleware {
     const hostname = this.getHostname(req);
     const siteName = res?.cookies.get('sc_site') || this.config.getSite(hostname).name;
 
-    const createResponse = async () => {
+    const createResponse = async (res?: NextResponse) => {
       if (
         (this.config.disabled && this.config.disabled(req, NextResponse.next())) ||
         this.excludeRoute(req.nextUrl.pathname) ||
         (this.config.excludeRoute && this.config.excludeRoute(req.nextUrl.pathname))
       ) {
-        return NextResponse.next();
+        return res || NextResponse.next();
       }
       // Find the redirect from result of RedirectService
       const existsRedirect = await this.getExistsRedirect(req, siteName);
 
       if (!existsRedirect) {
-        return NextResponse.next();
+        return res || NextResponse.next();
       }
 
       const url = req.nextUrl.clone();
@@ -135,7 +135,7 @@ export class RedirectsMiddleware {
       }
     };
 
-    const response = await createResponse();
+    const response = await createResponse(res);
 
     // Share site name with the following executed middlewares
     response.cookies.set('sc_site', siteName);


### PR DESCRIPTION
This fixes the bug of multisite context being lost when rewrite plugin is present.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
