### PR TITLE
[angular] Fix angular app build failure

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -131,13 +131,16 @@
   },
   "//": [
     "overrides (for npm) and resolutions (for yarn) used to work around the bug in critters that affect bootstrap: https://github.com/GoogleChromeLabs/critters/issues/103",
-    "both sections can be removed once critters and css-select versions are updated in build-angular"
+    "both sections can be removed once critters and css-select versions are updated in build-angular",
+    "for webpack, we use lower version to fix the angular/webpack bug: https://github.com/webpack/webpack/issues/16981 that prevents project from building",
+    "remove webpack override when upgrading Angular to next major version"
   ],
   "overrides": {
     "@angular-devkit/build-angular": {
       "critters": {
         "css-select": "4.2.1"
-      }
+      },
+      "webpack": "5.78.0"
     }
   },
   "resolutions": {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
This is a workaround for https://github.com/webpack/webpack/issues/16981
build-angular would automatically load webpack version 5.80 (or later), however it causes angular app build to fail. 
This does not happen with older node and npm versions (16, 6.x respectively) for some reason, but does reproduce with nodejs 18.x. 

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - test inside and outside of monorepo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
