### PR TITLE
[nextjs] Re-introduce babelrc

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["next/babel"]
+}

--- a/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.babelrc
@@ -1,3 +1,9 @@
+// This file exists in order to disable Next.js SWC compilation due to
+// current instability. Specifically, when compiling on Windows-based
+// rendering hosts using containers you may see the following error:
+// https://nextjs.org/docs/messages/failed-loading-swc
+//
+// You may wish to remove this file when deploying to Vercel.
 {
     "presets": ["next/babel"]
 }


### PR DESCRIPTION
The Wheel of Time weaves as the Wheel wills and we again need to add babelrc after the nextjs version update.
This should be a temporary measure to make our test agents work again, while we look for a better solution.