### PR TITLE
Ensure cookie is only used in subsequent middleware plugins, after the initial resolution

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
@@ -355,45 +355,6 @@ describe('MultisiteMiddleware', () => {
       nextRewriteStub.restore();
     });
 
-    it('sc_site cookie is provided', async () => {
-      const req = createRequest({ cookieValues: { sc_site: 'foobar' } });
-
-      const res = createResponse();
-
-      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
-
-      const { middleware, getSite } = createMiddleware();
-
-      const finalRes = await middleware.getHandler()(req, res);
-
-      validateDebugLog('multisite middleware start: %o', {
-        pathname: '/styleguide',
-        hostname: 'foo.net',
-      });
-
-      validateDebugLog('multisite middleware end: %o', {
-        rewritePath: '/_site_foobar/styleguide',
-        siteName: 'foobar',
-        headers: {
-          'x-sc-rewrite': '/_site_foobar/styleguide',
-        },
-        cookies: {
-          ...res.cookies,
-          sc_site: 'foobar',
-        },
-      });
-
-      expect(getSite.notCalled).equal(true);
-
-      expect(finalRes).to.deep.equal(res);
-
-      expect(nextRewriteStub).calledWith({
-        ...req.nextUrl,
-        pathname: '/_site_foobar/styleguide',
-      });
-
-      nextRewriteStub.restore();
-    });
   });
 
   describe('error handling', () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
@@ -354,7 +354,6 @@ describe('MultisiteMiddleware', () => {
 
       nextRewriteStub.restore();
     });
-
   });
 
   describe('error handling', () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
@@ -74,6 +74,8 @@ export class MultisiteMiddleware {
     const hostHeader = req.headers.get('host')?.split(':')[0];
     const hostname = hostHeader || this.defaultHostname;
 
+    
+
     debug.multisite('multisite middleware start: %o', {
       pathname,
       hostname,
@@ -96,8 +98,7 @@ export class MultisiteMiddleware {
 
     // Site name can be forced by query string parameter or cookie
     const siteName =
-      req.nextUrl.searchParams.get('sc_site') ||
-      req.cookies.get('sc_site') ||
+      req.nextUrl.searchParams.get('sc_site') ||      
       this.config.getSite(hostname).name;
 
     // Rewrite to site specific path

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
@@ -73,9 +73,6 @@ export class MultisiteMiddleware {
     const pathname = req.nextUrl.pathname;
     const hostHeader = req.headers.get('host')?.split(':')[0];
     const hostname = hostHeader || this.defaultHostname;
-
-    
-
     debug.multisite('multisite middleware start: %o', {
       pathname,
       hostname,
@@ -97,9 +94,7 @@ export class MultisiteMiddleware {
     }
 
     // Site name can be forced by query string parameter or cookie
-    const siteName =
-      req.nextUrl.searchParams.get('sc_site') ||      
-      this.config.getSite(hostname).name;
+    const siteName = req.nextUrl.searchParams.get('sc_site') || this.config.getSite(hostname).name;
 
     // Rewrite to site specific path
     const rewritePath = getSiteRewrite(pathname, {


### PR DESCRIPTION
Considering a cookie value in initial site resolution leads to some issues. This PR fixes it.
We should use the cookie in post-multisite middleware plugins, but only the things immediately available to a user (like hostname, query string, pathname etc) should affect the initial site resolution at the start of request/middleware processing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
