### PR TITLE
[NextJS] Fix for bug in RichText component - links not reinitialised when content changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs-sxa]` Add condition DISABLE_SSG_FETCH for 404/500 pages to enable full ISR (Incremental Static Regeneration) flow ([#1496](https://github.com/Sitecore/jss/pull/1496))
 * `[templates/nextjs-sxa]` Fix class .indent for component which have column size 12 ([#1505](https://github.com/Sitecore/jss/pull/1505))
 * `[templates/nextjs-sxa]` Fix type(from Text to RichText) of editing text in value Text2 for Promo Component in WithText variant ([#1504](https://github.com/Sitecore/jss/pull/1504)).
+* `[sitecore-jss-nextjs]` Fix RichText component to re-initialize links when content changes ([#1503](https://github.com/Sitecore/jss/pull/1503))
 
 ## 21.1.6
 

--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -119,7 +119,7 @@ describe('RichText', () => {
     expect(initialMountedComponent.html()).contains('<a href="/t100">1</a>');
     expect(initialMountedComponent.html()).contains('<a href="/t100">2</a>');
 
-    // expect(router.prefetch).callCount(1);
+    expect(router.prefetch).callCount(1);
 
     const main = document.querySelector('main');
 
@@ -155,7 +155,7 @@ describe('RichText', () => {
     expect(remountedComponent.html()).contains('<a href="/t20">1</a>');
     expect(remountedComponent.html()).contains('<a href="/t20">2</a>');
 
-    // expect(router.prefetch).callCount(1);
+    expect(router.prefetch).callCount(2);
 
     const links2 = main && main.querySelectorAll('a');
 
@@ -203,7 +203,8 @@ describe('RichText', () => {
       expect(c.html()).contains('<div id="test">');
       expect(c.html()).contains('<h1>Hello!</h1>');
 
-      
+      expect(router.prefetch).callCount(1);
+
       const main = document.querySelector('main');
       
       const links = main && main.querySelectorAll('a');

--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -178,56 +178,54 @@ describe('RichText', () => {
     document.body.removeChild(app);
   });
 
-    it('should initialize links using internalLinksSelector', () => {
-      const app = document.createElement('main');
+  it('should initialize links using internalLinksSelector', () => {
+    const app = document.createElement('main');
 
-      document.body.appendChild(app);
+    document.body.appendChild(app);
 
-      const router = Router();
+    const router = Router();
 
-      const props = {
-        field: {
-          value:
-            '<div id="test"><h1>Hello!</h1><a href="/testpath/t1?test=sample1">t1</a><a href="/t2">t2</a></div>',
-        },
-        internalLinksSelector: 'a[href^="/testpath"]',
-      };
+    const props = {
+      field: {
+        value:
+          '<div id="test"><h1>Hello!</h1><a href="/testpath/t1?test=sample1">t1</a><a href="/t2">t2</a></div>',
+      },
+      internalLinksSelector: 'a[href^="/testpath"]',
+    };
 
-      const c = mount(
-        <Page value={router}>
-          <RichText {...props} />
-        </Page>,
-        { attachTo: app }
-      );
+    const c = mount(
+      <Page value={router}>
+        <RichText {...props} />
+      </Page>,
+      { attachTo: app }
+    );
 
-      expect(c.html()).contains('<div id="test">');
-      expect(c.html()).contains('<h1>Hello!</h1>');
+    expect(c.html()).contains('<div id="test">');
+    expect(c.html()).contains('<h1>Hello!</h1>');
 
-      expect(router.prefetch).callCount(1);
+    expect(router.prefetch).callCount(1);
 
-      const main = document.querySelector('main');
-      
-      const links = main && main.querySelectorAll('a');
-      
-      const link1 = links && links[0];
-      const link2 = links && links[1];
-      
-      expect(link1!.href).to.endWith('/testpath/t1?test=sample1');
-      expect(link2!.pathname).to.equal('/t2');
-      
-      link1 && link1.click();
-      
-      expect(router.push).callCount(1);
+    const main = document.querySelector('main');
+    const links = main && main.querySelectorAll('a');
+    const link1 = links && links[0];
+    const link2 = links && links[1];
 
-      link2 && link2.click();
+    expect(link1!.href).to.endWith('/testpath/t1?test=sample1');
+    expect(link2!.pathname).to.equal('/t2');
 
-      // Check that push not invoked, because second link don't have event listener
-      expect(router.push).callCount(1);
+    link1 && link1.click();
 
-      expect(c.find(ReactRichText).length).to.equal(1);
+    expect(router.push).callCount(1);
 
-      document.body.removeChild(app);
-    });
+    link2 && link2.click();
+
+    // Check that push not invoked, because second link don't have event listener
+    expect(router.push).callCount(1);
+
+    expect(c.find(ReactRichText).length).to.equal(1);
+
+    document.body.removeChild(app);
+  });
 
   it('should not initialize links when does not have value', () => {
     const router = Router();

--- a/packages/sitecore-jss-nextjs/src/components/RichText.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.tsx
@@ -30,7 +30,7 @@ export const RichText = (props: RichTextProps): JSX.Element => {
     if (hasText && !isEditing) {
       initializeLinks();
     }
-  }, []);
+  }, [hasText]);
 
   const routeHandler = (ev: MouseEvent) => {
     if (!ev.target) return;

--- a/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
@@ -9,7 +9,7 @@ declare var global: NodeJS.Global;
 
 const { JSDOM } = require('jsdom');
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://example.com/'});
 const jsDomWindow = jsdom.window;
 
 /**

--- a/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
+++ b/packages/sitecore-jss-nextjs/src/tests/jsdom-setup.ts
@@ -9,7 +9,9 @@ declare var global: NodeJS.Global;
 
 const { JSDOM } = require('jsdom');
 
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'https://example.com/'});
+const jsdom = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'https://example.com/',
+});
 const jsDomWindow = jsdom.window;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
When the RichText component content changes, the useEffect() hook is not re-run as it has no dependancies. This means the initializeLinks() function is not run so any embedded internal links within the component will not have the appropriate click event handler. This causes any link within the component to cause a full page load rather than client side routing occuring. This change adds the "hasText" property (essentially the rich text) as a dependancy for the useEffect() hook, ensuring the initializeLinks() function is run when the content changes, enabling client side routing to occur.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)
Unit test added. 
Manual testing involved applying the proposed changes to a local dev instance of Sitecore 10.2 and 10.3 and observing the appropriate  event handler is applied to internal links within the rich text component, both on first render but also after the content changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
This PR fixes Bug 1502:
https://github.com/Sitecore/jss/issues/1502