### PR TITLE
Prevent canary publish after hotfix merges

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,12 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSpec: '16.x'
+# variables['Build.SourceVersionMessage'] is only accessible at step level, so we use it directly for condition here
+- script: |
+    echo "Hotfix commit detected. New canary will not be published."
+    echo "##vso[task.setvariable variable=shouldPublish]false"
+  displayName: Re-evaluate shouldPublish for hotfix release
+  condition: and(eq(variables.shouldPublish, true), startsWith(variables['Build.SourceVersionMessage'], '[hotfix]'))
 - script: |
     yarn cache clean --all && yarn install --immutable
   displayName: 'yarn install - initial'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,8 @@ variables:
     branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
     branchName: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
+# To be used in the last step when publishing to npm
+  publishTag: --pre-dist-tag canary
 # disable `PublishCodeCoverageResults` report generation, as `reportgenerator` provides custom report
   disable.coverage.autogenerate: 'true'
 # Some steps here scaffold jss apps and check if they build and lint correctly
@@ -46,9 +48,9 @@ steps:
     versionSpec: '16.x'
 # variables['Build.SourceVersionMessage'] is only accessible at step level, so we use it directly for condition here
 - script: |
-    echo "Hotfix commit detected. New canary will not be published."
-    echo "##vso[task.setvariable variable=shouldPublish]false"
-  displayName: Re-evaluate shouldPublish for hotfix release
+    echo "Hotfix commit detected. 'hotfix' tag will be published to npm"
+    echo "##vso[task.setvariable variable=publishTag]--pre-dist-tag hotfix"
+  displayName: Re-evaluate publishTag for hotfix release
   condition: and(eq(variables.shouldPublish, true), startsWith(variables['Build.SourceVersionMessage'], '[hotfix]'))
 - script: |
     yarn cache clean --all && yarn install --immutable
@@ -124,7 +126,7 @@ steps:
   #
 - script: |
     echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-    $(npm bin)/lerna publish from-git --canary --pre-dist-tag canary --preid canary --no-verify-access --yes
+    $(npm bin)/lerna publish from-git --canary $(publishTag) --preid canary --no-verify-access --yes
     yarn install --no-immutable --mode=update-lockfile
     git add yarn.lock
     git commit -m "update yarn.lock [skip ci]"


### PR DESCRIPTION
The goal:
* Prevent a canary version update after hotfix PR is merged into release branch.
* Not publish verXX tag when releasing/testing a hotfix merge.

Proposed solution:
* Add a "[hotfix]" prefix to hotfix PR names.
* Azure pipeline will publish canary with "hotfix" tag when encountering "[hotfix]" commits while building a release branch.

The "why"s:
* Why use commit message? 
** Hotfixes are merged from a "hotfix/" branches, however, source branch info is not available to Azure when release build pipeline is run (that is only available during PR pipeline runs). One place that can share hotfix info is merge commit message - which will be the same as pull request name - and available to Azure.

* Why this prefix specifically?
** No reason, could be anything.


## Testing Details
Manual testing to verify variables changed in one step will have updated value in the next one

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
