### PR TITLE
Revert "Upgrade node to LTS"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ variables:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '18.x'
+    versionSpec: '16.x'
 - script: |
     yarn cache clean --all && yarn install --immutable
   displayName: 'yarn install - initial'


### PR DESCRIPTION
Reverts Sitecore/jss#1353 as it seems to be the reason our canary version builds fail.
