### PR TITLE
Add separate items for edit frame list demo

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-1
 displayName: EditFrame Demo List Item 1
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.ts
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-1
+displayName: EditFrame Demo List Item 1
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-2
 displayName: EditFrame Demo List Item 2
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.ts
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-2
+displayName: EditFrame Demo List Item 2
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/angular/data/routes/styleguide/en.yml
@@ -265,7 +265,7 @@ placeholders:
                       </p>
                     applyRedToText: 0
                     sampleList:
-                      # see /data/content/Styleguide/ContentListField for definitions of these IDs
-                      - id: styleguide-content-list-field-shared-1
-                      - id: styleguide-content-list-field-shared-2
+                      # see /data/content/Styleguide/EditFrameDemo for definitions of these IDs
+                      - id: styleguide-edit-frame-list-item-1
+                      - id: styleguide-edit-frame-list-item-2
 

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecore.ts
@@ -2,7 +2,7 @@
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**
- * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * This is the data template for an individual _item_ in the Styleguide's Edit Frame component demo.
  * @param {Manifest} manifest Manifest instance to add components to
  */
 export default function (manifest: Manifest) {

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecore.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**

--- a/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecoret.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/sitecore/definitions/templates/styleguide-edit-frame-list-item-template.sitecoret.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-unused-vars
+import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
+
+/**
+ * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * @param {Manifest} manifest Manifest instance to add components to
+ */
+export default function (manifest: Manifest) {
+  manifest.addTemplate({
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template',
+    fields: [{ name: 'title', type: CommonFieldTypes.SingleLineText }],
+  });
+}

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/components/styleguide-edit-frame/styleguide-edit-frame.component.html
@@ -13,7 +13,7 @@
     <p [ngStyle]="{'color': (applyRed ? 'red': 'blue')}">This text will change color. Use the field edit button to change its appearance</p>
     This list can be changed via field editor:
     <ul>
-      <li *ngFor="let contentItem of rendering.fields.sampleList">{{contentItem.name}}</li>
+      <li *ngFor="let contentItem of rendering.fields.sampleList">{{contentItem.fields.title?.value}}</li>
     </ul>
     <ng-content></ng-content>
   </sc-edit-frame>

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-1
 displayName: EditFrame Demo List Item 1
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.ts
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-1
+displayName: EditFrame Demo List Item 1
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-2
 displayName: EditFrame Demo List Item 2
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.ts
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-2
+displayName: EditFrame Demo List Item 2
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/data/routes/styleguide/en.yml
@@ -254,5 +254,6 @@ placeholders:
                      </p>
                     applyRedToText: 0
                     sampleList:
-                      - id: styleguide-content-list-field-shared-1
-                      - id: styleguide-content-list-field-shared-2
+                      # see /data/content/Styleguide/EditFrameDemo for definitions of these IDs
+                      - id: styleguide-edit-frame-list-item-1
+                      - id: styleguide-edit-frame-list-item-2

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.ts
@@ -1,8 +1,7 @@
-// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**
- * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * This is the data template for an individual _item_ in the Styleguide's Edit Frame component demo.
  * @param {Manifest} manifest Manifest instance to add components to
  */
 export default function (manifest: Manifest) {

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecoret.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecoret.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-unused-vars
+import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
+
+/**
+ * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * @param {Manifest} manifest Manifest instance to add components to
+ */
+export default function (manifest: Manifest) {
+  manifest.addTemplate({
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template',
+    fields: [{ name: 'title', type: CommonFieldTypes.SingleLineText }],
+  });
+}

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
@@ -1,4 +1,4 @@
-import { withDatasourceCheck } from '@sitecore-jss/sitecore-jss-nextjs';
+import { Field, Item, withDatasourceCheck } from '@sitecore-jss/sitecore-jss-nextjs';
 import { ComponentProps } from 'lib/component-props';
 import { EditFrame } from '@sitecore-jss/sitecore-jss-nextjs';
 import StyleguideSpecimen from './Styleguide-Specimen';

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-EditFrame.tsx
@@ -22,7 +22,7 @@ type StyleguideEditFrameProps = ComponentProps &
 const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => {
   const applyRed = props.fields.applyRedToText.value;
   return (
-    <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
+    <StyleguideSpecimen {...props} e2eId="styleguide-edit-frame">
       <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
       This is the content that will be wrapped by edit frame in Experience Editor.<br/>
         Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
@@ -32,7 +32,7 @@ const StyleguideEditFrame = (props: StyleguideEditFrameProps): JSX.Element => {
         This list can be changed via field editor:
         <ul>
           {props.fields.sampleList.map((item, idx) => (
-            <li key={idx}>{item.name}</li>
+            <li key={idx}>{item.fields.title?.value}</li>
           ))}
         </ul>
         {props.children}

--- a/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-1
+displayName: EditFrame Demo List Item 1
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-1
 displayName: EditFrame Demo List Item 1
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.js
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-2
+displayName: EditFrame Demo List Item 2
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-2
 displayName: EditFrame Demo List Item 2
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.js
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
@@ -248,7 +248,7 @@ placeholders:
         fields:
           heading: Editing
         placeholders:
-          React-jss-styleguide-section:
+          <%- helper.getAppPrefix(appPrefix, appName) %>jss-styleguide-section:
           - componentName: Styleguide-EditFrame
             fields:
               heading: Edit Frame

--- a/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/react/data/routes/styleguide/en.yml
@@ -258,7 +258,6 @@ placeholders:
                </p>
               applyRedToText: 0
               sampleList:
-                - id: styleguide-content-list-field-shared-1
-                - id: styleguide-content-list-field-shared-2
-
-
+                # see /data/content/Styleguide/EditFrameDemo for definitions of these IDs
+                - id: styleguide-edit-frame-list-item-1
+                - id: styleguide-edit-frame-list-item-2

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-unused-vars
+import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
+
+/**
+ * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * @param {Manifest} manifest Manifest instance to add components to
+ */
+export default function (manifest) {
+  manifest.addTemplate({
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template',
+    fields: [{ name: 'title', type: CommonFieldTypes.SingleLineText }],
+  });
+}

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**

--- a/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/react/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -2,7 +2,7 @@
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**
- * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * This is the data template for an individual _item_ in the Styleguide's Edit Frame component demo.
  * @param {Manifest} manifest Manifest instance to add components to
  */
 export default function (manifest) {

--- a/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/components/Styleguide-EditFrame/index.js
@@ -11,7 +11,7 @@ import StyleguideSpecimen from '../Styleguide-Specimen';
 const StyleguideEditFrame = (props) => {
   const applyRed = props.rendering.fields.applyRedToText?.value;
   return (
-    <StyleguideSpecimen {...props} e2eId="styleguide-editframe">
+    <StyleguideSpecimen {...props} e2eId="styleguide-edit-frame">
       <EditFrame {...getEditFrameProps(props.rendering.dataSource)}>
         This is the content that will be wrapped by edit frame in Experience Editor.<br/>
         Try out the custom webedit buttons for a variety of tasks like executing javascript, or webedit commands. <br/>
@@ -21,7 +21,7 @@ const StyleguideEditFrame = (props) => {
         This list can be changed via field editor:
         <ul>
           {props.rendering.fields.sampleList.map((item, idx) => (
-            <li key={idx}>{item.name}</li>
+            <li key={idx}>{item.fields.title?.value}</li>
           ))}
         </ul>
         {props.children}

--- a/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-1
+displayName: EditFrame Demo List Item 1
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item1/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item1/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-1
 displayName: EditFrame Demo List Item 1
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.js
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 1

--- a/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,0 +1,6 @@
+id: styleguide-edit-frame-list-item-2
+displayName: EditFrame Demo List Item 2
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
+fields:
+  title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item2/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/content/Styleguide/EditFrameDemo/Item2/en.yml
@@ -1,6 +1,6 @@
 id: styleguide-edit-frame-list-item-2
 displayName: EditFrame Demo List Item 2
-# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-ContentList-Template.sitecore.js
+# Template defines the available fields. See /sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.js
 template: <%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template
 fields:
   title: Edit Frame Demo List Item 2

--- a/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
@@ -259,5 +259,6 @@ placeholders:
                      </p>
                     applyRedToText: 0
                     sampleList:
-                      - id: styleguide-content-list-field-shared-1
-                      - id: styleguide-content-list-field-shared-2
+                      # see /data/content/Styleguide/EditFrameDemo for definitions of these IDs
+                      - id: styleguide-edit-frame-list-item-1
+                      - id: styleguide-edit-frame-list-item-2

--- a/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
+++ b/packages/create-sitecore-jss/src/templates/vue/data/routes/styleguide/en.yml
@@ -249,7 +249,7 @@ placeholders:
             fields:
               heading: Editing
             placeholders:
-              Vue-jss-styleguide-section:
+              <%- helper.getAppPrefix(appPrefix, appName) %>jss-styleguide-section:
                 - componentName: Styleguide-EditFrame
                   fields:
                     heading: Edit Frame

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line no-unused-vars
+import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
+
+/**
+ * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * @param {Manifest} manifest Manifest instance to add components to
+ */
+export default function (manifest) {
+  manifest.addTemplate({
+    name: '<%- helper.getAppPrefix(appPrefix, appName) %>Styleguide-EditFrame-ListItem-Template',
+    fields: [{ name: 'title', type: CommonFieldTypes.SingleLineText }],
+  });
+}

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**

--- a/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
+++ b/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/templates/Styleguide-EditFrame-ListItem-Template.sitecore.js
@@ -2,7 +2,7 @@
 import { CommonFieldTypes, Manifest } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 /**
- * This is the data template for an individual _item_ in the Styleguide's Content List field demo.
+ * This is the data template for an individual _item_ in the Styleguide's Edit Frame component demo.
  * @param {Manifest} manifest Manifest instance to add components to
  */
 export default function (manifest) {

--- a/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
+++ b/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
@@ -59,7 +59,7 @@ export default {
         parameters: {}, // set additional parameters when needed
       },
       textStyle: this.rendering.fields.applyRedToText ? {color: 'red'}: {color: 'blue'},
-    }; =
+    };
   },
   components: {
     StyleguideSpecimen,

--- a/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
+++ b/packages/create-sitecore-jss/src/templates/vue/src/components/Styleguide/Styleguide-EditFrame.vue
@@ -15,7 +15,7 @@
       This list can be changed via field editor:
       <ul>
         <li v-for="(item, index) in $props.fields.sampleList" v-bind:key="index">
-          {{ item.name }}
+          {{ item.fields.title?.value }}
         </li>
       </ul>
     </sc-edit-frame>
@@ -58,7 +58,7 @@ export default {
         cssClass: 'jss-edit-frame', // customize edit frame appearance through CSS
         parameters: {}, // set additional parameters when needed
       },
-      textStyle: this.rendering.fields.applyRedToText ? {color: 'red'}: {color: 'blue'},
+      textStyle: this.fields.applyRedToText?.value ? {color: 'red'}: {color: 'blue'},
     };
   },
   components: {


### PR DESCRIPTION
Edit Frame demo in styleguide reused items from Content List. It will now has its own set of items to avoid conflicts. 
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Testing Details

- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - just manual

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
