### PR TITLE
[sitecore-jss-proxy] Disable websocket processing by default in proxy

### DIFF
--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/src/config.ts
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/src/config.ts
@@ -89,6 +89,11 @@ export const config: ProxyConfig = {
    */
   maxResponseSizeBytes: 10 * 1024 * 1024,
   /**
+   * Enables or disables proxy handling WebSocket connections
+   * Disabled by default - default JSS proxy logic doesn't handle WS requests and extra implementation is needed for WS to be processed.
+   */
+  ws: false,
+  /**
    * Options object for http-proxy-middleware. Consult its docs.
    */
   proxyOptions: {

--- a/packages/sitecore-jss-proxy/src/ProxyConfig.ts
+++ b/packages/sitecore-jss-proxy/src/ProxyConfig.ts
@@ -41,6 +41,10 @@ export interface ProxyConfig {
    */
   pathRewriteExcludeRoutes?: string[];
   /**
+   * Turn WebSocket requests processing on or off
+   */
+  ws?: boolean;
+  /**
    * Function to determine if a given URL should be SSRed (return true), or passed through (return false)
    * Mutually exclusive with pathRewriteExcludeRoutes.
    */

--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -558,7 +558,7 @@ function createOptions(
     ...config.proxyOptions,
     target: config.apiHost,
     changeOrigin: true, // required otherwise need to include CORS headers
-    ws: true,
+    ws: config.ws || false,
     pathRewrite: (reqPath, req) => rewriteRequestPath(reqPath, req, config, parseRouteUrl),
     logLevel: config.debug ? 'debug' : 'info',
     onProxyReq: (proxyReq, req, res) =>


### PR DESCRIPTION
[sitecore-jss/sitecore-jss-proxy] Better handling for WebSocket requests.
* Makes proxy handling of WebSocket requests configurable
* Adds ws property via ProxyConfig
* Makes it disabled by default

## Testing Details
Manual testing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
