### PR TITLE
[Next.js] Next 13 upgrade

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide-tracking/src/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide-tracking/src/Navigation.tsx
@@ -12,10 +12,8 @@ const Navigation = (): JSX.Element => {
   return (
     <div className="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom">
       <h5 className="my-0 me-md-auto fw-normal">
-        <Link href="/">
-          <a className="text-dark">
-            <img src={`${publicUrl}/sc_logo.svg`} alt="Sitecore" />
-          </a>
+        <Link className="text-dark" href="/">
+          <img src={`${publicUrl}/sc_logo.svg`} alt="Sitecore" />
         </Link>
       </h5>
       <nav className="my-2 my-md-0 me-md-3">
@@ -27,14 +25,14 @@ const Navigation = (): JSX.Element => {
         >
           {t('Documentation')}
         </a>
-        <Link href="/styleguide">
-          <a className="p-2 text-dark">{t('Styleguide')}</a>
+        <Link className="p-2 text-dark" href="/styleguide">
+          {t('Styleguide')}
         </Link>
-        <Link href="/graphql">
-          <a className="p-2 text-dark">{t('GraphQL')}</a>
+        <Link className="p-2 text-dark" href="/graphql">
+          {t('GraphQL')}
         </Link>
-        <Link href="/tracking">
-          <a className="p-2 text-dark">{t('Tracking')}</a>
+        <Link className="p-2 text-dark" href="/tracking">
+          {t('Tracking')}
         </Link>
       </nav>
     </div>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/Navigation.tsx
@@ -12,10 +12,8 @@ const Navigation = (): JSX.Element => {
   return (
     <div className="d-flex flex-column flex-md-row align-items-center p-3 px-md-4 mb-3 bg-white border-bottom">
       <h5 className="my-0 me-md-auto fw-normal">
-        <Link href="/">
-          <a className="text-dark">
-            <img src={`${publicUrl}/sc_logo.svg`} alt="Sitecore" />
-          </a>
+        <Link href="/" className="text-dark">
+          <img src={`${publicUrl}/sc_logo.svg`} alt="Sitecore" />
         </Link>
       </h5>
       <nav className="my-2 my-md-0 me-md-3">
@@ -27,11 +25,11 @@ const Navigation = (): JSX.Element => {
         >
           {t('Documentation')}
         </a>
-        <Link href="/styleguide">
-          <a className="p-2 text-dark">{t('Styleguide')}</a>
+        <Link className="p-2 text-dark" href="/styleguide">
+          {t('Styleguide')}
         </Link>
-        <Link href="/graphql">
-          <a className="p-2 text-dark">{t('GraphQL')}</a>
+        <Link className="p-2 text-dark" href="/graphql">
+          {t('GraphQL')}
         </Link>
       </nav>
     </div>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/fields/Styleguide-FieldUsage-Image.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/fields/Styleguide-FieldUsage-Image.tsx
@@ -47,7 +47,7 @@ const StyleguideFieldUsageImage = (props: StyleguideFieldUsageImageProps): JSX.E
       E.g. we have used 'priority' to demonstrate how an image could be considered high priority and preload.
       Lazy loading is automatically disabled for images using priority.
       See here for all the features provided by next/image: https://nextjs.org/docs/api-reference/next/image
-      next/image generates responsive srcSet automatically based on layout. See https://nextjs.org/docs/api-reference/next/image#layout.
+      'fill' causes the next/image to fill the parent element instead of setting width and height. See https://nextjs.org/docs/api-reference/next/image#fill.
       IMPORTANT: The generated sizes should match your Sitecore server-side allowlist. See /sitecore/config/*.config (search for 'allowedMediaParams')
     */}
     <p>Srcset responsive image</p>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/fields/Styleguide-FieldUsage-Image.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/fields/Styleguide-FieldUsage-Image.tsx
@@ -51,14 +51,14 @@ const StyleguideFieldUsageImage = (props: StyleguideFieldUsageImageProps): JSX.E
       IMPORTANT: The generated sizes should match your Sitecore server-side allowlist. See /sitecore/config/*.config (search for 'allowedMediaParams')
     */}
     <p>Srcset responsive image</p>
-    <NextImage
-      field={props.fields.sample2}
-      height="105"
-      width="200"
-      sizes="50vw"
-      layout="responsive"
-      priority
-    />
+    <div style={{ position: 'relative', height: 160, width: 300 }}>
+      <NextImage
+        field={props.fields.sample2}
+        sizes="(min-width: 960px) 300px, 100px"
+        fill
+        priority
+      />
+    </div>
   </StyleguideSpecimen>
 );
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-IntegratedDemo.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-IntegratedDemo.tsx
@@ -115,7 +115,7 @@ const GraphQLIntegratedDemo = (props: GraphQlIntegratedDemoProps): JSX.Element =
             {contextItem.children.results.map((child: Item) => (
               <li key={child.id}>
                 <NextLink href={child.url.path}>
-                  <a>{child.pageTitle.value}</a>
+                  {child.pageTitle.value}
                 </NextLink>
                 &nbsp; (editable title too! <Text field={child.pageTitle.jsonValue} />)
               </li>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-CustomRouteType.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-CustomRouteType.tsx
@@ -28,7 +28,7 @@ const StyleguideCustomRouteType = (): JSX.Element => {
       <RichText field={fields.content} />
 
       <Link href="/styleguide">
-        <a>Return to the Styleguide</a>
+        Return to the Styleguide
       </Link>
     </div>
   );

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-Multilingual.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-Multilingual.tsx
@@ -32,11 +32,11 @@ const StyleguideMultilingual = (props: StyleguideMultilingualProps): JSX.Element
       <p>
         {/* In case if href already includes locale: https://nextjs.org/docs/advanced-features/i18n-routing#transition-between-locales */}
         <Link href="/en/styleguide" locale={false}>
-          <a>Show in English</a>
+          Show in English
         </Link>
         <br />
         <Link href="/styleguide" locale="<%- language %>">
-          <a>Show in <%- language %></a>
+          Show in <%- language %>
         </Link>
       </p>
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-RouteFields.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-RouteFields.tsx
@@ -27,7 +27,7 @@ const StyleguideRouteFields = (props: StyleguideRouteFieldsProps): JSX.Element =
       </p>
       <p>
         <Link href="/styleguide/custom-route-type">
-          <a>Sample of using a custom route type</a>
+          Sample of using a custom route type
         </Link>
       </p>
     </StyleguideSpecimen>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
@@ -27,6 +27,20 @@ const disconnectedPlugin = (nextConfig = {}) => {
         },
       ];
     },
+    webpack: (config, options) => {
+      // Prevent webpack-5 from throwing error for sitecore-import.json when app first starts
+      config.resolve.fallback = {
+        'sitecore/manifest/sitecore-import.json': false,
+        ...config.resolve.fallback,
+      };
+
+      // Overload the Webpack config if it was already overloaded
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options);
+      }
+
+      return config;
+    },
   });
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/disconnected.js
@@ -27,21 +27,6 @@ const disconnectedPlugin = (nextConfig = {}) => {
         },
       ];
     },
-
-    webpack: (config, options) => {
-      // Prevent webpack-5 from throwing error for sitecore-import.json when app first starts
-      config.resolve.fallback = {
-        'sitecore/manifest/sitecore-import.json': false,
-        ...config.resolve.fallback
-      };
-
-      // Overload the Webpack config if it was already overloaded
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(config, options);
-      }
-
-      return config;
-    }
   });
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
@@ -7,20 +7,6 @@ const styleguidePlugin = (nextConfig = {}) => {
       ...nextConfig.i18n,
       locales: ['en', '<%- language %>'],
     },
-    webpack: (config, options) => {
-      // Prevent webpack-5 from throwing error for sitecore-import.json when app first starts
-      config.resolve.fallback = {
-        'sitecore/manifest/sitecore-import.json': false,
-        ...config.resolve.fallback,
-      };
-
-      // Overload the Webpack config if it was already overloaded
-      if (typeof nextConfig.webpack === 'function') {
-        return nextConfig.webpack(config, options);
-      }
-
-      return config;
-    },
   });
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/lib/next-config/plugins/styleguide.js
@@ -7,6 +7,20 @@ const styleguidePlugin = (nextConfig = {}) => {
       ...nextConfig.i18n,
       locales: ['en', '<%- language %>'],
     },
+    webpack: (config, options) => {
+      // Prevent webpack-5 from throwing error for sitecore-import.json when app first starts
+      config.resolve.fallback = {
+        'sitecore/manifest/sitecore-import.json': false,
+        ...config.resolve.fallback,
+      };
+
+      // Overload the Webpack config if it was already overloaded
+      if (typeof nextConfig.webpack === 'function') {
+        return nextConfig.webpack(config, options);
+      }
+
+      return config;
+    },
   });
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -32,7 +32,7 @@
     "@sitecore-jss/sitecore-jss-nextjs": "^21.1.0-canary",
     "graphql": "~15.8.0",
     "graphql-tag": "^2.12.6",
-    "next": "^12.3.4",
+    "next": "^13.1.6",
     "next-localization": "^0.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -63,7 +63,6 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-yaml": "^0.5.0",
     "graphql-let": "^0.18.6",
-    "next-transpile-modules": "^10.0.0",
     "npm-run-all": "~4.1.5",
     "prettier": "^2.8.3",
     "ts-node": "^10.9.1",

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/monorepo.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/next-config/plugins/monorepo.js
@@ -1,21 +1,12 @@
-const withTM = require('next-transpile-modules')(['@sitecore-jss/sitecore-jss-nextjs'], {
-  resolveSymlinks: false,
-});
-const path = require('path');
-
-const CWD = process.cwd();
-
 /**
  * @param {import('next').NextConfig} nextConfig
  */
 const monorepoPlugin = (nextConfig = {}) => {
-  return withTM(Object.assign({}, nextConfig, {
+  return Object.assign({}, nextConfig, {
     webpack: (config, options) => {
       if (options.isServer) {
         config.externals = ['react', 'vertx', ...config.externals];
       }
-
-      config.resolve.alias['react'] = path.resolve(CWD, '.', 'node_modules', 'react');
 
       // Overload the Webpack config if it was already overloaded
       if (typeof nextConfig.webpack === 'function') {
@@ -24,7 +15,7 @@ const monorepoPlugin = (nextConfig = {}) => {
 
       return config;
     }
-  }));
+  });
 };
 
 module.exports = monorepoPlugin;

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-react": "^7.32.1",
     "jsdom": "^21.1.0",
     "mocha": "^10.2.0",
-    "next": "^12.3.4",
+    "next": "^13.1.6",
     "nock": "^13.3.0",
     "nyc": "^15.1.0",
     "react": "^18.2.0",
@@ -65,7 +65,7 @@
     "typescript": "~4.9.4"
   },
   "peerDependencies": {
-    "next": "^12.3.4",
+    "next": "^13.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -44,17 +44,14 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             href={{ pathname: href, query: querystring, hash: anchor }}
             key="link"
             locale={false}
+            title={value.title}
+            target={value.target}
+            className={value.class}
+            {...htmlLinkProps}
+            ref={ref}
           >
-            <a
-              title={value.title}
-              target={value.target}
-              className={value.class}
-              {...htmlLinkProps}
-              ref={ref}
-            >
-              {text}
-              {children}
-            </a>
+            {text}
+            {children}
           </NextLink>
         );
       }

--- a/packages/sitecore-jss-nextjs/src/components/NextImage.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/NextImage.test.tsx
@@ -153,6 +153,26 @@ describe('<NextImage />', () => {
     it('should render image with className prop', () => {
       expect(rendered.prop('className')).to.eql(props.className);
     });
+
+    it('should render image when alt prop is missing', () => {
+      const props = {
+        field: { value: { src: '/assets/img/test0.png' } },
+        width,
+        height: 10,
+        id: 'some-id',
+        className: 'the-dude-abides',
+      };
+
+      const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('img');
+
+      expect(rendered).to.have.length(1);
+      expect(rendered.prop('src')).to.eql(`${HOSTNAME}${props.field.value.src}?w=${props.width}`);
+      expect(rendered.prop('alt')).to.eql('');
+      expect(mockLoader.called).to.be.true;
+      expect(mockLoader).to.have.been.calledWith(
+        match({ src: props.field.value.src, width: props.width })
+      );
+    });
   });
 
   describe('with "editable" property value but editing disabled', () => {

--- a/packages/sitecore-jss-nextjs/src/components/NextImage.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/NextImage.test.tsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import { NextImage, sitecoreLoader } from './NextImage';
 import { ImageField } from '@sitecore-jss/sitecore-jss-react';
-import { ImageLoader, ImageLoaderProps } from 'next/image';
+import { ImageLoader } from 'next/image';
 import { spy, match } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { SinonSpy } from 'sinon';
@@ -58,8 +58,14 @@ describe('sitecoreLoader', () => {
 });
 
 describe('<NextImage />', () => {
+  const HOSTNAME = 'https://cm.jss.localhost';
+  const width = 8;
   type MockLoaderType = ImageLoader extends SinonSpy ? SinonSpy : SinonSpy<any, any>;
-  const customLoader = ({ src }) => new URL(`https://cm.jss.localhost${src}`).href;
+  const customLoader = ({ src }) => {
+    const isQsPresent = src.split('?').length === 2;
+    const widthParam = isQsPresent ? `&w=${width}` : `?w=${width}`;
+    return new URL(`${HOSTNAME}${src}`).href + widthParam;
+  };
   const mockLoader = (spy(customLoader) as unknown) as MockLoaderType;
   afterEach(() => {
     () => mockLoader.resetHistory();
@@ -70,14 +76,15 @@ describe('<NextImage />', () => {
       field: {
         src: '/assets/img/test0.png',
       },
-      width: 8,
+      width,
       height: 10,
     };
 
-    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('Image');
+    const mounted = mount(<NextImage loader={mockLoader} {...props} />);
+    const rendered = mounted.find('img');
     it('should render image with url', () => {
       expect(rendered).to.have.lengthOf(1);
-      expect(rendered.prop('src')).to.equal(props.field.src);
+      expect(rendered.prop('src')).to.equal(`${HOSTNAME}${props.field.src}?w=${props.width}`);
       expect(rendered.prop('width')).to.equal(props.width);
       expect(rendered.prop('height')).to.equal(props.height);
 
@@ -91,21 +98,19 @@ describe('<NextImage />', () => {
   describe('with responsive image object', () => {
     const props = {
       field: { value: { src: '/assets/img/test0.png', alt: 'my image' } },
-      layout: 'responsive' as const,
       sizes: '(min-width: 960px) 300px, 100px',
-      width: 8,
+      width,
       height: 10,
       id: 'some-id',
       className: 'the-dude-abides',
     };
 
-    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('Image');
+    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('img');
 
     it('should render image with needed props', () => {
       expect(rendered).to.have.length(1);
-      expect(rendered.prop('src')).to.equal(props.field.value.src);
+      expect(rendered.prop('src')).to.equal(`${HOSTNAME}${props.field.value.src}?w=${props.width}`);
       expect(rendered.prop('sizes')).to.equal('(min-width: 960px) 300px, 100px');
-      expect(rendered.prop('layout')).to.equal(props.layout);
       expect(mockLoader.called).to.be.true;
       expect(mockLoader).to.have.been.calledWith(
         match({ src: props.field.value.src, width: props.width })
@@ -124,16 +129,16 @@ describe('<NextImage />', () => {
   describe('with "value" property value', () => {
     const props = {
       field: { value: { src: '/assets/img/test0.png', alt: 'my image' } },
-      width: 8,
+      width,
       height: 10,
       id: 'some-id',
       className: 'the-dude-abides',
     };
-    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('Image');
+    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('img');
 
     it('should render image component with "value" properties', () => {
       expect(rendered).to.have.length(1);
-      expect(rendered.prop('src')).to.eql(props.field.value.src);
+      expect(rendered.prop('src')).to.eql(`${HOSTNAME}${props.field.value.src}?w=${props.width}`);
       expect(rendered.prop('alt')).to.eql(props.field.value.alt);
       expect(mockLoader.called).to.be.true;
       expect(mockLoader).to.have.been.calledWith(
@@ -153,17 +158,17 @@ describe('<NextImage />', () => {
   describe('with "editable" property value but editing disabled', () => {
     const props = {
       field: { value: { src: '/assets/img/test0.png', alt: 'my image' } },
-      width: 8,
+      width,
       height: 10,
       alt: 'my image',
       editable: false,
       className: 'the-dude-abides w-100',
     };
-    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('Image');
+    const rendered = mount(<NextImage loader={mockLoader} {...props} />).find('img');
 
     it('should render image component with "value" properties', () => {
       expect(rendered).to.have.length(1);
-      expect(rendered.prop('src')).to.eql(props.field.value.src);
+      expect(rendered.prop('src')).to.eql(`${HOSTNAME}${props.field.value.src}?w=${props.width}`);
       expect(rendered.prop('alt')).to.eql(props.field.value.alt);
       expect(mockLoader.called).to.be.true;
       expect(mockLoader).to.have.been.calledWith(
@@ -179,54 +184,72 @@ describe('<NextImage />', () => {
   describe('with "mediaUrlPrefix" property', () => {
     it('should transform url with "value" property value', () => {
       const props = {
-        field: { value: { src: '/~assets/img/test0.png', alt: 'my image' } },
+        field: {
+          value: { src: '/~assets/img/test0.png', alt: 'my image' },
+        },
         id: 'some-id',
-        width: 100,
+        width,
         height: 50,
         imageParams: { foo: 'bar' },
         mediaUrlPrefix: /\/([-~]{1})assets\//i,
       };
       const rendered = mount(<NextImage loader={mockLoader} {...props} />);
 
-      expect(rendered.find('Image').prop('src')).to.equal('/~/jssmedia/img/test0.png?foo=bar');
+      expect(rendered.find('img').prop('src')).to.equal(
+        `${HOSTNAME}/~/jssmedia/img/test0.png?foo=bar&w=8`
+      );
       rendered.setProps({
         ...props,
         field: { src: '/-assets/img/test0.png' },
       });
-      expect(rendered.find('Image').prop('src')).to.equal('/-/jssmedia/img/test0.png?foo=bar');
+      expect(rendered.find('img').prop('src')).to.equal(
+        `${HOSTNAME}/-/jssmedia/img/test0.png?foo=bar&w=8`
+      );
       expect(mockLoader.called).to.be.true;
       expect(mockLoader).to.have.been.calledWith(
-        match({ src: '/-/jssmedia/img/test0.png?foo=bar', width: props.width })
+        match({
+          src: '/-/jssmedia/img/test0.png?foo=bar',
+          width: props.width,
+        })
       );
     });
 
     it('should transform url with direct image object, no value/editable', () => {
       const props = {
-        field: { value: { src: '/~assets/img/test0.png', alt: 'my image' } },
-        width: 8,
+        field: {
+          value: { src: '/~assets/img/test0.png', alt: 'my image' },
+        },
+        width,
         height: 10,
         id: 'some-id',
         imageParams: { foo: 'bar' },
         mediaUrlPrefix: /\/([-~]{1})assets\//i,
       };
       const rendered = mount(<NextImage loader={mockLoader} {...props} />);
-      expect(rendered.find('Image').prop('src')).to.equal('/~/jssmedia/img/test0.png?foo=bar');
+      expect(rendered.find('img').prop('src')).to.equal(
+        `${HOSTNAME}/~/jssmedia/img/test0.png?foo=bar&w=8`
+      );
       rendered.setProps({
         ...props,
         field: { src: '/-assets/img/test0.png' },
-        width: 8,
+        width,
         height: 10,
       });
-      expect(rendered.find('Image').prop('src')).to.equal('/-/jssmedia/img/test0.png?foo=bar');
+      expect(rendered.find('img').prop('src')).to.equal(
+        `${HOSTNAME}/-/jssmedia/img/test0.png?foo=bar&w=8`
+      );
       expect(mockLoader.called).to.be.true;
       expect(mockLoader).to.have.been.calledWith(
-        match({ src: '/-/jssmedia/img/test0.png?foo=bar', width: props.width })
+        match({
+          src: '/-/jssmedia/img/test0.png?foo=bar',
+          width: props.width,
+        })
       );
     });
 
     it('should render no image when field prop is empty', () => {
       const img = '' as ImageField;
-      const rendered = mount(<NextImage field={img} />).find('Image');
+      const rendered = mount(<NextImage field={img} />).find('img');
       expect(rendered).to.have.length(0);
     });
   });
@@ -247,19 +270,18 @@ describe('<NextImage />', () => {
       field: {
         src: '/assets/img/test0.png',
       },
-      width: 8,
+      width,
       height: 10,
       loader: userMockLoader,
     };
 
-    const rendered = mount(<NextImage {...props} />).find('Image');
+    const rendered = mount(<NextImage {...props} />).find('img');
 
     it('should render image with url', () => {
       expect(rendered).to.have.lengthOf(1);
-      expect(rendered.prop('src')).to.equal(props.field.src);
+      expect(rendered.prop('src')).to.equal(`${HOSTNAME}${props.field.src}`);
       expect(rendered.prop('width')).to.equal(props.width);
       expect(rendered.prop('height')).to.equal(props.height);
-      expect(rendered.prop('loader')).to.equal(props.loader);
       expect(userMockLoader).to.have.been.called;
       expect(userMockLoader).to.have.been.calledWith(
         match({ src: props.field.src, width: props.width })

--- a/packages/sitecore-jss-nextjs/src/components/NextImage.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/NextImage.tsx
@@ -85,7 +85,7 @@ export const NextImage: React.FC<NextImageProps> = ({
   const loader = (otherProps.loader ? otherProps.loader : sitecoreLoader) as ImageLoader;
 
   if (attrs) {
-    return <Image loader={loader} {...imageProps} />;
+    return <Image alt="no-alt-set" loader={loader} {...imageProps} />;
   }
 
   return null; // we can't handle the truth

--- a/packages/sitecore-jss-nextjs/src/components/NextImage.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/NextImage.tsx
@@ -85,7 +85,7 @@ export const NextImage: React.FC<NextImageProps> = ({
   const loader = (otherProps.loader ? otherProps.loader : sitecoreLoader) as ImageLoader;
 
   if (attrs) {
-    return <Image alt="no-alt-set" loader={loader} {...imageProps} />;
+    return <Image alt="" loader={loader} {...imageProps} />;
   }
 
   return null; // we can't handle the truth

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
@@ -38,7 +38,10 @@ describe('MultisiteMiddleware', () => {
       },
       headers: {
         get(key: string) {
-          const headers = { host: 'foo.net', ...props.headerValues };
+          const headers = {
+            host: 'foo.net',
+            ...props.headerValues,
+          };
           return headers[key];
         },
         ...props.headers,
@@ -98,6 +101,7 @@ describe('MultisiteMiddleware', () => {
     return { middleware, getSite };
   };
 
+  // Stub for NextResponse generation, see https://github.com/vercel/next.js/issues/42374
   (Headers.prototype as any).getAll = () => [];
 
   beforeEach(() => {
@@ -141,7 +145,9 @@ describe('MultisiteMiddleware', () => {
       it('should apply both default and custom rules when custom excludeRoute function provided', async () => {
         const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
-        const { middleware } = createMiddleware({ excludeRoute });
+        const { middleware } = createMiddleware({
+          excludeRoute,
+        });
 
         await test('/src/image.png', middleware);
         await test('/api/layout/render', middleware);
@@ -160,13 +166,17 @@ describe('MultisiteMiddleware', () => {
     });
 
     it('fallback hostname is used', async () => {
-      const req = createRequest({ headerValues: { host: undefined } });
+      const req = createRequest({
+        headerValues: { host: undefined },
+      });
 
       const res = createResponse();
 
       nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
 
-      const { middleware, getSite } = createMiddleware({ defaultHostname: 'bar.net' });
+      const { middleware, getSite } = createMiddleware({
+        defaultHostname: 'bar.net',
+      });
 
       const finalRes = await middleware.getHandler()(req, res);
 
@@ -200,7 +210,9 @@ describe('MultisiteMiddleware', () => {
     });
 
     it('fallback default hostName is used', async () => {
-      const req = createRequest({ headerValues: { host: undefined } });
+      const req = createRequest({
+        headerValues: { host: undefined },
+      });
 
       const res = createResponse();
 
@@ -316,13 +328,17 @@ describe('MultisiteMiddleware', () => {
     });
 
     it('sc_site querystring parameter is provided', async () => {
-      const req = createRequest({ searchParams: { sc_site: 'qsFoo' } });
+      const req = createRequest({
+        searchParams: { sc_site: 'qsFoo' },
+      });
 
       const res = createResponse();
 
       nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
 
-      const { middleware, getSite } = createMiddleware({ useCookieResolution: () => true });
+      const { middleware, getSite } = createMiddleware({
+        useCookieResolution: () => true,
+      });
 
       const finalRes = await middleware.getHandler()(req, res);
 
@@ -354,13 +370,17 @@ describe('MultisiteMiddleware', () => {
     });
 
     it('sc_site cookie is provided and its usage enabled', async () => {
-      const req = createRequest({ cookieValues: { sc_site: 'foobar' } });
+      const req = createRequest({
+        cookieValues: { sc_site: 'foobar' },
+      });
 
       const res = createResponse();
 
       nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
 
-      const { middleware, getSite } = createMiddleware({ useCookieResolution: () => true });
+      const { middleware, getSite } = createMiddleware({
+        useCookieResolution: () => true,
+      });
 
       const finalRes = await middleware.getHandler()(req, res);
 
@@ -392,7 +412,9 @@ describe('MultisiteMiddleware', () => {
     });
 
     it('sc_site cookie is provided and its usage disabled', async () => {
-      const req = createRequest({ cookieValues: { sc_site: 'foobar' } });
+      const req = createRequest({
+        cookieValues: { sc_site: 'foobar' },
+      });
 
       const res = createResponse();
 

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
@@ -46,7 +46,7 @@ describe('MultisiteMiddleware', () => {
       cookies: {
         get(cookieName: string) {
           const cookies = { ...props.cookieValues };
-          return cookies[cookieName];
+          return { value: cookies[cookieName] };
         },
         ...props?.cookies,
         ...props.cookieValues,
@@ -97,6 +97,8 @@ describe('MultisiteMiddleware', () => {
 
     return { middleware, getSite };
   };
+
+  (Headers.prototype as any).getAll = () => [];
 
   beforeEach(() => {
     debugSpy.resetHistory();

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
@@ -102,7 +102,7 @@ export class MultisiteMiddleware {
       req.nextUrl.searchParams.get('sc_site') ||
       (this.config.useCookieResolution &&
         this.config.useCookieResolution(req) &&
-        req.cookies.get('sc_site')) ||
+        req.cookies.get('sc_site')?.value) ||
       this.config.getSite(hostname).name;
 
     // Rewrite to site specific path

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -67,7 +67,7 @@ describe('PersonalizeMiddleware', () => {
         get(cookieName: string) {
           const cookies = { 'BID_cdp-client-key': 'browser-id', ...props.cookieValues };
 
-          return cookies[cookieName];
+          return { value: cookies[cookieName] };
         },
         ...props.cookies,
       },
@@ -91,7 +91,7 @@ describe('PersonalizeMiddleware', () => {
           res.cookies[key] = value;
         },
         get(key) {
-          return res.cookies[key];
+          return { value: res.cookies[key] };
         },
         ...props.cookieValues,
       },
@@ -185,6 +185,8 @@ describe('PersonalizeMiddleware', () => {
 
     return { middleware, executeExperience, generateBrowserId, getPersonalizeInfo, getSite };
   };
+
+  (Headers.prototype as any).getAll = () => [];
 
   beforeEach(() => {
     userAgentStub.resetHistory();

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -65,7 +65,10 @@ describe('PersonalizeMiddleware', () => {
       },
       cookies: {
         get(cookieName: string) {
-          const cookies = { 'BID_cdp-client-key': 'browser-id', ...props.cookieValues };
+          const cookies = {
+            'BID_cdp-client-key': 'browser-id',
+            ...props.cookieValues,
+          };
 
           return { value: cookies[cookieName] };
         },
@@ -152,7 +155,12 @@ describe('PersonalizeMiddleware', () => {
     };
 
     const getSite: any =
-      props.getSite || sinon.stub().returns({ name: siteName, language: '', hostName: hostname });
+      props.getSite ||
+      sinon.stub().returns({
+        name: siteName,
+        language: '',
+        hostName: hostname,
+      });
 
     const middleware = new PersonalizeMiddleware({
       getSite,
@@ -183,9 +191,16 @@ describe('PersonalizeMiddleware', () => {
         )
       ));
 
-    return { middleware, executeExperience, generateBrowserId, getPersonalizeInfo, getSite };
+    return {
+      middleware,
+      executeExperience,
+      generateBrowserId,
+      getPersonalizeInfo,
+      getSite,
+    };
   };
 
+  // Stub for NextResponse generation, see https://github.com/vercel/next.js/issues/42374
   (Headers.prototype as any).getAll = () => [];
 
   beforeEach(() => {
@@ -356,7 +371,9 @@ describe('PersonalizeMiddleware', () => {
       it('should apply both default and custom rules when custom excludeRoute function provided', async () => {
         const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
-        const { middleware } = createMiddleware({ excludeRoute });
+        const { middleware } = createMiddleware({
+          excludeRoute,
+        });
 
         await test('/src/image.png', middleware);
         await test('/api/layout/render', middleware);

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -112,7 +112,7 @@ export class PersonalizeMiddleware {
   }
 
   protected getBrowserId(req: NextRequest): string | undefined {
-    return req.cookies.get(this.browserIdCookieName) || undefined;
+    return req.cookies.get(this.browserIdCookieName)?.value || undefined;
   }
 
   protected setBrowserId(res: NextResponse, browserId: string) {
@@ -146,7 +146,9 @@ export class PersonalizeMiddleware {
   }
 
   protected isPreview(req: NextRequest) {
-    return req.cookies.get('__prerender_bypass') || req.cookies.get('__next_preview_data');
+    return (
+      req.cookies.get('__prerender_bypass')?.value || req.cookies.get('__next_preview_data')?.value
+    );
   }
 
   /**
@@ -166,7 +168,7 @@ export class PersonalizeMiddleware {
     const hostname = hostHeader || this.defaultHostname;
     const pathname = req.nextUrl.pathname;
     const language = req.nextUrl.locale || req.nextUrl.defaultLocale || 'en';
-    const siteName = res?.cookies.get('sc_site') || this.config.getSite(hostname).name;
+    const siteName = res?.cookies.get('sc_site')?.value || this.config.getSite(hostname).name;
 
     let browserId = this.getBrowserId(req);
     debug.personalize('personalize middleware start: %o', {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -68,7 +68,12 @@ describe('RedirectsMiddleware', () => {
     } = {}
   ) => {
     const getSite: any =
-      props.getSite || sinon.stub().returns({ name: siteName, language: '', hostName: hostname });
+      props.getSite ||
+      sinon.stub().returns({
+        name: siteName,
+        language: '',
+        hostName: hostname,
+      });
 
     const middleware = new RedirectsMiddleware({
       getSite,
@@ -95,6 +100,7 @@ describe('RedirectsMiddleware', () => {
     return { middleware, fetchRedirects, getSite };
   };
 
+  // Stub for NextResponse generation, see https://github.com/vercel/next.js/issues/42374
   (Headers.prototype as any).getAll = () => [];
 
   afterEach(() => {
@@ -128,7 +134,9 @@ describe('RedirectsMiddleware', () => {
       it('should apply both default and custom rules when custom excludeRoute function provided', async () => {
         const excludeRoute = (pathname: string) => pathname === '/crazypath/luna';
 
-        const { middleware } = createMiddleware({ excludeRoute });
+        const { middleware } = createMiddleware({
+          excludeRoute,
+        });
 
         await test('/src/image.png', middleware);
         await test('/api/layout/render', middleware);
@@ -184,7 +192,11 @@ describe('RedirectsMiddleware', () => {
           setCookies,
         });
         const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
-          return ({ url, status, cookies: { set: setCookies } } as unknown) as NextResponse;
+          return ({
+            url,
+            status,
+            cookies: { set: setCookies },
+          } as unknown) as NextResponse;
         });
         const req = createRequest({
           nextUrl: {
@@ -390,7 +402,10 @@ describe('RedirectsMiddleware', () => {
           setCookies,
         });
         const nextRewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((url) => {
-          return ({ url, cookies: { set: setCookies } } as unknown) as NextResponse;
+          return ({
+            url,
+            cookies: { set: setCookies },
+          } as unknown) as NextResponse;
         });
         const req = createRequest({
           nextUrl: {
@@ -519,7 +534,11 @@ describe('RedirectsMiddleware', () => {
           setCookies,
         });
         const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
-          return ({ url, status, cookies: { set: setCookies } } as unknown) as NextResponse;
+          return ({
+            url,
+            status,
+            cookies: { set: setCookies },
+          } as unknown) as NextResponse;
         });
 
         const req = createRequest({
@@ -561,7 +580,11 @@ describe('RedirectsMiddleware', () => {
           setCookies,
         });
         const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
-          return ({ url, status, cookies: { set: setCookies } } as unknown) as NextResponse;
+          return ({
+            url,
+            status,
+            cookies: { set: setCookies },
+          } as unknown) as NextResponse;
         });
 
         const req = createRequest({

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -29,7 +29,7 @@ describe('RedirectsMiddleware', () => {
       },
       cookies: {
         get(key: string) {
-          return req.cookies[key];
+          return { value: req.cookies[key] };
         },
         ...props.cookies,
       },
@@ -94,6 +94,8 @@ describe('RedirectsMiddleware', () => {
 
     return { middleware, fetchRedirects, getSite };
   };
+
+  (Headers.prototype as any).getAll = () => [];
 
   afterEach(() => {
     sinon.restore();
@@ -475,7 +477,7 @@ describe('RedirectsMiddleware', () => {
         expect(getSite).to.not.be.called;
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
-        expect(finalRes.cookies.get('sc_site')).to.equal(site);
+        expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
       });
 
       it('should preserve site name from response data when provided, if handler is disabled', async () => {
@@ -506,7 +508,7 @@ describe('RedirectsMiddleware', () => {
         expect(getSite).to.not.be.called;
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.false;
-        expect(finalRes.cookies.get('sc_site')).to.equal(site);
+        expect(finalRes.cookies.get('sc_site')?.value).to.equal(site);
       });
 
       it('default fallback hostname is used', async () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -87,7 +87,7 @@ export class RedirectsMiddleware {
 
   private handler = async (req: NextRequest, res?: NextResponse): Promise<NextResponse> => {
     const hostname = this.getHostname(req);
-    const siteName = res?.cookies.get('sc_site') || this.config.getSite(hostname).name;
+    const siteName = res?.cookies.get('sc_site')?.value || this.config.getSite(hostname).name;
 
     const createResponse = async () => {
       if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4957,100 +4957,100 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/env@npm:12.3.4"
-  checksum: daa3fc11efd1344c503eab41311a0e503ba7fd08607eeb3dc571036a6211eb37959cc4ed48b71dcc411cc214e7623ffd02411080aad3e09dc6a1192d5b256e60
+"@next/env@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/env@npm:13.1.6"
+  checksum: 0f911a18f0b3372007632fffa87f5d7f802c00d07b3bf757d2d09574735ae43f60000ecdf64b6f06e195971c508c2bcee82dd1e3aab27a08a4300eb0317652bb
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm-eabi@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-android-arm-eabi@npm:12.3.4"
+"@next/swc-android-arm-eabi@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-android-arm-eabi@npm:13.1.6"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm64@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-android-arm64@npm:12.3.4"
+"@next/swc-android-arm64@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-android-arm64@npm:13.1.6"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-darwin-arm64@npm:12.3.4"
+"@next/swc-darwin-arm64@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-darwin-arm64@npm:13.1.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-darwin-x64@npm:12.3.4"
+"@next/swc-darwin-x64@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-darwin-x64@npm:13.1.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-freebsd-x64@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-freebsd-x64@npm:12.3.4"
+"@next/swc-freebsd-x64@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-freebsd-x64@npm:13.1.6"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm-gnueabihf@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.3.4"
+"@next/swc-linux-arm-gnueabihf@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:13.1.6"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-linux-arm64-gnu@npm:12.3.4"
+"@next/swc-linux-arm64-gnu@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-linux-arm64-gnu@npm:13.1.6"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-linux-arm64-musl@npm:12.3.4"
+"@next/swc-linux-arm64-musl@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-linux-arm64-musl@npm:13.1.6"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-linux-x64-gnu@npm:12.3.4"
+"@next/swc-linux-x64-gnu@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-linux-x64-gnu@npm:13.1.6"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-linux-x64-musl@npm:12.3.4"
+"@next/swc-linux-x64-musl@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-linux-x64-musl@npm:13.1.6"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-win32-arm64-msvc@npm:12.3.4"
+"@next/swc-win32-arm64-msvc@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-win32-arm64-msvc@npm:13.1.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-win32-ia32-msvc@npm:12.3.4"
+"@next/swc-win32-ia32-msvc@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-win32-ia32-msvc@npm:13.1.6"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:12.3.4":
-  version: 12.3.4
-  resolution: "@next/swc-win32-x64-msvc@npm:12.3.4"
+"@next/swc-win32-x64-msvc@npm:13.1.6":
+  version: 13.1.6
+  resolution: "@next/swc-win32-x64-msvc@npm:13.1.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6012,7 +6012,7 @@ __metadata:
     eslint-plugin-react: ^7.32.1
     jsdom: ^21.1.0
     mocha: ^10.2.0
-    next: ^12.3.4
+    next: ^13.1.6
     nock: ^13.3.0
     node-html-parser: ^6.1.4
     nyc: ^15.1.0
@@ -6026,7 +6026,7 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ~4.9.4
   peerDependencies:
-    next: ^12.3.4
+    next: ^13.1.6
     react: ^18.2.0
     react-dom: ^18.2.0
   languageName: unknown
@@ -6266,12 +6266,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@swc/helpers@npm:0.4.11":
-  version: 0.4.11
-  resolution: "@swc/helpers@npm:0.4.11"
+"@swc/helpers@npm:0.4.14":
+  version: 0.4.14
+  resolution: "@swc/helpers@npm:0.4.14"
   dependencies:
     tslib: ^2.4.0
-  checksum: 736857d524b41a8a4db81094e9b027f554004e0fa3e86325d85bdb38f7e6459ce022db079edb6c61ba0f46fe8583b3e663e95f7acbd13e51b8da6c34e45bba2e
+  checksum: 273fd3f3fc461a92f3790cc551ea054745c6d6959afbe1232e6d7aa1c722bbc114d308aab96bef5c78fc0303c85c7b472ef00e2253251cc89737f3b1af56e5a5
   languageName: node
   linkType: hard
 
@@ -11432,6 +11432,13 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 4c94af3769367a70e11ed69aa6095f1c600c0ff510f3921ab4045af961820d57c0233acfa8b6396037391f31b4c397e1f614d234294f979ff61430a6c166c3f6
+  languageName: node
+  linkType: hard
+
+"client-only@npm:0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 0c16bf660dadb90610553c1d8946a7fdfb81d624adea073b8440b7d795d5b5b08beb3c950c6a2cf16279365a3265158a236876d92bce16423c485c322d7dfaf8
   languageName: node
   linkType: hard
 
@@ -21883,34 +21890,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^12.3.4":
-  version: 12.3.4
-  resolution: "next@npm:12.3.4"
+"next@npm:^13.1.6":
+  version: 13.1.6
+  resolution: "next@npm:13.1.6"
   dependencies:
-    "@next/env": 12.3.4
-    "@next/swc-android-arm-eabi": 12.3.4
-    "@next/swc-android-arm64": 12.3.4
-    "@next/swc-darwin-arm64": 12.3.4
-    "@next/swc-darwin-x64": 12.3.4
-    "@next/swc-freebsd-x64": 12.3.4
-    "@next/swc-linux-arm-gnueabihf": 12.3.4
-    "@next/swc-linux-arm64-gnu": 12.3.4
-    "@next/swc-linux-arm64-musl": 12.3.4
-    "@next/swc-linux-x64-gnu": 12.3.4
-    "@next/swc-linux-x64-musl": 12.3.4
-    "@next/swc-win32-arm64-msvc": 12.3.4
-    "@next/swc-win32-ia32-msvc": 12.3.4
-    "@next/swc-win32-x64-msvc": 12.3.4
-    "@swc/helpers": 0.4.11
+    "@next/env": 13.1.6
+    "@next/swc-android-arm-eabi": 13.1.6
+    "@next/swc-android-arm64": 13.1.6
+    "@next/swc-darwin-arm64": 13.1.6
+    "@next/swc-darwin-x64": 13.1.6
+    "@next/swc-freebsd-x64": 13.1.6
+    "@next/swc-linux-arm-gnueabihf": 13.1.6
+    "@next/swc-linux-arm64-gnu": 13.1.6
+    "@next/swc-linux-arm64-musl": 13.1.6
+    "@next/swc-linux-x64-gnu": 13.1.6
+    "@next/swc-linux-x64-musl": 13.1.6
+    "@next/swc-win32-arm64-msvc": 13.1.6
+    "@next/swc-win32-ia32-msvc": 13.1.6
+    "@next/swc-win32-x64-msvc": 13.1.6
+    "@swc/helpers": 0.4.14
     caniuse-lite: ^1.0.30001406
     postcss: 8.4.14
-    styled-jsx: 5.0.7
-    use-sync-external-store: 1.2.0
+    styled-jsx: 5.1.1
   peerDependencies:
     fibers: ">= 3.1.0"
     node-sass: ^6.0.0 || ^7.0.0
-    react: ^17.0.2 || ^18.0.0-0
-    react-dom: ^17.0.2 || ^18.0.0-0
+    react: ^18.2.0
+    react-dom: ^18.2.0
     sass: ^1.3.0
   dependenciesMeta:
     "@next/swc-android-arm-eabi":
@@ -21948,7 +21954,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: d96fc4f5bcd5a630d74111519f4820dcbd75dddf16c6d00d2167bd3cb8d74965d46d83c8e5ec301bf999013c7d96f1bfff9424f0221317d68b594c4d01f5825e
+  checksum: 584977e382bd826c21e7fc5f67bca50e4d95741a854b1686394d45331404479c7266569671227421975fc18e5cf70769a4ad7edede7450d4497213205bba77c8
   languageName: node
   linkType: hard
 
@@ -27709,9 +27715,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-jsx@npm:5.0.7":
-  version: 5.0.7
-  resolution: "styled-jsx@npm:5.0.7"
+"styled-jsx@npm:5.1.1":
+  version: 5.1.1
+  resolution: "styled-jsx@npm:5.1.1"
+  dependencies:
+    client-only: 0.0.1
   peerDependencies:
     react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
   peerDependenciesMeta:
@@ -27719,7 +27727,7 @@ __metadata:
       optional: true
     babel-plugin-macros:
       optional: true
-  checksum: 61959993915f4b1662a682dbbefb3512de9399cf6901969bcadd26ba5441d2b5ca5c1021b233bbd573da2541b41efb45d56c6f618dbc8d88a381ebc62461fefe
+  checksum: 523a33b38603492547e861b98e29c873939b04e15fbe5ef16132c6f1e15958126647983c7d4675325038b428a5e91183d996e90141b18bdd1bbadf6e2c45b2fa
   languageName: node
   linkType: hard
 
@@ -29024,7 +29032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.2.0":
+"use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* _Next_ is bumped to _^13.1.6_
* _next/link_ <Link /> component doesn't accept `<a/>` tag as a child anymore
* _next/image_ <Image />: 
  * Component doesn't support _layout_ property, _fill_ (fluid image) needs to be used instead, which requires having _relative_ positioned parent. 
  * Set _sizes_ value to be the same as we have for RAV.
  * Now _alt_ is required property
* _next-transpile-modules_ not needed anymore, _next_ now supports linked dependencies resolution OOTB, multiple _react_ dependencies related fix also not required to be present anymore
* Middleware's _cookie.get_ now returns _{ value, name, ...rest }_ instead of _value_
* Aligned unit tests according to new changes
* Not related to upgrade:
  * Moved _sitecore/manifest/sitecore-import.json_ fallback config from _next-config/plugins/disconnected_ to _next-config/plugins/styleguide_, because error can be thrown in connected mode too
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
