### PR TITLE
[create-sitecore-jss] Incompatibility message when installing sxa and styleguide

### DIFF
--- a/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-sxa/index.ts
@@ -5,6 +5,7 @@ import {
   transform,
   DEFAULT_APPNAME,
   ClientAppArgs,
+  incompatibleAddonsMsg,
 } from '../../common';
 
 export default class NextjsSxaInitializer implements Initializer {
@@ -27,6 +28,13 @@ export default class NextjsSxaInitializer implements Initializer {
     const templatePath = path.resolve(__dirname, '../../templates/nextjs-sxa');
 
     await transform(templatePath, mergedArgs);
+
+    if (
+      args.templates.includes('nextjs-styleguide') ||
+      pkg.config?.templates?.includes('nextjs-styleguide')
+    ) {
+      console.log(incompatibleAddonsMsg('nextjs-sxa', 'nextjs-styleguide'));
+    }
 
     const response = {
       // TODO: next steps

--- a/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
@@ -53,5 +53,14 @@ export class NextjsCheckbox extends CheckboxPrompt {
         isValid: incompatibleAddonsMsg('nextjs-styleguide-tracking', 'nextjs-personalize'),
       });
     }
+
+    const isSxaSelected = isSelected('nextjs-sxa');
+    const isStyleguideSelected = isSelected('nextjs-styleguide');
+
+    if (isSxaSelected && isStyleguideSelected) {
+      this.onError({
+        isValid: incompatibleAddonsMsg('nextjs-sxa', 'nextjs-styleguide'),
+      });
+    }
   }
 }


### PR DESCRIPTION
Adding incompatibility message when initializing nextjs sample app with both sxa with styleguide addons.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
