### PR TITLE
[nextjs-sxa] update comments on rootitemid

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
@@ -22,8 +22,10 @@ export class DictionaryServiceFactory {
           siteName,
           /*
             The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current
-            app. If your Sitecore instance only has 1 JSS App, you can specify the root item ID here;
-            otherwise, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
+            app. 
+            When not provided, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
+            For SXA site(s) and multisite setup there's no need to specify it - it will be autoresolved.
+            Otherwise, if your Sitecore instance only has 1 JSS App (i.e. in a Sitecore XP setup), you can specify the root item ID here;
             rootItemId: '{GUID}'
           */
         })

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
@@ -21,11 +21,10 @@ export class DictionaryServiceFactory {
           apiKey: config.sitecoreApiKey,
           siteName,
           /*
-            The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current
-            app. 
+            The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current app. 
             When not provided, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
             For SXA site(s) and multisite setup there's no need to specify it - it will be autoresolved.
-            Otherwise, if your Sitecore instance only has 1 JSS App (i.e. in a Sitecore XP setup), you can specify the root item ID here;
+            Otherwise, if your Sitecore instance only has 1 JSS App (i.e. in a Sitecore XP setup), you can specify the root item ID here.
             rootItemId: '{GUID}'
           */
         })


### PR DESCRIPTION
This simply updates comments on rootItemId usage for DictionaryService.

Following SXA changes, rootItemId should be autoresolved for SXA sites in XM Cloud. 