### PR TITLE
[angular] upgrade bootstrap in sample app

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
@@ -100,7 +100,7 @@ placeholders:
                       href: https://dev.sitecore.net
                       text: Sitecore Dev Site
                       target: _blank
-                      class: font-weight-bold
+                      class: fw-bold
                       title: <a> title attribute
                 - componentName: StyleguideFieldUsageItemLink
                   fields:

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -65,7 +65,7 @@
     "@ngx-translate/http-loader": "~7.0.0",
     "@sitecore-jss/sitecore-jss-angular": "^21.1.0-canary",
     "apollo-angular": "~4.1.1",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "^5.2.3",
     "core-js": "~3.9.1",
     "graphql": "15.5.0",
     "graphql-tag": "~2.11.0",
@@ -127,5 +127,19 @@
     "ts-node": "~10.9.0",
     "typescript": "~4.7.2",
     "yaml-lint": "^1.2.4"
+  },
+  "//": [
+    "overrides (for npm) and resolutions (for yarn) used to work around the bug in critters that affect bootstrap: https://github.com/GoogleChromeLabs/critters/issues/103",
+    "both sections can be removed once critters and css-select versions are updated in build-angular"
+  ],
+  "overrides": {
+    "@angular-devkit/build-angular": {
+      "critters": {
+        "css-select": "4.2.1"
+      }
+    }
+  },
+  "resolutions": {
+    "css-select": "4.2.1"
   }
 }

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-field-usage-link/styleguide-field-usage-link.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-field-usage-link/styleguide-field-usage-link.component.html
@@ -29,7 +29,7 @@
   <br />
   The link component accepts params of its own:&nbsp;
   <a *scLink="rendering.fields.externalLink; attrs: linkDynamicAttributes"
-    class="font-weight-bold"
+    class="fw-bold"
     data-otherattributes="pass-through-to-anchor-tag"
   ></a>
   <br />

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-field-usage-text/styleguide-field-usage-text.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-field-usage-text/styleguide-field-usage-text.component.html
@@ -5,7 +5,7 @@
   <!-- Advanced usage of text field. Turns off Sitecore editing, supports raw HTML, and has a CSS class on the wrapper -->
   <section
     *scText="rendering.fields.sample2; encode: false; editable: false"
-    class="font-weight-bold"
+    class="fw-bold"
     data-sample="other-attributes-pass-through"
   ></section>
 

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-layout/styleguide-layout.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-layout/styleguide-layout.component.html
@@ -7,7 +7,7 @@
   </div>
   <div class="col-sm-4 col-lg-2 order-sm-first pt-2">
     <nav *ngFor="let section of navigation" class="nav flex-column pt-2">
-      <a [href]="'/styleguide#' + section.id" class="nav-item font-weight-bold">
+      <a [href]="'/styleguide#' + section.id" class="nav-item fw-bold">
         {{ section.heading }}
       </a>
       <nav *ngFor="let topic of section.children" class="nav flex-column">

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/routing/navigation/navigation.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/routing/navigation/navigation.component.html
@@ -1,8 +1,8 @@
 <div class="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom">
-  <h5 class="my-0 mr-md-auto font-weight-normal">
+  <h5 class="my-0 me-md-auto fw-normal">
     <a routerLink="/" class="text-dark" class="logo"></a>
   </h5>
-  <nav class="my-2 my-md-0 mr-md-3">
+  <nav class="my-2 my-md-0 me-md-3">
     <a
       class="p-2 text-dark"
       href="https://jss.sitecore.com"

--- a/packages/create-sitecore-jss/src/templates/angular/src/styles.css
+++ b/packages/create-sitecore-jss/src/templates/angular/src/styles.css
@@ -24,3 +24,11 @@ a[target='_blank']:after {
   font-weight: 300;
   line-height: 1.2;
 }
+
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
* Upgrades bootstrap to v5.2 in angular sample app
* Adds resolutions to avoid rules skip during build
* Tweaks CSS to match changes in bootstrap v5

Known issue:
* You may get the following error when building angular sample app in monorepo setup:
** Rules skipped due to selector errors: legend+* -> Cannot read property 'type' of undefined
 to avoid it, add resolutions for css-select into the monorepo's root package:
```
  "resolutions": {
    "css-select": "4.2.1"
  }

```

You can read more in here: https://github.com/GoogleChromeLabs/critters/issues/103

## Testing Details
Manual testing for build and CSS on angular sample.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
