### PR TITLE
[react][nextjs] Fix double hash in anchor links

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -187,6 +187,22 @@ describe('<Link />', () => {
     expect(c.find(ReactLink).length).to.equal(0);
   });
 
+  it('should not add extra hash when linktype is anchor', () => {
+    const field = {
+      linktype: 'anchor',
+      href: '#anchor',
+      text: 'anchor link',
+      anchor: 'anchor',
+    };
+    const rendered = mount(
+      <Page>
+        <Link field={field} />
+      </Page>
+    ).find('a');
+    expect(rendered.html()).to.contain(`href="${field.href}"`);
+    expect(rendered.text()).to.equal(field.text);
+  });
+
   it('should render NextLink using internalLinkMatcher', () => {
     const field = {
       value: {

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 
 import { Link, LinkField } from './Link';
 import { generalLinkField as eeLinkData } from '../test-data/ee-data';
+import { it } from 'node:test';
 
 describe('<Link />', () => {
   it('should render nothing with missing field', () => {
@@ -49,6 +50,18 @@ describe('<Link />', () => {
     const rendered = mount(<Link field={field} />).find('a');
     expect(rendered.html()).to.contain(field.href);
     expect(rendered.html()).to.contain(field.text);
+  });
+  
+  it('should not add extra hash when linktype is anchor', () => {
+    const field = {
+      linktype: 'anchor',
+      href: '#anchor',
+      text: 'anchor link',
+      anchor: "anchor",
+    };
+    const rendered = mount(<Link field={field} />).find('a');
+    expect(rendered.html()).to.contain(`href="${field.href}"`);
+    expect(rendered.text()).to.equal(field.text);
   });
 
   it('should render ee HTML', () => {

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -51,13 +51,13 @@ describe('<Link />', () => {
     expect(rendered.html()).to.contain(field.href);
     expect(rendered.html()).to.contain(field.text);
   });
-  
+
   it('should not add extra hash when linktype is anchor', () => {
     const field = {
       linktype: 'anchor',
       href: '#anchor',
       text: 'anchor link',
-      anchor: "anchor",
+      anchor: 'anchor',
     };
     const rendered = mount(<Link field={field} />).find('a');
     expect(rendered.html()).to.contain(`href="${field.href}"`);

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -12,6 +12,7 @@ export interface LinkFieldValue {
   text?: string;
   anchor?: string;
   querystring?: string;
+  linktype?: string;
 }
 
 export interface LinkField {
@@ -95,7 +96,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       return null;
     }
 
-    const anchor = link.anchor ? `#${link.anchor}` : '';
+    const anchor = link.linktype !== 'anchor' && link.anchor ? `#${link.anchor}` : '';
     const querystring = link.querystring ? `?${link.querystring}` : '';
 
     const anchorAttrs: { [attr: string]: unknown } = {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Fixes an issue where 'anchor' type links would be incorrectly rendered.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
