### PR TITLE
[Next.js][Multi-site] Better page props site resolution for editing/preview

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/src/lib/page-props-factory/plugins/site.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/src/lib/page-props-factory/plugins/site.ts
@@ -9,6 +9,8 @@ class SitePlugin implements Plugin {
   order = 0;
 
   async exec(props: SitecorePageProps, context: GetServerSidePropsContext | GetStaticPropsContext) {
+    if (context.preview) return props;
+
     const path =
       context.params === undefined
         ? '/'

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/page-props-factory/plugins/personalize.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/page-props-factory/plugins/personalize.ts
@@ -7,6 +7,8 @@ class PersonalizePlugin implements Plugin {
   order = 3;
 
   async exec(props: SitecorePageProps, context: GetServerSidePropsContext | GetStaticPropsContext) {
+    if (context.preview) return props;
+
     const path =
       context.params === undefined
         ? '/'

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/page-props-factory/plugins/error-pages.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/page-props-factory/plugins/error-pages.ts
@@ -9,6 +9,8 @@ class ErrorPagesPlugin implements Plugin {
   order = 3;
 
   async exec(props: SitecorePageProps, context: GetServerSidePropsContext | GetStaticPropsContext) {
+    if (context.preview) return props;
+
     const errorPagesService = new GraphQLErrorPagesService({
       endpoint: config.graphQLEndpoint,
       apiKey: config.sitecoreApiKey,

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/preview-mode.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/preview-mode.ts
@@ -1,3 +1,4 @@
+import { SiteInfo } from '@sitecore-jss/sitecore-jss-nextjs';
 import { editingDataService } from '@sitecore-jss/sitecore-jss-nextjs/editing';
 import { SitecorePageProps } from 'lib/page-props';
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
@@ -16,6 +17,7 @@ class PreviewModePlugin implements Plugin {
         `Unable to get editing data for preview ${JSON.stringify(context.previewData)}`
       );
     }
+    props.site = data.layoutData.sitecore.context.site as SiteInfo;
     props.locale = data.language;
     props.layoutData = data.layoutData;
     props.dictionary = data.dictionary;

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/site.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/site.ts
@@ -1,4 +1,5 @@
 import { SitecorePageProps } from 'lib/page-props';
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import { Plugin } from '..';
 import { siteResolver } from 'lib/site-resolver';
 import config from 'temp/config';
@@ -6,7 +7,9 @@ import config from 'temp/config';
 class SitePlugin implements Plugin {
   order = 0;
 
-  async exec(props: SitecorePageProps) {
+  async exec(props: SitecorePageProps, context: GetServerSidePropsContext | GetStaticPropsContext) {
+    if (context.preview) return props;
+
     // Resolve site by name
     props.site = siteResolver.getByName(config.jssAppName);
 


### PR DESCRIPTION
## Description / Motivation
* Better page props site resolution for editing/preview
* Added (missing) short-circuits for personalize and error-pages as well
* Fixes issue where a newly added site fails to resolve in Pages (Pages appends sc_site query string to the canvas request under the hood)

## Testing Details
Tested on XMC staging

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
