### PR TITLE
[Next.js] Remove .babelrc to (re)enable SWC compilation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Our versioning strategy is as follows:
 ([#1472](https://github.com/Sitecore/jss/pull/1472))
 * `[sitecore-jss-nextjs] Add a new handling for token $siteLang(context site language) in middleware redirect ([#1454](https://github.com/Sitecore/jss/pull/1454))
 * `[sitecore-jss]` `[templates/nextjs-sxa]` Rewrite logic of handling custom error pages. The error pages rewrite page with error(it's saving status code) instead of redirected ([#1469](https://github.com/Sitecore/jss/pull/1469)) ([#1476](https://github.com/Sitecore/jss/pull/1476))
+* `[templates/nextjs]` Remove .babelrc to (re)enable SWC compilation by default ([#1483](https://github.com/Sitecore/jss/pull/1483))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
@@ -1,9 +1,0 @@
-// This file exists in order to disable Next.js SWC compilation due to
-// current instability. Specifically, when compiling on Windows-based
-// rendering hosts using containers you may see the following error:
-// https://nextjs.org/docs/messages/failed-loading-swc
-//
-// You may wish to remove this file when deploying to Vercel.
-{
-    "presets": ["next/babel"]
-}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Remove .babelrc to (re)enable SWC compilation by default in our base nextjs template. Our original reason for adding (issues running inside Windows-based rendering host on local containers) is fixed on recent Next.js versions.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
