### PR TITLE
[Next.js] Finalize @sitecore/engage version upgrade

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
@@ -35,7 +35,7 @@ const CdpPageView = (): JSX.Element => {
     engage.pageView({
       channel: 'WEB',
       currency: 'USD',
-      pos: pointOfSale,
+      pointOfSale: pointOfSale,
       page,
       pageVariantId,
       language,


### PR DESCRIPTION
The engage version has been updated as part of nextjs third party upgrades.
This PR only renames pos param to pointOfSale in pageView call from CdpPageView control to match updated call signature.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
