### PR TITLE
Ensure app config variables have values at build-time

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -14,13 +14,12 @@ class MultisitePlugin implements ConfigPlugin {
   async exec(config: JssConfig) {
     let sites: SiteInfo[] = [];
 
-    // graphQL endpoint can have a dynamic value in the config - so we resolve it in a special way at build time
     const endpoint = config.graphQLEndpoint;
     const apiKey = config.sitecoreApiKey;
 
     if (!endpoint || !apiKey) {
       console.warn(
-        chalk.yellow('Skipping site information fetch (missing GraphQL connection details). Endpoint or API key missing.')
+        chalk.yellow('Skipping site information fetch (missing GraphQL endpoint or API key).')
       );
     } else {
       console.log(`Fetching site information from ${endpoint}`);

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -24,12 +24,12 @@ class MultisitePlugin implements ConfigPlugin {
     };
 
     // graphQL endpoint can have a dynamic value in the config - so we resolve it in a special way at build time
-    const buildTimeGraphQlEndpoint = process.env.GRAPH_QL_ENDPOINT || computeConfigValue(config.computed?.graphQLEndpoint || '');
+    const endpoint = process.env.GRAPH_QL_ENDPOINT || computeConfigValue(config.computed?.graphQLEndpoint || '');
     const apiKey = process.env.SITECORE_API_KEY || config.sitecoreApiKey;
 
     if (!endpoint || !apiKey) {
       console.warn(
-        chalk.yellow('Skipping site information fetch (missing GraphQL connection details)')
+        chalk.yellow('Skipping site information fetch (missing GraphQL connection details). Endpoint or API key missing.')
       );
     } else {
       console.log(`Fetching site information from ${endpoint}`);

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -14,18 +14,9 @@ class MultisitePlugin implements ConfigPlugin {
   async exec(config: JssConfig) {
     let sites: SiteInfo[] = [];
 
-    const computeConfigValue = (val: string) => {
-      if(val.startsWith('`') && val.endsWith('`')) {
-        return new Function('return ' + val.replaceAll('config', 'this')).call(config);
-      }
-      else {
-        return val;
-      }
-    };
-
     // graphQL endpoint can have a dynamic value in the config - so we resolve it in a special way at build time
-    const endpoint = process.env.GRAPH_QL_ENDPOINT || computeConfigValue(config.computed?.graphQLEndpoint || '');
-    const apiKey = process.env.SITECORE_API_KEY || config.sitecoreApiKey;
+    const endpoint = config.graphQLEndpoint;
+    const apiKey = config.sitecoreApiKey;
 
     if (!endpoint || !apiKey) {
       console.warn(

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -13,7 +13,18 @@ class MultisitePlugin implements ConfigPlugin {
 
   async exec(config: JssConfig) {
     let sites: SiteInfo[] = [];
-    const endpoint = process.env.GRAPH_QL_ENDPOINT || config.graphQLEndpoint;
+
+    const computeConfigValue = (val: string) => {
+      if(val.startsWith('`') && val.endsWith('`')) {
+        return new Function('return ' + val.replaceAll('config', 'this')).call(config);
+      }
+      else {
+        return val;
+      }
+    };
+
+    // graphQL endpoint can have a dynamic value in the config - so we resolve it in a special way at build time
+    const buildTimeGraphQlEndpoint = process.env.GRAPH_QL_ENDPOINT || computeConfigValue(config.computed?.graphQLEndpoint || '');
     const apiKey = process.env.SITECORE_API_KEY || config.sitecoreApiKey;
 
     if (!endpoint || !apiKey) {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/index.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/index.ts
@@ -4,15 +4,13 @@ const plugins = require('scripts/temp/config-plugins');
 /**
  * JSS configuration object
  */
-export interface JssConfig extends Record<string, string | Record<string, string> | undefined> {
+export interface JssConfig extends Record<string, string | undefined> {
   sitecoreApiKey?: string;
   sitecoreApiHost?: string;
   jssAppName?: string;
   graphQLEndpointPath?: string;
   defaultLanguage?: string;
-  computed?: {
-    [key: string]: string;
-  }
+  graphQLEndpoint?: string;
 }
 
 export interface ConfigPlugin {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/index.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/index.ts
@@ -4,13 +4,15 @@ const plugins = require('scripts/temp/config-plugins');
 /**
  * JSS configuration object
  */
-export interface JssConfig extends Record<string, string | undefined> {
+export interface JssConfig extends Record<string, string | Record<string, string> | undefined> {
   sitecoreApiKey?: string;
   sitecoreApiHost?: string;
   jssAppName?: string;
   graphQLEndpointPath?: string;
   defaultLanguage?: string;
-  graphQLEndpoint?: string;
+  computed?: {
+    [key: string]: string;
+  }
 }
 
 export interface ConfigPlugin {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -10,7 +10,7 @@ class ComputedPlugin implements ConfigPlugin {
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {
-      graphQLEndpoint: `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
+      computed: { graphQLEndpoint: '`${config.sitecoreApiHost}${config.graphQLEndpointPath}`' },
     });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -10,7 +10,7 @@ class ComputedPlugin implements ConfigPlugin {
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {
-      computed: { graphQLEndpoint: '`${config.sitecoreApiHost}${config.graphQLEndpointPath}`' },
+      graphQLEndpoint: config.graphQLEndpoint || `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
     });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
@@ -1,0 +1,19 @@
+import { ConfigPlugin, JssConfig } from '..';
+
+/**
+ * This config will set fallback values for properties that were left empty
+ * If neither env, nor other places had a proper value, this will ensure a fallback is set
+ */
+class ComputedPlugin implements ConfigPlugin {
+  // should always comes last
+  order = 99;
+
+  async exec(config: JssConfig) {
+    return Object.assign({}, config, {
+      defaultLanguage: config.defaultLanguage || 'en',
+      sitecoreApiKey: config.sitecoreApiKey || 'no-api-key-set'
+    });
+  }
+}
+
+export const computedPlugin = new ComputedPlugin();

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
@@ -4,7 +4,7 @@ import { ConfigPlugin, JssConfig } from '..';
  * This config will set fallback values for properties that were left empty
  * If neither env, nor other places had a proper value, this will ensure a fallback is set
  */
-class ComputedPlugin implements ConfigPlugin {
+class FallbackPlugin implements ConfigPlugin {
   // should always comes last
   order = 99;
 
@@ -16,4 +16,4 @@ class ComputedPlugin implements ConfigPlugin {
   }
 }
 
-export const computedPlugin = new ComputedPlugin();
+export const fallbackPlugin = new FallbackPlugin();

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/package-json.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/package-json.ts
@@ -11,9 +11,9 @@ class PackageJsonPlugin implements ConfigPlugin {
     if (!packageConfig.config) return config;
 
     return Object.assign({}, config, {
-      jssAppName: packageConfig.config.appName,
-      graphQLEndpointPath: packageConfig.config.graphQLEndpointPath,
-      defaultLanguage: packageConfig.config.language,
+      jssAppName: config.jssAppName || packageConfig.config.appName,
+      graphQLEndpointPath: config.graphQLEndpointPath || packageConfig.config.graphQLEndpointPath,
+      defaultLanguage: config.defaultLanguage || packageConfig.config.language,
     });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/scjssconfig.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/scjssconfig.ts
@@ -13,18 +13,14 @@ class ScJssConfigPlugin implements ConfigPlugin {
     try {
       scJssConfig = require('scjssconfig.json');
     } catch (e) {
-      // fall back on env values
-      return Object.assign({}, config, {
-        sitecoreApiKey: process.env.SITECORE_API_KEY,
-        sitecoreApiHost: process.env.SITECORE_API_HOST,
-      });
+      return config;
     }
 
     if (!scJssConfig) return config;
 
     return Object.assign({}, config, {
-      sitecoreApiKey: scJssConfig.sitecore?.apiKey,
-      sitecoreApiHost: scJssConfig.sitecore?.layoutServiceHost,
+      sitecoreApiKey: config.sitecoreApiKey || scJssConfig.sitecore?.apiKey,
+      sitecoreApiHost: config.sitecoreApiHost || scJssConfig.sitecore?.layoutServiceHost,
     });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/scjssconfig.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/scjssconfig.ts
@@ -13,7 +13,11 @@ class ScJssConfigPlugin implements ConfigPlugin {
     try {
       scJssConfig = require('scjssconfig.json');
     } catch (e) {
-      return config;
+      // fall back on env values
+      return Object.assign({}, config, {
+        sitecoreApiKey: process.env.SITECORE_API_KEY,
+        sitecoreApiHost: process.env.SITECORE_API_HOST,
+      });
     }
 
     if (!scJssConfig) return config;

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -47,10 +47,10 @@ function writeConfig(config: JssConfig): void {
 // See scripts/bootstrap.ts to modify the generation of this file.
 const config = {};\n`;
 
-  const staticConfig = {...config, computed: undefined };
   const computedConfig = config.computed;
+  delete config['computed'];
   // Set configuration values, allowing override with environment variables
-  Object.keys(staticConfig).forEach((prop) => {
+  Object.keys(config).forEach((prop) => {
     configText += `config.${prop} = process.env.${constantCase(prop)} || '${config[prop]}',\n`;
   });
   computedConfig && Object.keys(computedConfig).forEach((prop) => {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -47,9 +47,16 @@ function writeConfig(config: JssConfig): void {
 // See scripts/bootstrap.ts to modify the generation of this file.
 const config = {};\n`;
 
+  const staticConfig = {...config, computed: undefined };
+  const computedConfig = config.computed;
   // Set configuration values, allowing override with environment variables
-  Object.keys(config).forEach((prop) => {
+  Object.keys(staticConfig).forEach((prop) => {
     configText += `config.${prop} = process.env.${constantCase(prop)} || '${config[prop]}',\n`;
+  });
+  computedConfig && Object.keys(computedConfig).forEach((prop) => {
+    configText += `config.${prop} = process.env.${constantCase(prop)} || ${
+      computedConfig[prop]
+    };\n`;
   });
   configText += `module.exports = config;`;
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -10,11 +10,11 @@ import { JssConfig, jssConfigFactory } from './config';
 */
 
 const defaultConfig: JssConfig = {
-  sitecoreApiKey: process.env.SITECORE_API_KEY,
-  sitecoreApiHost: process.env.SITECORE_API_HOST,
-  jssAppName: process.env.JSS_APP_NAME,
-  graphQLEndpointPath: process.env.GRAPH_QL_ENDPOINT_PATH,
-  defaultLanguage: process.env.DEFAULT_LANGUAGE,
+  sitecoreApiKey: process.env[`${constantCase('sitecoreApiKey')}`],
+  sitecoreApiHost: process.env[`${constantCase('sitecoreApiHost')}`],
+  jssAppName: process.env[`${constantCase('jssAppName')}`],
+  graphQLEndpointPath: process.env[`${constantCase('graphQLEndpointPath')}`],
+  defaultLanguage: process.env[`${constantCase('defaultLanguage')}`],
 };
 
 generateConfig(defaultConfig);

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -10,11 +10,11 @@ import { JssConfig, jssConfigFactory } from './config';
 */
 
 const defaultConfig: JssConfig = {
-  sitecoreApiKey: 'no-api-key-set',
-  sitecoreApiHost: '',
-  jssAppName: 'Unknown',
-  graphQLEndpointPath: '',
-  defaultLanguage: 'en',
+  sitecoreApiKey: process.env.SITECORE_API_KEY,
+  sitecoreApiHost: process.env.SITECORE_API_HOST,
+  jssAppName: process.env.JSS_APP_NAME,
+  graphQLEndpointPath: process.env.GRAPH_QL_ENDPOINT_PATH,
+  defaultLanguage: process.env.DEFAULT_LANGUAGE,
 };
 
 generateConfig(defaultConfig);
@@ -47,16 +47,9 @@ function writeConfig(config: JssConfig): void {
 // See scripts/bootstrap.ts to modify the generation of this file.
 const config = {};\n`;
 
-  const computedConfig = config.computed;
-  delete config['computed'];
   // Set configuration values, allowing override with environment variables
   Object.keys(config).forEach((prop) => {
     configText += `config.${prop} = process.env.${constantCase(prop)} || '${config[prop]}',\n`;
-  });
-  computedConfig && Object.keys(computedConfig).forEach((prop) => {
-    configText += `config.${prop} = process.env.${constantCase(prop)} || ${
-      computedConfig[prop]
-    };\n`;
   });
   configText += `module.exports = config;`;
 


### PR DESCRIPTION
This PR slightly reworks how a config in nextjs app is built. 
Each value is resolved with the following logic:
1) Attempt to retrieve value from env
2) Attempt to retrieve value from supplementary files (package.json / scjssconfig)
3) If certain values (that can't be empty, i.e. language) are still empty - use fallback value.

This roughly follows pre-plugin approach to building config where env values take precedence, other sources follow as fallback.
This also ensures that graphQL endpoint will have a correct value, if hostname values is present in either env or scjssconfig.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
