### PR TITLE
Internal dev/16/fix pipeline bootstrap

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 variables:
-  isDev: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
+  isDev: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
 
 steps:
   - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,9 @@ variables:
   isDev: $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
 
 steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '14.x'
   - script: |
       npm ci
     displayName: 'npm ci'

--- a/samples/react-native/package-lock.json
+++ b/samples/react-native/package-lock.json
@@ -6165,7 +6165,7 @@
 		"node_modules/hammerjs": {
 			"name": "@egjs/hammerjs",
 			"version": "2.0.17-snapshot",
-			"resolved": "git+ssh://git@github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51",
+			"resolved": "git+https://git@github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51",
 			"integrity": "sha512-vmaz8aBaf9Dv8Xf45rfm7PBGnRy8cu2GIiogmWy05Wl16vG0oAbOP+Sue/c+C2xLx0tc2wprsqVtveKumxo6Xg==",
 			"license": "MIT",
 			"dependencies": {
@@ -16915,7 +16915,7 @@
 			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"hammerjs": {
-			"version": "git+ssh://git@github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51",
+			"version": "git+https://git@github.com/naver/hammer.js.git#54bc698b25edd6e1b76ca975ebaced5ce0467d51",
 			"integrity": "sha512-vmaz8aBaf9Dv8Xf45rfm7PBGnRy8cu2GIiogmWy05Wl16vG0oAbOP+Sue/c+C2xLx0tc2wprsqVtveKumxo6Xg==",
 			"from": "hammerjs@git+https://github.com/naver/hammer.js.git",
 			"requires": {


### PR DESCRIPTION
Part 2 of fixing ver16 pipeline: 
* Ensure node version is set to the supported v14
* Fix an SSH dependency for react-native so that npm ci can do its thing without access errors
* Add extra condition so that pre-release will publish when pushing to release branch
