### PR TITLE
[nextjs][RAV] Install `pre-push-hook` to root .git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-react]` `[sitecore-jss-nextjs]` FEaaS component will render 'staged' variant for editing and preview and 'published' variant for live site by default, unless variant is overriden via rendering parameters. ([#1433](https://github.com/Sitecore/jss/pull/1433))
 * `[templates/nextjs]` `[templates/angular]` `[templates/react]` `[templates/vue]` Pre-push hook for lint check ([#1427](https://github.com/Sitecore/jss/pull/1427))
 ([#1442](https://github.com/Sitecore/jss/pull/1442)) ([#1444](https://github.com/Sitecore/jss/pull/1444)) ([#1468](https://github.com/Sitecore/jss/pull/1468))
+([#1472](https://github.com/Sitecore/jss/pull/1472))
 * `[sitecore-jss-nextjs] Add a new handling for token $siteLang(context site language) in middleware redirect ([#1454](https://github.com/Sitecore/jss/pull/1454))
 
 ### 🧹 Chores

--- a/packages/create-sitecore-jss/src/bin.ts
+++ b/packages/create-sitecore-jss/src/bin.ts
@@ -105,13 +105,14 @@ export const main = async (args: ParsedArgs) => {
         type: 'confirm',
         name: 'prePushHook',
         message: 'Would you like to use the pre-push hook for linting check?',
+        default: false,
       });
 
       args.prePushHook = answer.prePushHook;
     }
   } else {
     if (args.prePushHook === null) {
-      args.prePushHook = true;
+      args.prePushHook = false;
     }
   }
 

--- a/packages/create-sitecore-jss/src/bin.ts
+++ b/packages/create-sitecore-jss/src/bin.ts
@@ -110,7 +110,9 @@ export const main = async (args: ParsedArgs) => {
       args.prePushHook = answer.prePushHook;
     }
   } else {
-    args.prePushHook = true;
+    if (args.prePushHook === null) {
+      args.prePushHook = true;
+    }
   }
 
   try {

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
@@ -2,14 +2,16 @@
 import * as path from 'path';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-import chalk from 'chalk';
+
+const greenLog = '\x1b[32m%s\x1b[0m';
+const redLog = '\x1b[31m%o\x1b[0m';
 
 const installHooks = async () => {
   try {
     const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
     const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
     const gitRootPath = stdout.trim();
-    console.log(chalk.green(`Writing data to local .git folder ${gitRootPath}...`));
+    console.log(greenLog, 'Writing data to local .git folder...');
 
     const data = `#!/bin/sh
 #
@@ -17,15 +19,16 @@ const installHooks = async () => {
 #
 # To skip this hook, use the --no-verify flag
 # when pushing.
-#
 echo "Running lint check..."
 cd ${appPath}
-npm run lint`;
+npm run lint
+#
+  `;
 
     await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
-    console.log(chalk.green('Success'));
+    console.log(greenLog, 'Success!');
   } catch (error) {
-    console.log(chalk.red(`Error installing hook: ${error}`));
+    console.log(redLog, `Error installing hook: ${error}`);
   }
 };
 

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
@@ -1,5 +1,5 @@
-﻿import fs from 'fs';
-import path from 'path';
+﻿import * as fs from 'fs';
+import * as path from 'path';
 import { promisify } from 'util';
 import { exec } from 'child_process';
 

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
@@ -1,29 +1,34 @@
-﻿import * as fs from 'fs';
+﻿import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
-const installHooks = () => {
-  // data to be written to the file
-  const data = `#!/bin/sh
-#
-# pre-push hook runs our linter before we push our changes
-#
-# To skip this hook, use the --no-verify flag
-# when pushing.
-#
+const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
+const successMessage = '\x1b[32m%s\x1b[0m';
+const errorMessage = '\x1b[31m%o\x1b[0m';
 
-echo "Running lint check..."
-npm run lint`;
+const installHooks = async () => {
+  try {
+    const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
+    const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
+    const gitRootPath = stdout.trim();
+    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
 
-  // \x1b[32m%s\x1b[0m - set color to green, insert the string, reset color after string is logged to console
-  console.log('\x1b[32m%s\x1b[0m', 'Writing to local .git folder...');
+    const data = `#!/bin/sh
+    # pre-push hook runs our linter before we push our changes
+    #
+    # To skip this hook, use the --no-verify flag
+    # when pushing.
+    echo "Running lint check..."
+    cd ${appPath}
+    npm run lint
+  `;
 
-  // Write the hook to the local .git folder. Using writeFile in order to catch any errors
-  fs.writeFile('./.git/hooks/pre-push', data, 'utf8', (err: Error) => {
-    if (err) {
-      console.log('\x1b[31m%o\x1b[0m', err);
-    } else {
-      console.log('\x1b[32m%s\x1b[0m', 'Success!');
-    }
-  });
+    await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
+    console.log(successMessage, 'Success!');
+  } catch (error) {
+    console.log(errorMessage, `Error installing hook: ${error}`);
+  }
 };
 
 installHooks();

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/install-pre-push-hook.ts
@@ -2,32 +2,30 @@
 import * as path from 'path';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-
-const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
-const successMessage = '\x1b[32m%s\x1b[0m';
-const errorMessage = '\x1b[31m%o\x1b[0m';
+import chalk from 'chalk';
 
 const installHooks = async () => {
   try {
     const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
     const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
     const gitRootPath = stdout.trim();
-    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
+    console.log(chalk.green(`Writing data to local .git folder ${gitRootPath}...`));
 
     const data = `#!/bin/sh
-    # pre-push hook runs our linter before we push our changes
-    #
-    # To skip this hook, use the --no-verify flag
-    # when pushing.
-    echo "Running lint check..."
-    cd ${appPath}
-    npm run lint
-  `;
+#
+# pre-push hook runs our linter before we push our changes
+#
+# To skip this hook, use the --no-verify flag
+# when pushing.
+#
+echo "Running lint check..."
+cd ${appPath}
+npm run lint`;
 
     await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
-    console.log(successMessage, 'Success!');
+    console.log(chalk.green('Success'));
   } catch (error) {
-    console.log(errorMessage, `Error installing hook: ${error}`);
+    console.log(chalk.red(`Error installing hook: ${error}`));
   }
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/install-pre-push-hook.ts
@@ -2,32 +2,30 @@
 import path from 'path';
 import { promisify } from 'util';
 import { exec } from 'child_process';
-
-const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
-const successMessage = '\x1b[32m%s\x1b[0m';
-const errorMessage = '\x1b[31m%o\x1b[0m';
+import chalk from 'chalk';
 
 const installHooks = async () => {
   try {
     const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
     const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
     const gitRootPath = stdout.trim();
-    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
+    console.log(chalk.green(`Writing data to local .git folder ${gitRootPath}...`));
 
     const data = `#!/bin/sh
-    # pre-push hook runs our linter before we push our changes
-    #
-    # To skip this hook, use the --no-verify flag
-    # when pushing.
-    echo "Running lint check..."
-    cd ${appPath}
-    npm run lint
-  `;
+#
+# pre-push hook runs our linter before we push our changes
+#
+# To skip this hook, use the --no-verify flag
+# when pushing.
+#
+echo "Running lint check..."
+cd ${appPath}
+npm run lint`;
 
     await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
-    console.log(successMessage, 'Success!');
+    console.log(chalk.green('Success'));
   } catch (error) {
-    console.log(errorMessage, `Error installing hook: ${error}`);
+    console.log(chalk.red(`Error installing hook: ${error}`));
   }
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/install-pre-push-hook.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/install-pre-push-hook.ts
@@ -1,28 +1,34 @@
 ﻿import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
-const installHooks = () => {
-  // data to be written to the file
-  const data = `#!/bin/sh
-  #
-  # pre-push hook runs our linter before we push our changes
-  #
-  # To skip this hook, use the --no-verify flag
-  # when pushing.
-  #
-  echo "Running lint check..."
-  npm run lint`;
+const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
+const successMessage = '\x1b[32m%s\x1b[0m';
+const errorMessage = '\x1b[31m%o\x1b[0m';
 
-  // \x1b[32m%s\x1b[0m - set color to green, insert the string, reset color after string is logged to console
-  console.log('\x1b[32m%s\x1b[0m', 'Writing to local .git folder...');
+const installHooks = async () => {
+  try {
+    const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
+    const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
+    const gitRootPath = stdout.trim();
+    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
 
-  // Write the hook to the local .git folder. Using writeFile in order to catch any errors
-  fs.writeFile('./.git/hooks/pre-push', data, 'utf8', err => {
-    if (err) {
-      console.log('\x1b[31m%o\x1b[0m', err);
-    } else {
-      console.log('\x1b[32m%s\x1b[0m', 'Success!');
-    }
-  });
+    const data = `#!/bin/sh
+    # pre-push hook runs our linter before we push our changes
+    #
+    # To skip this hook, use the --no-verify flag
+    # when pushing.
+    echo "Running lint check..."
+    cd ${appPath}
+    npm run lint
+  `;
+
+    await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
+    console.log(successMessage, 'Success!');
+  } catch (error) {
+    console.log(errorMessage, `Error installing hook: ${error}`);
+  }
 };
 
 installHooks();

--- a/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
@@ -1,28 +1,34 @@
-﻿const fs = require('fs');
+﻿import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
-const installHooks = () => {
-  // data to be written to the file
-  const data = `#!/bin/sh
-  #
-  # pre-push hook runs our linter before we push our changes
-  #
-  # To skip this hook, use the --no-verify flag
-  # when pushing.
-  #
-  echo "Running lint check..."
-  npm run lint`;
+const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
+const successMessage = '\x1b[32m%s\x1b[0m';
+const errorMessage = '\x1b[31m%o\x1b[0m';
 
-  // \x1b[32m%s\x1b[0m - set color to green, insert the string, reset color after string is logged to console
-  console.log('\x1b[32m%s\x1b[0m', 'Writing to local .git folder...');
+const installHooks = async () => {
+  try {
+    const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
+    const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
+    const gitRootPath = stdout.trim();
+    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
 
-  // Write the hook to the local .git folder. Using writeFile in order to catch any errors
-  fs.writeFile('./.git/hooks/pre-push', data, 'utf8', err => {
-    if (err) {
-      console.log('\x1b[31m%o\x1b[0m', err);
-    } else {
-      console.log('\x1b[32m%s\x1b[0m', 'Success!');
-    }
-  });
+    const data = `#!/bin/sh
+    # pre-push hook runs our linter before we push our changes
+    #
+    # To skip this hook, use the --no-verify flag
+    # when pushing.
+    echo "Running lint check..."
+    cd ${appPath}
+    npm run lint
+  `;
+
+    await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
+    console.log(successMessage, 'Success!');
+  } catch (error) {
+    console.log(errorMessage, `Error installing hook: ${error}`);
+  }
 };
 
 installHooks();

--- a/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
@@ -2,32 +2,30 @@
 const path = require('path');
 const { promisify } = require('util');
 const { exec } = require('child_process');
-
-const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
-const successMessage = '\x1b[32m%s\x1b[0m';
-const errorMessage = '\x1b[31m%o\x1b[0m';
+const chalk = require('chalk');
 
 const installHooks = async () => {
   try {
     const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
     const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
     const gitRootPath = stdout.trim();
-    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
+    console.log(chalk.green(`Writing data to local .git folder ${gitRootPath}...`));
 
     const data = `#!/bin/sh
-    # pre-push hook runs our linter before we push our changes
-    #
-    # To skip this hook, use the --no-verify flag
-    # when pushing.
-    echo "Running lint check..."
-    cd ${appPath}
-    npm run lint
-  `;
+#
+# pre-push hook runs our linter before we push our changes
+#
+# To skip this hook, use the --no-verify flag
+# when pushing.
+#
+echo "Running lint check..."
+cd ${appPath}
+npm run lint`;
 
     await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
-    console.log(successMessage, 'Success!');
+    console.log(chalk.green('Success'));
   } catch (error) {
-    console.log(errorMessage, `Error installing hook: ${error}`);
+    console.log(chalk.red(`Error installing hook: ${error}`));
   }
 };
 

--- a/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/install-pre-push-hook.js
@@ -1,7 +1,7 @@
-﻿import fs from 'fs';
-import path from 'path';
-import { promisify } from 'util';
-import { exec } from 'child_process';
+﻿﻿const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const { exec } = require('child_process');
 
 const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
 const successMessage = '\x1b[32m%s\x1b[0m';

--- a/packages/create-sitecore-jss/src/templates/vue/package.json
+++ b/packages/create-sitecore-jss/src/templates/vue/package.json
@@ -76,6 +76,7 @@
     "@vue/cli-service": "~5.0.8",
     "@vue/compiler-sfc": "^3.2.45",
     "@vue/eslint-config-prettier": "~7.0.0",
+    "chalk": "~4.1.2",
     "chokidar": "~3.5.3",
     "constant-case": "^3.0.4",
     "cross-env": "~7.0.3",

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
@@ -1,28 +1,34 @@
-﻿const fs = require('fs');
+﻿import fs from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+import { exec } from 'child_process';
 
-const installHooks = () => {
-  // data to be written to the file
-  const data = `#!/bin/sh
-  #
-  # pre-push hook runs our linter before we push our changes
-  #
-  # To skip this hook, use the --no-verify flag
-  # when pushing.
-  #
-  echo "Running lint check..."
-  npm run lint`;
+const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
+const successMessage = '\x1b[32m%s\x1b[0m';
+const errorMessage = '\x1b[31m%o\x1b[0m';
 
-  // \x1b[32m%s\x1b[0m - set color to green, insert the string, reset color after string is logged to console
-  console.log('\x1b[32m%s\x1b[0m', 'Writing to local .git folder...');
+const installHooks = async () => {
+  try {
+    const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
+    const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
+    const gitRootPath = stdout.trim();
+    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
 
-  // Write the hook to the local .git folder. Using writeFile in order to catch any errors
-  fs.writeFile('./.git/hooks/pre-push', data, 'utf8', (err) => {
-    if (err) {
-      console.log('\x1b[31m%o\x1b[0m', err);
-    } else {
-      console.log('\x1b[32m%s\x1b[0m', 'Success!');
-    }
-  });
+    const data = `#!/bin/sh
+    # pre-push hook runs our linter before we push our changes
+    #
+    # To skip this hook, use the --no-verify flag
+    # when pushing.
+    echo "Running lint check..."
+    cd ${appPath}
+    npm run lint
+  `;
+
+    await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
+    console.log(successMessage, 'Success!');
+  } catch (error) {
+    console.log(errorMessage, `Error installing hook: ${error}`);
+  }
 };
 
 installHooks();

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
@@ -2,32 +2,30 @@
 const path = require('path');
 const { promisify } = require('util');
 const { exec } = require('child_process');
-
-const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
-const successMessage = '\x1b[32m%s\x1b[0m';
-const errorMessage = '\x1b[31m%o\x1b[0m';
+const chalk = require('chalk');
 
 const installHooks = async () => {
   try {
     const appPath = path.join(__dirname, '..').replace(/\\/g, '/');
     const { stdout } = await promisify(exec)('git rev-parse --show-toplevel');
     const gitRootPath = stdout.trim();
-    console.log(gitRootDirMessage, 'Writing data to local .git folder...');
+    console.log(chalk.green(`Writing data to local .git folder ${gitRootPath}...`));
 
     const data = `#!/bin/sh
-    # pre-push hook runs our linter before we push our changes
-    #
-    # To skip this hook, use the --no-verify flag
-    # when pushing.
-    echo "Running lint check..."
-    cd ${appPath}
-    npm run lint
-  `;
+#
+# pre-push hook runs our linter before we push our changes
+#
+# To skip this hook, use the --no-verify flag
+# when pushing.
+#
+echo "Running lint check..."
+cd ${appPath}
+npm run lint`;
 
     await promisify(fs.writeFile)(`${gitRootPath}/.git/hooks/pre-push`, data, 'utf8');
-    console.log(successMessage, 'Success!');
+    console.log(chalk.green('Success'));
   } catch (error) {
-    console.log(errorMessage, `Error installing hook: ${error}`);
+    console.log(chalk.red(`Error installing hook: ${error}`));
   }
 };
 

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/install-pre-push-hook.js
@@ -1,7 +1,7 @@
-﻿import fs from 'fs';
-import path from 'path';
-import { promisify } from 'util';
-import { exec } from 'child_process';
+﻿﻿const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const { exec } = require('child_process');
 
 const gitRootDirMessage = '\x1b[32m%s\x1b[0m';
 const successMessage = '\x1b[32m%s\x1b[0m';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Install the the `prePushHook` script to the root .git folder.
- Currently the --yes flag defaults prePushHook to true because of which if prePushHook flag is passed explicitly then it is not considered. We want the cli to accept both flags`--yes` and `prePushHook`.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
