### PR TITLE
[sitecore-jss] Use site name value from field for multisite

### DIFF
--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
@@ -10,7 +10,9 @@ describe('GraphQLSiteInfoService', () => {
       search: {
         results: [
           {
-            name: 'site 51',
+            name: {
+              value: 'site 51',
+            },
             hostName: {
               value: 'restricted.gov',
             },
@@ -19,7 +21,9 @@ describe('GraphQLSiteInfoService', () => {
             },
           },
           {
-            name: 'public',
+            name: {
+              value: 'public',
+            },
             hostName: {
               value: 'pr.showercurtains.org',
             },

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -25,7 +25,9 @@ const defaultQuery = /* GraphQL */ `
     ) {
       results {
       ... on Item {
-        name
+        name: field(name: "SiteName") {
+          value
+        }
         hostName: field(name: "Hostname") {
           value
         }
@@ -75,7 +77,9 @@ type GraphQLSiteInfoResponse = {
 };
 
 type GraphQLSiteInfoResult = {
-  name: string;
+  name: {
+    value: string;
+  };
   hostName: {
     value: string;
   };
@@ -110,7 +114,7 @@ export class GraphQLSiteInfoService {
     const response = await this.graphQLClient.request<GraphQLSiteInfoResponse>(this.query);
     const result = response?.search?.results?.reduce<SiteInfo[]>((result, current) => {
       result.push({
-        name: current.name,
+        name: current.name.value,
         hostName: current.hostName.value,
         language: current.language.value,
       });


### PR DESCRIPTION
Use name from field instead of an item name when getting site data via GraphQL

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
