### PR TITLE
[Next.js] Ensure disconnected JSS config plugin is run before computed plugin

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/scripts/config/plugins/disconnected.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/scripts/config/plugins/disconnected.ts
@@ -5,10 +5,11 @@ import { ConfigPlugin, JssConfig } from '..';
 
 /**
  * This plugin will override the "sitecoreApiHost" config prop
- * for disconnected mode (using disconnected server).
+ * for disconnected mode, ensuring all Sitecore requests are run
+ * through proxy rewrites (see \src\lib\next-config\plugins\disconnected.js).
  */
 class DisconnectedPlugin implements ConfigPlugin {
-  order = 3;
+  order = 2;
 
   async exec(config: JssConfig) {
     const disconnected = process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED;

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -6,7 +6,8 @@ import { ConfigPlugin, JssConfig } from '..';
  * based on other config settings.
  */
 class ComputedPlugin implements ConfigPlugin {
-  order = 2;
+  // should come after other plugins (but before fallback)
+  order = 10;
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/fallback.ts
@@ -5,8 +5,8 @@ import { ConfigPlugin, JssConfig } from '..';
  * If neither env, nor other places had a proper value, this will ensure a fallback is set
  */
 class FallbackPlugin implements ConfigPlugin {
-  // should always comes last
-  order = 99;
+  // should always come last
+  order = 100;
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
The computed JSS config plugin uses the `sitecoreApiHost` prop as part of its computed value for `graphQLEndpoint`. However, the disconnected JSS config plugin was running after this, so the `sitecoreApiHost` was not properly set for disconnected mode. 

This fixes the Graphql endpoint error when running in disconnected mode. Also gives some breathing room with the assigned orders.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
