### PR TITLE
[internal][v16] Fix branch checkout in azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ pool:
 
 variables:
   isDev: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
+  branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 steps:
   - task: NodeTool@0
@@ -71,7 +72,7 @@ steps:
       git config user.email builds@sitecore.com
       git config user.name "Automated Build"
       git remote set-url origin https://$GITHUB_PAT_ENV@github.com/Sitecore/jss.git
-      git checkout $(Build.SourceBranchName)
+      git checkout $(branchName)
       $(npm bin)/lerna version prerelease --preid canary --force-publish --message "version %s [skip ci]" --yes
     displayName: 'pre-release version update'
     condition: and(succeeded(), eq(variables.isDev, true))


### PR DESCRIPTION
Part 3 of pipeline adjustments. This one ensures pipeline checks out to the existing and correct branch name before performing lerna version and lerna publish actions.