### PR TITLE
[React][Hotfix] Fix duplicate hash in links for react in JSS 19

### DIFF
--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -11,6 +11,7 @@ export interface LinkFieldValue {
   text?: string;
   anchor?: string;
   querystring?: string;
+  linktype?: string;
 }
 
 export interface LinkField {
@@ -95,7 +96,7 @@ export const Link: React.SFC<LinkProps> = ({
     return null;
   }
 
-  const anchor = link.anchor ? `#${link.anchor}` : '';
+  const anchor = link.linktype !== 'anchor' && link.anchor ? `#${link.anchor}` : '';
   const querystring = link.querystring ? `?${link.querystring}` : '';
 
   const anchorAttrs: { [attr: string]: unknown } = {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Fixes an issue when anchor type links would render hash twice.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - tested for React in Preview and normal modes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
