### PR TITLE
[nextjs] Add rewrite for Sitecore's default 404 prefix

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -54,7 +54,7 @@ const nextConfig = {
         source: '/healthz',
         destination: '/api/healthz',
       },
-      // rewrite for default not-found page 
+      // rewrite for Sitecore service pages
       {
         source: '/sitecore/service/:path*',
         destination: `${jssConfig.sitecoreApiHost}/sitecore/service/:path*`,

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -53,7 +53,12 @@ const nextConfig = {
       {
         source: '/healthz',
         destination: '/api/healthz',
-      }
+      },
+      // rewrite for default not-found page 
+      {
+        source: '/sitecore/service/:path*',
+        destination: `${jssConfig.sitecoreApiHost}/sitecore/service/:path*`,
+      }, 
     ];
   },
 };


### PR DESCRIPTION
Adds an extra rewrite rule that allows JSS to handle Sitecore's default not-found page correctly.

## Testing Details
Manual testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
