### PR TITLE
[Nextjs][Personalize] Don't resolve site in CdpPageView when it's disabled

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
@@ -20,8 +20,6 @@ const CdpPageView = (): JSX.Element => {
     sitecoreContext: { pageState, route, variantId, site },
   } = useSitecoreContext();
 
-  const siteName = site?.name || config.jssAppName;
-
   /**
    * Creates a page view event using the Sitecore Engage SDK.
    */
@@ -72,11 +70,11 @@ const CdpPageView = (): JSX.Element => {
       return;
     }
 
-    const siteInfo = siteResolver.getByName(siteName);
+    const siteInfo = siteResolver.getByName(site?.name || config.jssAppName);
     const language = route.itemLanguage || config.defaultLanguage;
     const pageVariantId = CdpHelper.getPageVariantId(route.itemId, language, variantId as string);
     createPageView(route.name, language, siteInfo, pageVariantId);
-  }, [pageState, route, variantId, siteName]);
+  }, [pageState, route, variantId, site]);
 
   return <></>;
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/components/CdpPageView.tsx
@@ -21,7 +21,6 @@ const CdpPageView = (): JSX.Element => {
   } = useSitecoreContext();
 
   const siteName = site?.name || config.jssAppName;
-  const siteInfo = siteResolver.getByName(siteName);
 
   /**
    * Creates a page view event using the Sitecore Engage SDK.
@@ -72,10 +71,12 @@ const CdpPageView = (): JSX.Element => {
     if (disabled()) {
       return;
     }
+
+    const siteInfo = siteResolver.getByName(siteName);
     const language = route.itemLanguage || config.defaultLanguage;
     const pageVariantId = CdpHelper.getPageVariantId(route.itemId, language, variantId as string);
     createPageView(route.name, language, siteInfo, pageVariantId);
-  }, [pageState, route, variantId, siteInfo]);
+  }, [pageState, route, variantId, siteName]);
 
   return <></>;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
The site can't be resolved in editing mode, so don't need to execute this logic
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
