### PR TITLE
[Hotfix] Fix #573146 on top of JSS 19

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -189,6 +189,22 @@ describe('<Link />', () => {
     expect(c.find(ReactLink).length).to.equal(0);
   });
 
+  it('should not add extra hash when linktype is anchor', () => {
+    const field = {
+      linktype: 'anchor',
+      href: '#anchor',
+      text: 'anchor link',
+      anchor: 'anchor',
+    };
+    const rendered = mount(
+      <Page>
+        <Link field={field} />
+      </Page>
+    ).find('a');
+    expect(rendered.html()).to.contain(`href="${field.href}"`);
+    expect(rendered.text()).to.equal(field.text);
+  });
+
   it('should render NextLink using internalLinkMatcher', () => {
     const field = {
       value: {

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -51,6 +51,18 @@ describe('<Link />', () => {
     expect(rendered.html()).to.contain(field.text);
   });
 
+  it('should not add extra hash when linktype is anchor', () => {
+    const field = {
+      linktype: 'anchor',
+      href: '#anchor',
+      text: 'anchor link',
+      anchor: 'anchor',
+    };
+    const rendered = mount(<Link field={field} />).find('a');
+    expect(rendered.html()).to.contain(`href="${field.href}"`);
+    expect(rendered.text()).to.equal(field.text);
+  });
+
   it('should render ee HTML', () => {
     const field = {
       editableFirstPart: eeLinkData,

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -11,6 +11,7 @@ export interface LinkFieldValue {
   text?: string;
   anchor?: string;
   querystring?: string;
+  linktype?: string;
 }
 
 export interface LinkField {
@@ -95,7 +96,7 @@ export const Link: React.SFC<LinkProps> = ({
     return null;
   }
 
-  const anchor = link.anchor ? `#${link.anchor}` : '';
+  const anchor = link.linktype !== 'anchor' && link.anchor ? `#${link.anchor}` : '';
   const querystring = link.querystring ? `?${link.querystring}` : '';
 
   const anchorAttrs: { [attr: string]: unknown } = {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Add the fix for double hash links (https://github.com/Sitecore/jss/pull/1375) into JSS v19.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
