### PR TITLE
[Nextjs][Multisite] Fix skipped site info fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fix for Link component which throws error if field is undefined ([#1425](https://github.com/Sitecore/jss/pull/1425))
 * `[templates/react]` Fix compilation error when developing react template in monorepo ([#1428](https://github.com/Sitecore/jss/pull/1428))
 * `[sitecore-jss-nextjs]` Fix regex for middleware redirects ([#1431](https://github.com/Sitecore/jss/pull/1431))
+* `[templates/nextjs-multisite]` Fix skipped site info fetch ([#1434](https://github.com/Sitecore/jss/pull/1434))
 
 ## 21.1.0
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -8,7 +8,7 @@ import { GraphQLSiteInfoService, SiteInfo } from '@sitecore-jss/sitecore-jss-nex
  * You could easily modify this to fetch from another source such as a static JSON file instead.
  */
 class MultisitePlugin implements ConfigPlugin {
-  order = 3;
+  order = 4;
 
   async exec(config: JssConfig) {
     let sites: SiteInfo[] = [];

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -8,7 +8,7 @@ import { GraphQLSiteInfoService, SiteInfo } from '@sitecore-jss/sitecore-jss-nex
  * You could easily modify this to fetch from another source such as a static JSON file instead.
  */
 class MultisitePlugin implements ConfigPlugin {
-  order = 4;
+  order = 11;
 
   async exec(config: JssConfig) {
     let sites: SiteInfo[] = [];

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -11,8 +11,7 @@ class ComputedPlugin implements ConfigPlugin {
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {
-      graphQLEndpoint:
-        config.graphQLEndpoint || `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
+      graphQLEndpoint: config.graphQLEndpoint || `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
     });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -7,7 +7,7 @@ import { ConfigPlugin, JssConfig } from '..';
  */
 class ComputedPlugin implements ConfigPlugin {
   // should come after other plugins (but before fallback)
-  order = 3;
+  order = 10;
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/config/plugins/computed.ts
@@ -7,11 +7,12 @@ import { ConfigPlugin, JssConfig } from '..';
  */
 class ComputedPlugin implements ConfigPlugin {
   // should come after other plugins (but before fallback)
-  order = 10;
+  order = 3;
 
   async exec(config: JssConfig) {
     return Object.assign({}, config, {
-      graphQLEndpoint: config.graphQLEndpoint || `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
+      graphQLEndpoint:
+        config.graphQLEndpoint || `${config.sitecoreApiHost}${config.graphQLEndpointPath}`,
     });
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When working with nextjs and multisite the config value for graphqlEndpoint and apiKey comes out undefined because multisite config plugin runs before the computed config plugin.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
