### PR TITLE
[Vue] Fix for bug in Link component child check

### DIFF
--- a/packages/sitecore-jss-vue/src/components/Link.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.ts
@@ -93,7 +93,7 @@ export const Link = defineComponent({
     }
 
     const linkText =
-      showLinkTextWithChildrenPresent || !children || children.length === 0
+      showLinkTextWithChildrenPresent || !children || children().length === 0
         ? link.text || link.href
         : null;
 


### PR DESCRIPTION
If the "children" function is defined it will always have a length of 0. This check needs to check the length of the output of the children function, instead of the length of the function.

Without this fix the template will always render the linkText before the children elements if they are present.



<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current render of:
```vue
<sc-link :field="linkItem.fields.Link">
    <em>This tag should be the only thing in the a tag</em>
</sc-link>
```

will show as:
```html
<a class="" href="https://somelink" title="" target="">
    Text from the Sitecore Link Description field or the href
    <em">This tag should be the only thing in the a tag</em>
</a>
```

By applying this fix it will show as:
```html
<a class="" href="https://somelink" title="" target="">
    <em">This tag should be the only thing in the a tag</em>
</a>
```
as expected.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)


Import Link as ScLink
Put a sc link element with child elements in a vue template and populate it with a Sitecore link.
Example:
```vue
<template>
...
<sc-link :field="linkItem.fields.Link">
    <em>This tag should be the only thing in the a tag</em>
</sc-link>
...
</template>

<script setup lang="ts">
import { Link as ScLink } from '@sitecore-jss/sitecore-jss-vue'
...
</script>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
