### PR TITLE
[sitecore-jss-nextjs] Redirects middleware should debug log start/end

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -136,6 +136,10 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req, res);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/styleguide',
+        });
+
         validateDebugLog('skipped (%s)', 'preview');
 
         expect(finalRes).to.deep.equal(res);
@@ -152,6 +156,10 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/styleguide',
+        });
 
         validateDebugLog('skipped (%s)', 'preview');
 
@@ -171,7 +179,13 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req, res);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname,
+        });
+
         validateDebugLog('skipped (%s)', 'route excluded');
+
+        debugSpy.resetHistory();
 
         expect(finalRes).to.deep.equal(res);
       };
@@ -214,6 +228,10 @@ describe('RedirectsMiddleware', () => {
       const { middleware } = createMiddleware(props);
       const finalRes = await middleware.getHandler()(req);
 
+      validateDebugLog('redirects middleware start: %o', {
+        pathname: '/styleguide',
+      });
+
       validateDebugLog('skipped (redirects middleware is disabled)');
 
       expect(finalRes).to.deep.equal(res);
@@ -229,6 +247,10 @@ describe('RedirectsMiddleware', () => {
       const req = createRequest();
       const { middleware, fetchRedirects, siteResolver } = createMiddleware();
       const finalRes = await middleware.getHandler()(req);
+
+      validateDebugLog('redirects middleware start: %o', {
+        pathname: '/styleguide',
+      });
 
       validateDebugLog('skipped (redirect does not exist)');
 
@@ -275,6 +297,15 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
+
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
@@ -318,6 +349,15 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/ua/found',
+          siteName,
+        });
+
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
@@ -360,6 +400,15 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req);
+
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found?abc=def',
+          siteName,
+        });
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
@@ -405,6 +454,15 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
+
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
@@ -443,6 +501,15 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req);
+
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
@@ -484,6 +551,15 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
+
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
@@ -516,6 +592,15 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req, res);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
+
         expect(siteResolver.getByHost).not.called.to.equal(true);
         expect(siteResolver.getByName).to.be.calledWith(siteName);
         expect(fetchRedirects).to.be.calledWith(siteName);
@@ -546,6 +631,16 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName: site,
+        });
+
         expect(siteResolver.getByHost).to.not.be.called;
         expect(siteResolver.getByName).to.be.calledWith(site);
         expect(fetchRedirects.called).to.be.true;
@@ -576,6 +671,10 @@ describe('RedirectsMiddleware', () => {
         });
 
         const finalRes = await middleware.getHandler()(req, res);
+
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
 
         validateDebugLog('skipped (redirects middleware is disabled)');
 
@@ -623,7 +722,16 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
         validateDebugLog('host header is missing, default localhost is used');
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
 
         expect(siteResolver.getByHost).to.be.calledWith('localhost');
         expect(fetchRedirects).to.be.calledWith(siteName);
@@ -672,7 +780,16 @@ describe('RedirectsMiddleware', () => {
 
         const finalRes = await middleware.getHandler()(req);
 
+        validateDebugLog('redirects middleware start: %o', {
+          pathname: '/not-found',
+        });
+
         validateDebugLog('host header is missing, default foobar is used');
+
+        validateDebugLog('redirects middleware end: %o', {
+          redirectUrl: 'http://localhost:3000/found',
+          siteName,
+        });
 
         expect(siteResolver.getByHost).to.be.calledWith('foobar');
         expect(fetchRedirects).to.be.calledWith(siteName);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -55,6 +55,12 @@ export class RedirectsMiddleware extends MiddlewareBase {
     let site: SiteInfo | undefined;
 
     const createResponse = async () => {
+      const pathname = req.nextUrl.pathname;
+
+      debug.redirects('redirects middleware start: %o', {
+        pathname,
+      });
+
       if (!this.getHostHeader(req)) {
         debug.redirects(`host header is missing, default ${this.defaultHostname} is used`);
       }
@@ -64,7 +70,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
         return res || NextResponse.next();
       }
 
-      if (this.isPreview(req) || this.excludeRoute(req.nextUrl.pathname)) {
+      if (this.isPreview(req) || this.excludeRoute(pathname)) {
         debug.redirects('skipped (%s)', this.isPreview(req) ? 'preview' : 'route excluded');
 
         return res || NextResponse.next();
@@ -98,6 +104,11 @@ export class RedirectsMiddleware extends MiddlewareBase {
       }
 
       const redirectUrl = decodeURIComponent(url.href);
+
+      debug.redirects('redirects middleware end: %o', {
+        redirectUrl,
+        siteName: site.name,
+      });
 
       /** return Response redirect with http code of redirect type **/
       switch (existsRedirect.redirectType) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Added start/end logs for Redirects middleware
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
