### PR TITLE
[nextjs][sxa]Moving saas and sass-alias from devDependencies to dependencies

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/package.json
@@ -1,12 +1,10 @@
 {
   "dependencies": {
     "bootstrap": "^5.1.3",
-    "font-awesome": "^4.7.0"
-  },
-  "devDependencies": {
-    "sass-alias": "^1.0.5",
-    "sass": "^1.52.3"
-  },
+    "font-awesome": "^4.7.0",
+    "sass": "^1.52.3",
+    "sass-alias": "^1.0.5"    
+  }, 
   "scripts": {
     "scaffold": "ts-node --project tsconfig.scripts.json scripts/scaffold-component.ts"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
sass and saas-alias packages are used in the runtime of the Next.JS SXA Starter Kit inside the "saas" plugin.
Some of the hosting providers (like CloudflarePages and Azure Static Web Apps) only install packages listed as dependencies when they post-process the build artifacts which causes the application to never start.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - nothing much to test :) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
