### PR TITLE
[nextjs-sxa] Adding incompatibility message when initializing sxa with styleguide

### DIFF
--- a/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_APPNAME,
   ClientAppArgs,
   missingAddonMsg,
+  incompatibleAddonsMsg,
 } from '../../common';
 
 export default class NextjsSxaInitializer implements Initializer {
@@ -30,10 +31,10 @@ export default class NextjsSxaInitializer implements Initializer {
     await transform(templatePath, mergedArgs);
 
     if (
-      !args.templates.includes('nextjs-styleguide') &&
-      !pkg.config?.templates?.includes('nextjs-styleguide')
+      args.templates.includes('nextjs-styleguide') ||
+      pkg.config?.templates?.includes('nextjs-styleguide')
     ) {
-      console.log(missingAddonMsg('nextjs-sxa', 'nextjs-styleguide'));
+      console.log(incompatibleAddonsMsg('nextjs-sxa', 'nextjs-styleguide'));
     }
 
     const response = {

--- a/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
@@ -5,6 +5,7 @@ import {
   transform,
   DEFAULT_APPNAME,
   ClientAppArgs,
+  missingAddonMsg,
 } from '../../common';
 
 export default class NextjsSxaInitializer implements Initializer {
@@ -27,6 +28,13 @@ export default class NextjsSxaInitializer implements Initializer {
     const templatePath = path.resolve(__dirname, '../../templates/nextjs-sxa');
 
     await transform(templatePath, mergedArgs);
+
+    if (
+      !args.templates.includes('nextjs-styleguide') &&
+      !pkg.config?.templates?.includes('nextjs-styleguide')
+    ) {
+      console.log(missingAddonMsg('nextjs-sxa', 'nextjs-styleguide'));
+    }
 
     const response = {
       // TODO: next steps


### PR DESCRIPTION
Nextjs-sxa and nextjs-styleguide don't work well together. This PR adds a warning when installing both together.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
