### PR TITLE
[Vue] Fix local dev server launch error

### DIFF
--- a/packages/create-sitecore-jss/src/templates/vue/package.json
+++ b/packages/create-sitecore-jss/src/templates/vue/package.json
@@ -36,7 +36,7 @@
     "start:connected": "npm-run-all --serial bootstrap start:vue start:watch-components",
     "build": "npm-run-all --serial bootstrap build:client build:server",
     "scaffold": "node scripts/scaffold-component.js",
-    "start:vue": "vue-cli-service serve --open",
+    "start:vue": "vue-cli-service serve --open --host localhost",
     "start:proxy": "node scripts/disconnected-mode-proxy.js",
     "start:watch-components": "node scripts/generate-component-factory.js --watch",
     "build:client": "cross-env-shell BUILD_TARGET_ENV=client PUBLIC_URL=$npm_package_config_sitecoreDistPath \"vue-cli-service build\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When starting the Vue app in connected mode the local dev server automatically starts at `0.0.0.0:3000` which has a wrong hostname.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
