### PR TITLE
[FEaaS][nextjs-sxa] Fetch revision based on page state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs-personalize]` Disable page view tracking event in development ([#1414](https://github.com/Sitecore/jss/pull/1414))
 * `[templates/nextjs-sxa]` Add custom template for _jss scaffold_ ([#1420](https://github.com/Sitecore/jss/pull/1420))
+* `[sitecore-jss-react]` `[sitecore-jss-nextjs]` FEaaS component will render 'staged' variant for editing and preview and 'published' variant for live site by default, unless variant is overriden via rendering parameters. ([#1433](https://github.com/Sitecore/jss/pull/1433))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/FEaaSWrapper.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/FEaaSWrapper.tsx
@@ -27,12 +27,12 @@ export const Default = (props: FEaaSComponentProps): JSX.Element => {
  * @param {LayoutServiceData} layoutData
  * @param {GetStaticPropsContext} context
  */
-export const getStaticProps: GetStaticComponentProps = async (rendering) => {
+export const getStaticProps: GetStaticComponentProps = async (rendering, layoutData) => {
   if (process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED) {
     return null;
   }
   const params: FEaaSComponentParams = rendering.params || {};
-  const result = await fetchFEaaSComponentServerProps(params);
+  const result = await fetchFEaaSComponentServerProps(params, layoutData.sitecore.context.pageState);
   return result;
 };
 
@@ -42,11 +42,11 @@ export const getStaticProps: GetStaticComponentProps = async (rendering) => {
  * @param {LayoutServiceData} layoutData
  * @param {GetStaticPropsContext} context
  */
-export const getServerSideProps: GetServerSideComponentProps = async (rendering) => {
+export const getServerSideProps: GetServerSideComponentProps = async (rendering, layoutData) => {
   if (process.env.JSS_MODE === constants.JSS_MODE.DISCONNECTED) {
     return null;
   }
   const params: FEaaSComponentParams = rendering.params || {};
-  const result = await fetchFEaaSComponentServerProps(params);
+  const result = await fetchFEaaSComponentServerProps(params, layoutData.sitecore.context.pageState);
   return result;
 };

--- a/packages/sitecore-jss-react/src/components/FEaaSComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/components/FEaaSComponent.test.tsx
@@ -20,8 +20,17 @@ describe('<FEaaSComponent />', () => {
 
   describe('composeComponentEndpoint', () => {
     it('should return endpoint with https when hostname from params is missing it', () => {
-      const endpoint = composeComponentEndpoint(requiredParams);
+      const endpoint = composeComponentEndpoint(requiredParams, 'staged');
       expect(endpoint.startsWith('https://')).to.equal(true);
+    });
+
+    it('should use fallback when variant is not passed via params', () => {
+      const params = {
+        ...requiredParams,
+        ComponentRevision: undefined,
+      };
+      const endpoint = composeComponentEndpoint(params, 'published');
+      expect(endpoint.endsWith('/published')).to.equal(true);
     });
   });
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
FEaaS Components follow a lifecycle different from Sitecore items so Layout Service will not always provide JSS apps with the correct component revision to show. 
This PR puts revision resolution into JSS logic:

- In editing and preview modes, 'staged' FEaaS variants should be rendered by default;
- Variant can be overridden via ComponentRevision rendering parameter field from a FEaaS rendering.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - connected mode tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
