### PR TITLE
[Vue] Timeout error when opening graphql page in Experience Editor

### DIFF
--- a/packages/create-sitecore-jss/src/templates/vue/package.json
+++ b/packages/create-sitecore-jss/src/templates/vue/package.json
@@ -49,7 +49,7 @@
     "@apollo/client": "^3.7.4",
     "@panter/vue-i18next": "~0.15.2",
     "@sitecore-jss/sitecore-jss-vue": "^21.1.0-canary",
-    "@vue/apollo-composable": "^4.0.0-beta.1",
+    "@vue/apollo-composable": "4.0.0-beta.2",
     "@vue/apollo-option": "^4.0.0-alpha.20",
     "@vue/apollo-ssr": "^4.0.0-alpha.18",
     "@vue/server-renderer": "^3.2.45",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Using SSR latest apollo-composable (beta.4) brings _useQuery_ related errors. See es imports related issue https://github.com/vuejs/apollo/issues/1462. For now version can be fixed to apollo-composable@4.0.0.beta.2 - since it's beta.

```
ERROR TypeError: (0 , lib_namespaceObject.getCurrentInstance) is not a function
    at useQueryImpl (C:\inetpub\wwwroot\dist\sitecore-jss-app\server.bundle.js:106509:56)
    at useQuery (C:\inetpub\wwwroot\dist\sitecore-jss-app\server.bundle.js:106505:10)
```

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
