### PR TITLE
[Next.js][Multi-site] Updated site resolver to prefer more specific hostname matches

### DIFF
--- a/packages/sitecore-jss/src/site/site-resolver.test.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.test.ts
@@ -38,7 +38,6 @@ describe('SiteResolver', () => {
         { hostName: 'var.com', language: '', name: 'var' },
         { hostName: 'bar.net', language: '', name: 'bar' },
         { hostName: '*.com', language: '', name: 'foo' },
-        { hostName: 'foo.com', language: '', name: 'foo-en' },
       ]);
       const site = resolver.getByHost('foo.com');
 
@@ -50,7 +49,6 @@ describe('SiteResolver', () => {
       const resolver = new SiteResolver([
         { hostName: 'bar.net', language: '', name: 'bar' },
         { hostName: '*', language: '', name: 'wildcard' },
-        { hostName: 'foo.com', language: '', name: 'foo' },
       ]);
       const site = resolver.getByHost('foo.com');
 
@@ -64,6 +62,38 @@ describe('SiteResolver', () => {
 
       expect(site).to.not.be.undefined;
       expect(site?.name).to.equal('foo');
+    });
+
+    it('should prefer most specific match', () => {
+      const resolver = new SiteResolver([
+        { hostName: '*', language: '', name: 'foo' },
+        { hostName: '*.app.net', language: '', name: 'bar' },
+        { hostName: 'baz.app.net', language: '', name: 'baz' },
+      ]);
+      let site = resolver.getByHost('foo.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('foo');
+      site = resolver.getByHost('bar.app.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('bar');
+      site = resolver.getByHost('Baz.app.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('baz');
+    });
+
+    it('should prefer first site match for same hostName', () => {
+      const resolver = new SiteResolver([
+        { hostName: '*', language: '', name: 'foo' },
+        { hostName: 'Bar.net', language: '', name: 'bar' },
+        { hostName: '*', language: '', name: 'foo-never' },
+        { hostName: 'bar.net', language: '', name: 'bar-never' },
+      ]);
+      let site = resolver.getByHost('foo.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('foo');
+      site = resolver.getByHost('bar.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('bar');
     });
 
     describe('multi-value hostname', () => {

--- a/packages/sitecore-jss/src/site/site-resolver.test.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.test.ts
@@ -68,6 +68,7 @@ describe('SiteResolver', () => {
       const resolver = new SiteResolver([
         { hostName: '*', language: '', name: 'foo' },
         { hostName: '*.app.net', language: '', name: 'bar' },
+        { hostName: 'i.app.net', language: '', name: 'i-bar' },
         { hostName: 'baz.app.net', language: '', name: 'baz' },
       ]);
       let site = resolver.getByHost('foo.net');
@@ -76,6 +77,9 @@ describe('SiteResolver', () => {
       site = resolver.getByHost('bar.app.net');
       expect(site).to.not.be.undefined;
       expect(site?.name).to.equal('bar');
+      site = resolver.getByHost('i.app.net');
+      expect(site).to.not.be.undefined;
+      expect(site?.name).to.equal('i-bar');
       site = resolver.getByHost('Baz.app.net');
       expect(site).to.not.be.undefined;
       expect(site?.name).to.equal('baz');

--- a/packages/sitecore-jss/src/site/site-resolver.ts
+++ b/packages/sitecore-jss/src/site/site-resolver.ts
@@ -66,13 +66,17 @@ export class SiteResolver {
     // This equivalates to sorting from longest to shortest with the assumption
     // that your match is less specific as wildcards are introduced.
     // E.g. order.eu.site.com → *.eu.site.com → *.site.com → *
+    // In case of a tie (e.g. *.site.com vs i.site.com), prefer one with less wildcards.
     return new Map(
       Array.from(map).sort((a, b) => {
+        if (a[0].length === b[0].length) {
+          return (a[0].match(/\*/g) || []).length - (b[0].match(/\*/g) || []).length;
+        }
         return b[0].length - a[0].length;
       })
     );
   };
-
+  // b[0].match(/\*/g) || []).length
   protected matchesPattern(hostname: string, pattern: string): boolean {
     // dots should be treated as chars
     // stars should be treated as wildcards


### PR DESCRIPTION
## Description / Motivation
More specific hostname matches should take precedence over a less specific match (i.e. with wildcards). For example, given the following site info array:
```
[
    {
        name: "foo",
        hostname: "*"
    },
    {
        name: "bar",
        hostname: "*.app.net"
     },
     {
        name: "baz",
        hostname: "baz.app.net"
     },
]
```
it would resolve the following sites for given hostname:
```
"foo.net" > "foo"
"bar.app.net" > "bar"
"baz.app.net" > "baz"
```

## Testing Details
Unit tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
