### PR TITLE
[Next.js] Fix for Link component which throws error if field is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs]` `[templates/nextjs-styleguide-tracking]` Move remaining Styleguide-Tracking artifacts from the base template ([#1422](https://github.com/Sitecore/jss/pull/1422))
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextjs]` Fix for Link component which throws error if field is undefined ([#1425](https://github.com/Sitecore/jss/pull/1425))
+
 ## 21.1.0
 
 ### 🎉 New Features & Improvements

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -1,7 +1,7 @@
 import React, { createRef, ReactNode } from 'react';
 import { NextRouter } from 'next/router';
 import NextLink from 'next/link';
-import { Link as ReactLink } from '@sitecore-jss/sitecore-jss-react';
+import { Link as ReactLink, LinkField } from '@sitecore-jss/sitecore-jss-react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
@@ -313,5 +313,51 @@ describe('<Link />', () => {
 
     const link = c.find('a');
     expect(ref.current.id).to.equal(link.props().id);
+  });
+
+  it('should render ReactLink if editable', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+      },
+      editable: '<a href="/lorem">Lorem</a>',
+    };
+    const rendered = mount(
+      <Page>
+        <Link field={field} />
+      </Page>
+    );
+    expect(rendered.find(NextLink).length).to.equal(0);
+    expect(rendered.find(ReactLink).length).to.equal(1);
+  });
+
+  it('should render NextLink with editing explicitly disabled', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+      },
+      editable: '<a href="/lorem">Lorem</a>',
+    };
+    const rendered = mount(
+      <Page>
+        <Link field={field} editable={false} />
+      </Page>
+    );
+    expect(rendered.find(NextLink).length).to.equal(1);
+    expect(rendered.find(ReactLink).length).to.equal(0);
+  });
+
+  it('should render nothing with missing field', () => {
+    const field = (null as unknown) as LinkField;
+    const rendered = mount(<Link field={field} />).children();
+    expect(rendered).to.have.length(0);
+  });
+
+  it('should render nothing with missing editable and value', () => {
+    const field = {};
+    const rendered = mount(<Link field={field} />).children();
+    expect(rendered).to.have.length(0);
   });
 });

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -18,7 +18,7 @@ export type LinkProps = ReactLinkProps & {
 };
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props: LinkProps, ref): JSX.Element => {
+  (props: LinkProps, ref): JSX.Element | null => {
     const {
       field,
       editable,
@@ -27,6 +27,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       showLinkTextWithChildrenPresent,
       ...htmlLinkProps
     } = props;
+
+    if (
+      !field ||
+      (!(field as LinkFieldValue).editable && !field.value && !(field as LinkFieldValue).href)
+    ) {
+      return null;
+    }
 
     const value = ((field as LinkFieldValue).href
       ? field

--- a/packages/sitecore-jss-react/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.test.tsx
@@ -7,7 +7,7 @@ import { generalLinkField as eeLinkData } from '../test-data/ee-data';
 
 describe('<Link />', () => {
   it('should render nothing with missing field', () => {
-    const field = null as LinkField;
+    const field = (null as unknown) as LinkField;
     const rendered = mount(<Link field={field} />).children();
     expect(rendered).to.have.length(0);
   });


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
- Fixes an issue with nextjs Link component where build throws TypeError when field is undefined
- Also added a couple additional tests for editing use cases

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
