### PR TITLE
[node-headless-ssr-experience-edge] Add helper comment for `rootItemId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` Fix incorrectly named .gitignore file `\scripts\temp\.npmignore` ([#1463](https://github.com/Sitecore/jss/pull/1463))
 * `[angular]` Avoid sending two dictionary service calls when switching language and refreshing the page ([#1473](https://github.com/Sitecore/jss/pull/1473))
 * Fix installed sitecore-jss-* dependency version ([#1478](https://github.com/Sitecore/jss/pull/1478))
+* [node-headless-ssr-experience-edge] Add helper comment for rootItemId ([#1491](https://github.com/Sitecore/jss/pull/1491))
 
 ## 21.1.5
 

--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-experience-edge/src/index.ts
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-experience-edge/src/index.ts
@@ -17,6 +17,12 @@ const dictionaryService = new GraphQLDictionaryService({
   endpoint: config.endpoint,
   apiKey: config.apiKey,
   siteName: config.appName,
+  /*
+    The Dictionary Service needs a root item ID in order to fetch dictionary phrases for the current
+    app. If your Sitecore instance only has 1 JSS App, you can specify the root item ID here;
+    otherwise, the service will attempt to figure out the root item for the current JSS App using GraphQL and app name.
+    rootItemId: '{GUID}'
+  */
 });
 
 const { renderView, parseRouteUrl } = config.serverBundle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The `node-headless-ssr-experience-edge` template doesn't have the helper comment to add the `rootItemId` if missing.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
