### PR TITLE
[Next.js][Personalize] Update the default personalize middleware, personalize/cdp service timeout values to 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` Remove .babelrc to (re)enable SWC compilation by default ([#1483](https://github.com/Sitecore/jss/pull/1483))
 * `[sitecore-jss]` Handle null items in graphql layout service. ([#1492](https://github.com/Sitecore/jss/pull/1492))
 * `[sitecore-jss]` `[templates/nextjs-personalize]` Introduced optional personalize scope identifier to isolate embedded personalization data among XM Cloud Environments that are sharing a Personalize tenant ([#1494](https://github.com/Sitecore/jss/pull/1494))
+* `[templates/nextjs-personalize]` `[sitecore-jss]` Update the default personalize middleware, personalize/cdp service timeout values to 400 ([#1507](https://github.com/Sitecore/jss/pull/1507))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/.env
@@ -13,8 +13,8 @@ NEXT_PUBLIC_PERSONALIZE_SCOPE=
 # Can be provided as a single value (mypoint.com) or a multi-value JSON with locales ({"en":"en.mypoint.com","fr":"fr.mypoint.com"} etc)
 NEXT_PUBLIC_CDP_POINTOFSALE=
 
-# Timeout (ms) for Sitecore CDP requests to respond within. Default is 250.
+# Timeout (ms) for Sitecore CDP requests to respond within. Default is 400.
 PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT=
 
-# Timeout (ms) for Sitecore Experience Edge requests to respond within. Default is 250.
+# Timeout (ms) for Sitecore Experience Edge requests to respond within. Default is 400.
 PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT=

--- a/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-personalize/src/lib/middleware/plugins/personalize.ts
@@ -29,7 +29,7 @@ class PersonalizePlugin implements MiddlewarePlugin {
         timeout:
           (process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT &&
             parseInt(process.env.PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT)) ||
-          250,
+          400,
         scope: process.env.NEXT_PUBLIC_PERSONALIZE_SCOPE,
       },
       // Configuration for your Sitecore CDP endpoint
@@ -39,7 +39,7 @@ class PersonalizePlugin implements MiddlewarePlugin {
         timeout:
           (process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT &&
             parseInt(process.env.PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT)) ||
-          250,
+          400,
       },
       // This function determines if the middleware should be turned off.
       // IMPORTANT: You should implement based on your cookie consent management solution of choice.

--- a/packages/sitecore-jss/src/personalize/cdp-service.ts
+++ b/packages/sitecore-jss/src/personalize/cdp-service.ts
@@ -40,7 +40,7 @@ export type CdpServiceConfig = {
    */
   dataFetcherResolver?: DataFetcherResolver;
   /**
-   * Timeout (ms) for CDP request. Default is 250.
+   * Timeout (ms) for CDP request. Default is 400.
    */
   timeout?: number;
 };
@@ -75,7 +75,7 @@ export class CdpService {
    */
   private timeout: number;
   constructor(protected config: CdpServiceConfig) {
-    this.timeout = config.timeout || 250;
+    this.timeout = config.timeout || 400;
   }
 
   /**

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.test.ts
@@ -242,7 +242,7 @@ describe('GraphQLPersonalizeService', () => {
             expect(newResult).to.deep.equal(undefined);
             resolve(undefined);
           }),
-        250
+        400
       );
     });
     await cacheNonUpdate;

--- a/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
+++ b/packages/sitecore-jss/src/personalize/graphql-personalize-service.ts
@@ -14,7 +14,7 @@ export type GraphQLPersonalizeServiceConfig = CacheOptions & {
    */
   apiKey: string;
   /**
-   * Timeout (ms) for the Personalize request. Default is 250.
+   * Timeout (ms) for the Personalize request. Default is 400.
    */
   timeout?: number;
   /**
@@ -68,7 +68,7 @@ export class GraphQLPersonalizeService {
    * @param {GraphQLPersonalizeServiceConfig} config
    */
   constructor(protected config: GraphQLPersonalizeServiceConfig) {
-    this.config.timeout = config.timeout || 250;
+    this.config.timeout = config.timeout || 400;
     this.graphQLClient = this.getGraphQLClient();
     this.cache = this.getCacheClient();
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Updated:
 * Default personalize middleware timeout values to 400
 * Default personalize, cdp services timeout values to 400
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added - unit test updated
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
