### PR TITLE
Traverse layout to extract stylesheet ids

### DIFF
--- a/packages/sitecore-jss/src/feaas/index.ts
+++ b/packages/sitecore-jss/src/feaas/index.ts
@@ -1,0 +1,1 @@
+export * from './utils'

--- a/packages/sitecore-jss/src/feaas/utils.test.ts
+++ b/packages/sitecore-jss/src/feaas/utils.test.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import {
+  getPersonalizedRewrite,
+  getPersonalizedRewriteData,
+  normalizePersonalizedRewrite,
+  CdpHelper,
+  VARIANT_PREFIX,
+  DEFAULT_VARIANT,
+} from './utils';
+
+describe('utils', () => {
+  describe('getPersonalizedRewrite', () => {
+    const data = {
+      variantId: 'variant-id',
+    };
+    it('should return a string', () => {
+      expect(getPersonalizedRewrite('/pathname', data)).to.be.a('string');
+    });
+    it('should return the path with the variant id when pathname starts with "/"', () => {
+      const pathname = '/some/path';
+      const result = getPersonalizedRewrite(pathname, data);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/some/path`);
+    });
+    it('should return the path with the variant id when pathname not starts with "/"', () => {
+      const pathname = 'some/path';
+      const result = getPersonalizedRewrite(pathname, data);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/some/path`);
+    });
+    it('should return the root path with the variant id', () => {
+      const pathname = '/';
+      const result = getPersonalizedRewrite(pathname, data);
+      expect(result).to.equal(`/${VARIANT_PREFIX}${data.variantId}/`);
+    });
+  });
+
+  describe('getPersonalizedRewriteData', () => {
+    it('should return a PersonalizedRewriteData object', () => {
+      expect(getPersonalizedRewriteData('/some/path')).to.be.an('object');
+    });
+    it('should return the personalized data from the rewrite path', () => {
+      const pathname = `/some/path/${VARIANT_PREFIX}123/`;
+      const result = getPersonalizedRewriteData(pathname);
+      expect(result.variantId).to.equal('123');
+    });
+    it('should return the default variant id when pathname does not contain variant', () => {
+      const pathname = '/some/path';
+      const result = getPersonalizedRewriteData(pathname);
+      expect(result.variantId).to.equal(DEFAULT_VARIANT);
+    });
+    it('should return empty variant id when pathname is missing variant id', () => {
+      const pathname = `/some/path/${VARIANT_PREFIX}/`;
+      const result = getPersonalizedRewriteData(pathname);
+      expect(result.variantId).to.equal('');
+    });
+    it('should return varinat id from any position in pathname', () => {
+      const testId = '0451';
+      const path1 = `/${VARIANT_PREFIX}${testId}/some/path/`;
+      const path2 = `/_site_mysite/${VARIANT_PREFIX}${testId}/some/path/`;
+
+      expect(getPersonalizedRewriteData(path1)).to.deep.equal(getPersonalizedRewriteData(path2));
+    });
+  });
+
+  describe('normalizePersonalizedRewrite', () => {
+    it('should return a string', () => {
+      expect(normalizePersonalizedRewrite('/some/path')).to.be.a('string');
+    });
+    it('should return the pathname when it does not contain variant id', () => {
+      const pathname = '/some/path';
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal(pathname);
+    });
+    it('should return the pathname without the variant id', () => {
+      const pathname = `/${VARIANT_PREFIX}foo/some/path`;
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal('/some/path');
+    });
+    it('should return the root pathname without the variant id', () => {
+      const pathname = `/${VARIANT_PREFIX}foo/`;
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal('/');
+    });
+    it('should return the root pathname without the variant id when pathname not ends with "/"', () => {
+      const pathname = `/${VARIANT_PREFIX}foo`;
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal('/');
+    });
+    it('should normalize path with other prefixes present', () => {
+      const pathname = `/_site_mysite/${VARIANT_PREFIX}foo`;
+      const pathNameInversed = `/${VARIANT_PREFIX}foo/_site_mysite/`;
+      const result = normalizePersonalizedRewrite(pathname);
+      expect(result).to.equal('/_site_mysite/');
+      expect(normalizePersonalizedRewrite(pathNameInversed)).to.equal(result);
+    });
+  });
+
+  describe('FEAASUtils', () => {
+    describe('getFEAASLibraryIds', () => {
+    });
+  });

--- a/packages/sitecore-jss/src/feaas/utils.ts
+++ b/packages/sitecore-jss/src/feaas/utils.ts
@@ -1,0 +1,61 @@
+import {
+  ComponentRendering,
+  HtmlElementRendering,
+  LayoutServiceData,
+  RouteData,
+  reduceLayout,
+} from '../layout';
+
+/**
+ * Walks through rendering tree and returns list of ids of all FEAAS Component Libraries that are used
+ * @param {LayoutServiceData | RouteData<any> | ComponentRendering | HtmlElementRendering | null } object Layout, route data or rendering
+ */
+export function getFEAASLibraryIds(
+  object: LayoutServiceData | RouteData<any> | ComponentRendering | HtmlElementRendering | null
+) {
+  return reduceLayout(
+    object,
+    (initialValue, node) => {
+      let libraryId: string | undefined = undefined;
+
+      if ('fields' in node && node.fields !== undefined) {
+        // Read out FEAASComponent's libraryid
+        if (node.fields.LibraryId) {
+          if ('value' in node.fields.LibraryId && typeof node.fields.LibraryId.value === 'string') {
+            libraryId = node.fields.LibraryId.value;
+          }
+        }
+        // Check CSSStyles override
+        if (node.fields.CSSStyles) {
+          if ('value' in node.fields.CSSStyles && typeof node.fields.CSSStyles.value === 'string') {
+            libraryId = node.fields.CSSStyles.value.match(/-library--([^\s]+)/)?.[1] || libraryId;
+          }
+        }
+        // HTMLRendering its class attribute
+      } else if ('attributes' in node && typeof node.attributes.class === 'string') {
+        libraryId = node.attributes.class.match(/-library--([^\s]+)/)?.[1];
+      }
+
+      if (libraryId && !initialValue.includes(libraryId)) {
+        return initialValue.concat(libraryId);
+      }
+
+      return initialValue;
+    },
+    [] as string[]
+  );
+}
+
+/**
+ * Format URL for FEAAS Library stylesheet
+ * @param libraryId ID of a library that maintains stylesheet
+ * @param hostname CDN hostname
+ * - 'https://feaas.blob.core.windows.net' for production
+ * - 'https://feaasstaging.blob.core.windows.net' for staging
+ */
+export function getFEAASLibraryStylesheetURL(
+  libraryId: string,
+  hostname = 'https://feaas.blob.core.windows.net'
+) {
+  return `${hostname}/styles/${libraryId}/published.css`;
+}

--- a/packages/sitecore-jss/src/layout/index.ts
+++ b/packages/sitecore-jss/src/layout/index.ts
@@ -18,7 +18,7 @@ export {
   EDITING_COMPONENT_ID,
 } from './models';
 
-export { getFieldValue, getChildPlaceholder } from './utils';
+export { getFieldValue, getChildPlaceholder, reduceLayout } from './utils';
 
 export { LayoutService } from './layout-service';
 

--- a/packages/sitecore-jss/src/layout/utils.ts
+++ b/packages/sitecore-jss/src/layout/utils.ts
@@ -1,4 +1,11 @@
-import { ComponentRendering, ComponentFields, Field, HtmlElementRendering } from './models';
+import {
+  ComponentRendering,
+  ComponentFields,
+  Field,
+  HtmlElementRendering,
+  LayoutServiceData,
+  RouteData,
+} from './models';
 
 /**
  * Safely extracts a field value from a rendering or fields object.
@@ -71,4 +78,42 @@ export function getChildPlaceholder(
   }
 
   return rendering.placeholders[placeholderName];
+}
+
+/**
+ * Walks through layout rendering tree and invokes Reduce-compatible callback on every Rendering.
+ * Initial value determines return type
+ *
+ * @param {LayoutServiceData | RouteData<any> | ComponentRendering | HtmlElementRendering | null } object Layout, route data or rendering
+ * @param {Function} callback Reduce-style callback, accepting previous value and a rendering
+ * @param {any} initialValue Initial value that will be passed to callbacks, e.g. array
+ */
+export function reduceLayout<T>(
+  object: LayoutServiceData | RouteData<any> | ComponentRendering | HtmlElementRendering | null,
+  callback: (
+    previousValue: T,
+    component: ComponentRendering | HtmlElementRendering | RouteData
+  ) => T,
+  initialValue: T
+): T {
+  if (object === null) return initialValue;
+
+  // When layout: Check placheolders
+  if ('sitecore' in object) {
+    return reduceLayout(object.sitecore.route, callback, initialValue);
+  }
+
+  // When rendering / HTML Rendering / RouteData, invoke callback
+  initialValue = callback(initialValue, object);
+
+  // When route / component: check its placeholders
+  if ('placeholders' in object) {
+    initialValue = Object.values(object.placeholders || {})
+      .flat()
+      .reduce((previousValue, rendering) => {
+        return reduceLayout(rendering, callback, previousValue);
+      }, initialValue);
+  }
+
+  return initialValue;
 }

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -1,32 +1,15 @@
 import {
-  LayoutServiceData,
   ComponentRendering,
   HtmlElementRendering,
+  LayoutServiceData,
   PlaceholdersData,
+  RouteData,
 } from './../layout/models';
 
 export type ComponentRenderingWithExperiences = ComponentRendering & {
   experiences: { [name: string]: ComponentRenderingWithExperiences };
 };
 
-/**
- * Apply personalization to layout data. This will recursively go through all placeholders/components, check experiences nodes and replace default with object from specific experience.
- * @param {LayoutServiceData} layout Layout data
- * @param {string} variantId variant id
- */
-export function personalizeLayout(layout: LayoutServiceData, variantId: string): void {
-  // Add variantId to Sitecore context so that it is accessible here
-  layout.sitecore.context.variantId = variantId;
-  const placeholders = layout.sitecore.route?.placeholders;
-  if (Object.keys(placeholders ?? {}).length === 0) {
-    return;
-  }
-  if (placeholders) {
-    Object.keys(placeholders).forEach((placeholder) => {
-      placeholders[placeholder] = personalizePlaceholder(placeholders[placeholder], variantId);
-    });
-  }
-}
 
 /**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds functions to parse traverse layout and prepare list of FEAAS stylesheets to be loaded. FEAAS extension in pages allows applying themes to SXA and FEAAS elements. These themes require stylesheet to be loaded. The functions find out class names on components in the form of `-library--*` and parses the ids out.


## Description
* reduceLayout - a new general purpose reducer function that walks through the layout with call signature similar to Array#reduce
* getFEAASLibraryIds - function that returns list of FEAAS library ids used in the layout
* getFEAASLibraryStylesheetURL - generates url to stylesheet by url ID


## Testing Details
* Tests are not done yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
