### PR TITLE
[React] Add status message during install

### DIFF
--- a/packages/create-sitecore-jss/scripts/watch-templates.ts
+++ b/packages/create-sitecore-jss/scripts/watch-templates.ts
@@ -61,11 +61,13 @@ async function regenerateLockFile() {
       }
 
       console.log(chalk.red('yarn.lock was removed.'));
+      console.log(chalk.yellow('Installing dependencies...'));
     });
 
     // Re-install dependencies
     await promisify(exec)('yarn install', { cwd: rootPath });
     // Dependencies installed successfully
+    console.log(chalk.green('Dependencies installed successfully.'));
     console.log(chalk.green('yarn.lock generated successfully.'));
   } catch (err) {
     console.error(err);
@@ -78,11 +80,11 @@ const initializeApps = async (noInstall: boolean) => {
     watch = await import(path.resolve('watch.json'));
     const initializers = watch.initializers || [];
     await initRunner(initializers, { ...watch.args, templates: initializers, noInstall });
-    if (watch.args.restoreLockfile) {
-      restoreLockfile();
-    }
     if (initializers.includes('react')) {
       await regenerateLockFile();
+    }
+    if (watch.args.restoreLockfile) {
+      restoreLockfile();
     }
   } catch (error) {
     console.log(chalk.red('An error occurred: ', error));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While scaffolding a react app in monorepo while regenerating the `'yarn.lock` the console waits until the dependencies are installed leaving the user confused about the status of the process. 

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
