### PR TITLE
[Vue] Disconnected mode doesn't start in monorepo

### DIFF
--- a/packages/create-sitecore-jss/src/templates/vue/scripts/disconnected-mode-proxy.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/disconnected-mode-proxy.js
@@ -25,7 +25,6 @@ const proxyOptions = {
   watchPaths: ['./data'],
   language: config.defaultLanguage,
   port: process.env.PROXY_PORT || 3042,
-  requireArg: '@babel/register',
   onManifestUpdated: () => {
     // if we can resolve the config file, we can alter it to force reloading the app automatically
     // instead of waiting for a manual reload. We must materially alter the _contents_ of the file to trigger


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)

## Description / Motivation
In case _requireArg_ is not provided, the disconnected server manifest generation is started using [sitecore/definitions/config.js](https://github.com/Sitecore/jss/blob/dev/packages/create-sitecore-jss/src/templates/vue/sitecore/definitions/config.js) transpiler, that is working fine for us (and uses same the _@babel/register_ package).

As a worst case it would be possible to work around that by using `path.resolve(process.cwd(), 'node_modules/@babel/register')`. Since in monorepo some packages can be placed in the root _node_modules_ it's required to provide exact path if module imported from a different package, like [here](https://github.com/Sitecore/jss/blob/dev/packages/sitecore-jss-dev-tools/src/manifest/generator/generate.ts#L56)

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
