### PR TITLE
[sitecore-jss-nextjs] [Personalize] Don't resolve site in middleware when personalization is not enabled

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -164,14 +164,6 @@ export class PersonalizeMiddleware {
     const pathname = req.nextUrl.pathname;
     const language = req.nextUrl.locale || req.nextUrl.defaultLocale || 'en';
     let siteName = res?.cookies.get('sc_site')?.value;
-    let site;
-
-    if (!siteName) {
-      site = this.config.siteResolver.getByHost(hostname);
-      siteName = site.name;
-    } else {
-      site = this.config.siteResolver.getByName(siteName);
-    }
 
     let browserId = this.getBrowserId(req);
     debug.personalize('personalize middleware start: %o', {
@@ -202,6 +194,15 @@ export class PersonalizeMiddleware {
         response.redirected ? 'redirected' : this.isPreview(req) ? 'preview' : 'route excluded'
       );
       return response;
+    }
+
+    let site;
+
+    if (!siteName) {
+      site = this.config.siteResolver.getByHost(hostname);
+      siteName = site.name;
+    } else {
+      site = this.config.siteResolver.getByName(siteName);
     }
 
     // Get personalization info from Experience Edge


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Resolve site only in case personalization is enabled, otherwise in preview mode newly added site can't be resolved
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
