### PR TITLE
[v19] Ensure node version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,9 @@ variables:
     branchName: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
 
 steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '16.x'
   - script: |
       npm ci
     displayName: 'npm ci'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,6 @@ steps:
       npm ci
     displayName: 'npm ci'
   - script: |
-      node -v
-      npm --version
-    displayName: 'node version'
-  - script: |
       npm run bootstrap:ci
     displayName: 'bootstrapping packages'
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,10 @@ steps:
       npm ci
     displayName: 'npm ci'
   - script: |
+      node -v
+      npm --version
+    displayName: 'node version'
+  - script: |
       npm run bootstrap:ci
     displayName: 'bootstrapping packages'
   - script: |


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Sets node version to 16 for v19 branch. This ensures the branch builds in Azure Pipelines.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
