### PR TITLE
[Nextjs] Sample in Docker env references linked packages using lowercase path

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/tsconfig.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/tsconfig.json
@@ -14,7 +14,6 @@
     "skipLibCheck": true,
     "strict": true,
     "strictFunctionTypes": false,
-    "forceConsistentCasingInFileNames": true,
     "downlevelIteration": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description / Motivation
* Inside the Docker env, the sample app uses a lowercased path and can't find an appropriate module in case you have capitalized letters in your sample app dist path
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
Launched docker env with a reference to sample app inside the monorepo
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
