### PR TITLE
Fix memory leak for sclink scimage

### DIFF
--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -135,6 +135,7 @@ export class ImageDirective implements OnChanges {
     const view = this.templateRef.createEmbeddedView(null);
     const element: Element = view.rootNodes[0];
     if (!element) {
+      view.destroy();
       return {};
     }
     const attrs: { [key: string]: string } = {};
@@ -144,6 +145,7 @@ export class ImageDirective implements OnChanges {
         attrs[attr.name] = attr.value;
       }
     }
+    view.destroy();
     return attrs;
   }
 

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -112,6 +112,7 @@ export class LinkDirective implements OnChanges {
     const view = this.templateRef.createEmbeddedView(null);
     const element: Element = view.rootNodes[0];
     if (!element) {
+      view.destroy();
       return {};
     }
     const attrs: { [key: string]: string } = {};
@@ -121,6 +122,7 @@ export class LinkDirective implements OnChanges {
         attrs[attr.name] = attr.value;
       }
     }
+    view.destroy();
     return attrs;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We noticed memory leak with scImage and scLink. found we do not destory the views.

PLEASE backport to 16.0.x if possible. Thanks

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
