### PR TITLE
[nextjs] Prefer wildcard fallback for point of sale resolution

### DIFF
--- a/packages/sitecore-jss/src/personalize/pos-resolver.test.ts
+++ b/packages/sitecore-jss/src/personalize/pos-resolver.test.ts
@@ -29,7 +29,23 @@ describe('resolvePointOfSale', () => {
     expect(result).to.equal(myPoint);
   });
 
-  it('should return pos for site language as first backup', () => {
+  it('should use fallback wildcard value as first backup', () => {
+    const site: SiteInfo = {
+      name: 'apos',
+      hostName: 'www.apos.com',
+      pointOfSale: {
+        'de-DE': 'depos.com',
+        'es-ES': 'espos.com',
+        '*': 'fallpos.com',
+      },
+      language: 'de-DE',
+    };
+
+    const result = PosResolver.resolve(site, 'en');
+    expect(result).to.equal('fallpos.com');
+  });
+
+  it('should return pos for site language as second backup', () => {
     const site: SiteInfo = {
       name: 'apos',
       hostName: 'www.apos.com',
@@ -57,21 +73,5 @@ describe('resolvePointOfSale', () => {
 
     const result = PosResolver.resolve(site, '');
     expect(result).to.equal('depos.com');
-  });
-
-  it('should use fallback value when other values missing', () => {
-    const site: SiteInfo = {
-      name: 'apos',
-      hostName: 'www.apos.com',
-      pointOfSale: {
-        'de-DE': 'depos.com',
-        'es-ES': 'espos.com',
-        '*': 'fallpos.com',
-      },
-      language: 'en-CA',
-    };
-
-    const result = PosResolver.resolve(site, 'en');
-    expect(result).to.equal('fallpos.com');
   });
 });

--- a/packages/sitecore-jss/src/personalize/pos-resolver.ts
+++ b/packages/sitecore-jss/src/personalize/pos-resolver.ts
@@ -3,7 +3,7 @@ import { SiteInfo } from '../site';
 export class PosResolver {
   static resolve = (site: SiteInfo, language: string) => {
     return site.pointOfSale
-      ? site.pointOfSale[language] || site.pointOfSale[site.language] || site.pointOfSale['*']
+      ? site.pointOfSale[language] || site.pointOfSale['*'] || site.pointOfSale[site.language]
       : '';
   };
 }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
Point of sale would default to site language value over wildcard fallback value before.
This PR ensures wildcard is used as first fallback.

## Testing Details
- [x] Unit Test Added (amended)
- [ ] Manual Test/Other (Please elaborate)

