### PR TITLE
Improved usecases for styleguide edtframe example

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
@@ -263,7 +263,7 @@ placeholders:
                       But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
                       You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
                       </p>
-                    red: 0
+                    applyRedToText: 0
                     sampleList:
                       # see /data/content/Styleguide/ContentListField for definitions of these IDs
                       - id: styleguide-content-list-field-shared-1

--- a/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
@@ -259,4 +259,13 @@ placeholders:
                 - componentName: StyleguideEditFrame
                   fields:
                     heading: Edit Frame
+                    description: <p>Who framed Roger Rabbit? Hard to say. <br />
+                      But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
+                      You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+                      </p>
+                    red: 0
+                    sampleList:
+                      # see /data/content/Styleguide/ContentListField for definitions of these IDs
+                      - id: styleguide-content-list-field-shared-1
+                      - id: styleguide-content-list-field-shared-2
 

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
@@ -10,6 +10,9 @@ export default function StyleguideEditFrame(manifest: Manifest) {
     icon: SitecoreIcon.DocumentTag,
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },
+      { name: 'description', type: CommonFieldTypes.RichText},
+      { name: 'red', type: CommonFieldTypes.Checkbox},
+      { name: 'sampleList', type: CommonFieldTypes.ContentList}
     ],
   });
 }

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
@@ -7,6 +7,7 @@ import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore
 export default function StyleguideEditFrame(manifest: Manifest) {
   manifest.addComponent({
     name: 'StyleguideEditFrame',
+    templateName: '<%- helper.getAppPrefix(appPrefix, appName) %>StyleguideEditFrame',
     icon: SitecoreIcon.DocumentTag,
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/components/styleguide-edit-frame.sitecore.ts
@@ -11,8 +11,8 @@ export default function StyleguideEditFrame(manifest: Manifest) {
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },
       { name: 'description', type: CommonFieldTypes.RichText},
-      { name: 'red', type: CommonFieldTypes.Checkbox},
-      { name: 'sampleList', type: CommonFieldTypes.ContentList}
+      { name: 'applyRedToText', type: CommonFieldTypes.Checkbox},
+      { name: 'sampleList', type: CommonFieldTypes.ContentList},
     ],
   });
 }

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
@@ -6,9 +6,12 @@
     [cssClass]="editFrameProps.cssClass"
     [parameters]="editFrameProps.parameters"
     [sitecore]="context">
-    This is the content that will wrapped by edit frame in Experience Editor
-    <p [ngClass]="rendering.fields.red ? 'red': 'blue'">This text will change color</p>
-    This is uneditable list:
+    This is the content that will be wrapped by edit frame in Experience Editor.<br/>
+    Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
+    Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
+    <br/>
+    <p [ngStyle]="{'color': (applyRed ? 'red': 'blue')}">This text will change color. Use the field edit button to change its appearance</p>
+    This list can be changed via field editor:
     <ul>
       <li *ngFor="let contentItem of rendering.fields.sampleList">{{contentItem.name}}</li>
     </ul>

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
@@ -6,9 +6,12 @@
     [cssClass]="editFrameProps.cssClass"
     [parameters]="editFrameProps.parameters"
     [sitecore]="context">
-    Who framed Roger Rabbit? Hard to say. <br />
-    But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
-    You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+    This is the content that will wrapped by edit frame in Experience Editor
+    <p [ngClass]="rendering.fields.red ? 'red': 'blue'">This text will change color</p>
+    This is uneditable list:
+    <ul>
+      <li *ngFor="let contentItem of rendering.fields.sampleList">{{contentItem.name}}</li>
+    </ul>
     <ng-content></ng-content>
   </sc-edit-frame>
 </app-styleguide-specimen>

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.ts
@@ -3,6 +3,7 @@ import {
   ComponentRendering,
   EditFrameDataSource,
   FieldEditButton,
+  getFieldValue,
   LayoutServiceContextData,
   RouteData,
   WebEditButton
@@ -36,17 +37,19 @@ export class StyleguideEditFrameComponent implements OnInit {
 
   editFrameProps: EditFrameProps;
 
+  applyRed: boolean;
+  
   editFrameButtons = [
     {
       header: 'WebEditButton',
       icon: '/~/icon/Office/16x16/document_selection.png',
-      click: 'javascript:alert("An edit frame button was just clicked!")',
+      click: 'javascript:alert("An edit frame button was just clicked! You can also use chrome: and webedit: commands with it!")',
       tooltip: 'Doesnt do much, just a web edit button example',
     }, // use javascript:, webedit: or chrome: commands for webedit buttons
     {
       header: 'FieldEditButton',
       icon: '/~/icon/Office/16x16/pencil.png',
-      fields: ['heading'],
+      fields: ['applyRedToText', 'sampleList'],
       tooltip: 'Allows you to open field editor for specified fields',
     }, // or use field edit buttons to open Field Editor
   ];
@@ -57,6 +60,7 @@ export class StyleguideEditFrameComponent implements OnInit {
     this.jssContext.state.subscribe((state) => {
       this.context = state.sitecore;
     });
+    this.applyRed = getFieldValue<number>(this.rendering, 'applyRedToText') ? true: false;
     this.editFrameProps = this.getEditFrameProps(this.rendering.dataSource);
   }
 
@@ -70,7 +74,7 @@ export class StyleguideEditFrameComponent implements OnInit {
           }
         : undefined, // datasource will set the item to be edited by edit frame
       buttons: this.editFrameButtons, // add custom editing functionality or edit field sets with buttons
-      title: 'JSS edit frame',
+      title: 'jssEditFrame',
       tooltip: 'Perform editing anywhere while not tied to a rendering, placeholder or field',
       cssClass: 'jss-edit-frame', // customize edit frame appearance through CSS
       parameters: {}, // set additional parameters when needed

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/routes/styleguide/en.yml
@@ -248,3 +248,11 @@ placeholders:
                 - componentName: Styleguide-EditFrame
                   fields:
                     heading: Edit Frame
+                    description: <p>Who framed Roger Rabbit? Hard to say. <br />
+                     But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
+                     You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+                     </p>
+                    applyRedToText: 0
+                    sampleList:
+                      - id: styleguide-content-list-field-shared-1
+                      - id: styleguide-content-list-field-shared-2

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/components/styleguide/Styleguide-EditFrame.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/components/styleguide/Styleguide-EditFrame.sitecore.ts
@@ -10,7 +10,12 @@ export default function StyleguideEditFrame(manifest: Manifest): void {
   manifest.addComponent({
     name: 'Styleguide-EditFrame',
     icon: SitecoreIcon.DocumentTag,
-    fields: [{ name: 'heading', type: CommonFieldTypes.SingleLineText }],
+    fields: [
+      { name: 'heading', type: CommonFieldTypes.SingleLineText },
+      { name: 'description', type: CommonFieldTypes.RichText },
+      { name: 'applyRedToText', type: CommonFieldTypes.Checkbox },
+      { name: 'sampleList', type: CommonFieldTypes.ContentList },
+    ],
     templateName: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame',
   });
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
@@ -16,16 +16,27 @@ type StyleguideEditFrameProps = ComponentProps & {
  * In editing mode it will output markup for Edit Frame that will wrap the child content.
  * Edit buttons, custom CSS and datasource can be applied.
  */
-const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => (
-  <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
-    <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
-      Who framed Roger Rabbit? Hard to say. <br />
-      But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
-      You can add web edit or field edit buttons, modify edit frames style through CSS class and put the frame wherever you need it.
-      {props.children}
-    </EditFrame>
-  </StyleguideSpecimen>
-);
+const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => {
+  const applyRed = props.rendering.fields.applyRedToText?.value;
+  return (
+    <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
+      <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
+      This is the content that will be wrapped by edit frame in Experience Editor.<br/>
+        Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
+        Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
+        <br/>
+        <p style={{color: applyRed? 'red': 'blue'}}>This text will change color. Use the field edit button to change its appearance</p>
+        This list can be changed via field editor:
+        <ul>
+          {props.rendering.fields.sampleList.map((item, idx) => (
+            <li key={idx}>{item.name}</li>
+          ))}
+        </ul>
+        {props.children}
+      </EditFrame>
+    </StyleguideSpecimen>
+  );
+};
 
 const getEditFrameProps = (dataSource?: string) => {
   return {
@@ -37,7 +48,7 @@ const getEditFrameProps = (dataSource?: string) => {
         }
       : undefined, // datasource will set the item to be edited by edit frame
     buttons: editFrameButtons, // add custom editing functionality or edit field sets with buttons
-    title: 'JSS edit frame',
+    title: 'jssEditFrame',
     tooltip: 'Perform editing anywhere while not tied to a rendering, placeholder or field',
     cssClass: 'jss-edit-frame', // customize edit frame appearance through CSS
     parameters: {}, // set additional parameters when needed
@@ -54,7 +65,7 @@ const editFrameButtons = [
   {
     header: 'FieldEditButton',
     icon: '/~/icon/Office/16x16/pencil.png',
-    fields: ['heading'],
+    fields: ['applyRedToText', 'sampleList'],
     tooltip: 'Allows you to open field editor for specified fields',
   },
 ];

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
@@ -1,14 +1,17 @@
-import { Field, withDatasourceCheck } from '@sitecore-jss/sitecore-jss-nextjs';
+import { withDatasourceCheck } from '@sitecore-jss/sitecore-jss-nextjs';
 import { ComponentProps } from 'lib/component-props';
 import { EditFrame } from '@sitecore-jss/sitecore-jss-nextjs';
 import StyleguideSpecimen from './Styleguide-Specimen';
+import { StyleguideSpecimenFields } from 'lib/component-props/styleguide';
 
-type StyleguideEditFrameProps = ComponentProps & {
-  fields: {
-    heading: Field<string>;
+type StyleguideEditFrameProps = ComponentProps &
+  StyleguideSpecimenFields & {
+    fields: {
+      applyRedToText: Field<boolean>,
+      sampleList: Item[],
+    }
+    children: React.ReactNode;
   };
-  children: React.ReactNode;
-};
 
 /**
  * A sample component to describe Edit Frame usage with JSS.
@@ -17,7 +20,7 @@ type StyleguideEditFrameProps = ComponentProps & {
  * Edit buttons, custom CSS and datasource can be applied.
  */
 const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => {
-  const applyRed = props.rendering.fields.applyRedToText?.value;
+  const applyRed = props.fields.applyRedToText.value;
   return (
     <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
       <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
@@ -28,7 +31,7 @@ const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => {
         <p style={{color: applyRed? 'red': 'blue'}}>This text will change color. Use the field edit button to change its appearance</p>
         This list can be changed via field editor:
         <ul>
-          {props.rendering.fields.sampleList.map((item, idx) => (
+          {props.fields.sampleList.map((item, idx) => (
             <li key={idx}>{item.name}</li>
           ))}
         </ul>

--- a/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
@@ -252,4 +252,13 @@ placeholders:
           - componentName: Styleguide-EditFrame
             fields:
               heading: Edit Frame
+              description: <p>Who framed Roger Rabbit? Hard to say. <br />
+               But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
+               You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+               </p>
+              applyRedToText: 0
+              sampleList:
+                - id: styleguide-content-list-field-shared-1
+                - id: styleguide-content-list-field-shared-2
+
 

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
@@ -9,6 +9,7 @@ import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore
 export default function (manifest) {
   manifest.addComponent({
     name: 'Styleguide-EditFrame',
+    templateName: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame',
     icon: SitecoreIcon.DocumentTag,
     fields: [      
       { name: 'heading', type: CommonFieldTypes.SingleLineText },

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
@@ -10,6 +10,11 @@ export default function (manifest) {
   manifest.addComponent({
     name: 'Styleguide-EditFrame',
     icon: SitecoreIcon.DocumentTag,
-    fields: [{ name: 'heading', type: CommonFieldTypes.SingleLineText }],
+    fields: [      
+      { name: 'heading', type: CommonFieldTypes.SingleLineText },
+      { name: 'description', type: CommonFieldTypes.RichText},
+      { name: 'applyRedToText', type: CommonFieldTypes.Checkbox},
+      { name: 'sampleList', type: CommonFieldTypes.ContentList},
+    ],
   });
 }

--- a/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
@@ -11,22 +11,22 @@ import StyleguideSpecimen from '../Styleguide-Specimen';
 const StyleguideEditFrame = (props) => {
   const applyRed = props.rendering.fields.applyRedToText?.value;
   return (
-  <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
-    <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
-      This is the content that will be wrapped by edit frame in Experience Editor.<br/>
-      Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
-      Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
-      <br/>
-      <p style={{color: applyRed? 'red': 'blue'}}>This text will change color. Use the field edit button to change its appearance</p>
-      This list can be changed via field editor:
-      <ul>
-        {props.rendering.fields.sampleList.map((item, idx) => (
-          <li key={idx}>{item.name}</li>
-        ))}
-      </ul>
-      {props.children}
-    </EditFrame>
-  </StyleguideSpecimen>
+    <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
+      <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
+        This is the content that will be wrapped by edit frame in Experience Editor.<br/>
+        Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
+        Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
+        <br/>
+        <p style={{color: applyRed? 'red': 'blue'}}>This text will change color. Use the field edit button to change its appearance</p>
+        This list can be changed via field editor:
+        <ul>
+          {props.rendering.fields.sampleList.map((item, idx) => (
+            <li key={idx}>{item.name}</li>
+          ))}
+        </ul>
+        {props.children}
+      </EditFrame>
+    </StyleguideSpecimen>
   );
 };
 

--- a/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
@@ -8,17 +8,27 @@ import StyleguideSpecimen from '../Styleguide-Specimen';
  * In editing mode it will output markup for Edit Frame that will wrap the child content.
  * Edit buttons, custom CSS and datasource can be applied.
  */
-const StyleguideEditFrame = (props) => (
+const StyleguideEditFrame = (props) => {
+  const applyRed = props.rendering.fields.applyRedToText?.value;
+  return (
   <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
     <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
-      Who framed Roger Rabbit? Hard to say. <br />
-      But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
-      You can add web edit or field edit buttons, modify edit frame style through CSS class and
-      put the frame wherever you need it.
+      This is the content that will be wrapped by edit frame in Experience Editor.<br/>
+      Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
+      Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
+      <br/>
+      <p style={{color: applyRed? 'red': 'blue'}}>This text will change color. Use the field edit button to change its appearance</p>
+      This list can be changed via field editor:
+      <ul>
+        {props.rendering.fields.sampleList.map((item, idx) => (
+          <li key={idx}>{item.name}</li>
+        ))}
+      </ul>
       {props.children}
     </EditFrame>
   </StyleguideSpecimen>
-);
+  );
+};
 
 const getEditFrameProps = (dataSource) => {
   return {
@@ -30,7 +40,7 @@ const getEditFrameProps = (dataSource) => {
         }
       : undefined, // datasource will set the item to be edited by edit frame
     buttons: editFrameButtons, // add custom editing functionality or edit field sets with buttons
-    title: 'JSS edit frame',
+    title: 'jssEditFrame',
     tooltip: 'Perform editing anywhere while not tied to a rendering, placeholder or field',
     cssClass: 'jss-edit-frame', // customize edit frame appearance through CSS
     parameters: {}, // set additional parameters when needed
@@ -41,13 +51,13 @@ const editFrameButtons = [
   {
     header: 'WebEditButton',
     icon: '/~/icon/Office/16x16/document_selection.png',
-    click: 'javascript:alert("An edit frame button was just clicked!")',
+    click: 'javascript:alert("An edit frame button was just clicked! You can also use chrome: and webedit: commands with it!")',
     tooltip: 'Doesnt do much, just a web edit button example',
   }, // use javascript:, webedit: or chrome: commands for webedit buttons
   {
     header: 'FieldEditButton',
     icon: '/~/icon/Office/16x16/pencil.png',
-    fields: ['heading'],
+    fields: ['applyRedToText', 'sampleList'],
     tooltip: 'Allows you to open field editor for specified fields',
   }, // or use field edit buttons to open Field Editor
 ];

--- a/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
@@ -253,3 +253,11 @@ placeholders:
                 - componentName: Styleguide-EditFrame
                   fields:
                     heading: Edit Frame
+                    description: <p>Who framed Roger Rabbit? Hard to say. <br />
+                     But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
+                     You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+                     </p>
+                    applyRedToText: 0
+                    sampleList:
+                      - id: styleguide-content-list-field-shared-1
+                      - id: styleguide-content-list-field-shared-2

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
@@ -9,7 +9,7 @@ import { CommonFieldTypes, SitecoreIcon, Manifest } from '@sitecore-jss/sitecore
 export default function (manifest) {
   manifest.addComponent({
     name: 'Styleguide-EditFrame',
-    templateName: 'Vue-Styleguide-EditFrame',
+    templateName: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame',
     icon: SitecoreIcon.DocumentTag,
     fields: [
       { name: 'heading', type: CommonFieldTypes.SingleLineText },

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/components/Styleguide-EditFrame.sitecore.js
@@ -11,6 +11,11 @@ export default function (manifest) {
     name: 'Styleguide-EditFrame',
     templateName: 'Vue-Styleguide-EditFrame',
     icon: SitecoreIcon.DocumentTag,
-    fields: [{ name: 'heading', type: CommonFieldTypes.SingleLineText }],
+    fields: [
+      { name: 'heading', type: CommonFieldTypes.SingleLineText },
+      { name: 'description', type: CommonFieldTypes.RichText},
+      { name: 'applyRedToText', type: CommonFieldTypes.Checkbox},
+      { name: 'sampleList', type: CommonFieldTypes.ContentList},
+    ],
   });
 }

--- a/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
+++ b/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
@@ -7,9 +7,17 @@
 <template>
   <styleguide-specimen v-bind="$props" data-e2e-id="styleguide-edit-frame">
     <sc-edit-frame v-bind="editFrameProps">
-      Who framed Roger Rabbit? Hard to say. <br />
-      But JSS now allows to edit frame any piece of content on a page in editing mode. <br />
-      You can add web edit or field edit buttons, modify edit frame style through CSS class and put the frame wherever you need it.
+      This is the content that will be wrapped by edit frame in Experience Editor.<br/>
+      Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
+      Or use field edit buttons to author fields that are not usually editable in Experience Editor.<br/>
+      <br/>
+      <p v-bind:style="textStyle">This text will change color. Use the field edit button to change its appearance</p>
+      This list can be changed via field editor:
+      <ul>
+        <li v-for="(item, index) in $props.fields.sampleList" v-bind:key="index">
+          {{ item.name }}
+        </li>
+      </ul>
     </sc-edit-frame>
   </styleguide-specimen>
 </template>
@@ -35,22 +43,23 @@ export default {
           {
             header: 'WebEditButton',
             icon: '/~/icon/Office/16x16/document_selection.png',
-            click: 'javascript:alert("An edit frame button was just clicked!")',
+            click: 'javascript:alert("An edit frame button was just clicked! You can also use chrome: and webedit: commands with it!")',
             tooltip: 'Doesnt do much, just a web edit button example',
           }, // use javascript:, webedit: or chrome: commands for webedit buttons
           {
             header: 'FieldEditButton',
             icon: '/~/icon/Office/16x16/pencil.png',
-            fields: ['heading'],
+            fields: ['applyRedToText', 'sampleList'],
             tooltip: 'Allows you to open field editor for specified fields',
           }, // or use field edit buttons to open Field Editor
         ],
-        title: 'JSS edit frame',
+        title: 'jssEditFrame',
         tooltip: 'Perform editing anywhere while not tied to a rendering, placeholder or field',
         cssClass: 'jss-edit-frame', // customize edit frame appearance through CSS
         parameters: {}, // set additional parameters when needed
       },
-    };
+      textStyle: this.rendering.fields.applyRedToText ? {color: 'red'}: {color: 'blue'},
+    }; =
   },
   components: {
     StyleguideSpecimen,

--- a/packages/sitecore-jss-react/src/components/EditFrame.tsx
+++ b/packages/sitecore-jss-react/src/components/EditFrame.tsx
@@ -37,9 +37,9 @@ export const EditFrame: React.FC<PropsWithChildren<EditFrameProps>> = ({
   };
 
   const frameProps: Record<string, unknown> = {};
-  frameProps.class = 'scLooseFrameZone';
+  frameProps.className = 'scLooseFrameZone';
   if (cssClass) {
-    frameProps.class = `${frameProps.class} ${cssClass}`;
+    frameProps.className = `${frameProps.className} ${cssClass}`;
   }
 
   // item uri for edit frame target


### PR DESCRIPTION

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Adds a better showcase for edit frame component in Styleguide.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - just manual.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
