### PR TITLE
[v16] Ensure pipeline uses an ubuntu image that exists

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,7 @@ pr:
       - docs/*
 
 pool:
-  # todo: we dgaf what specific version of Linux is installed, is there any way to wildcard the version?
-  vmImage: 'Ubuntu-16.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   isDev: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]


### PR DESCRIPTION
An internal fix.
1) Make pipeline use latest ubuntu image, for it to no longer fail.
2) Return family-friendliness to the YML (comment removed).
