### PR TITLE
[Next.js] Fix use of environment variables for JSS config generation (without JSS CLI)

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import chalk from 'chalk';
 import { ConfigPlugin, JssConfig } from '..';
 import { GraphQLSiteInfoService, SiteInfo } from '@sitecore-jss/sitecore-jss-nextjs';

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
 import { constantCase } from 'constant-case';


### PR DESCRIPTION
## Description / Motivation
Import `dotenv/config` so that environment variables are picked up in default JSS config generation.

Note this happened to work if using JSS CLI (since `dotenv` support is built-in) to run commands (e.g. `jss start:connected`), but not if using npm (e.g. `npm run start:connected`).

## Testing Details
Local testing and on XM Cloud Staging deployed to Vercel

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
