### PR TITLE
[Chore] launch lerna build through npm and not directly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ steps:
     yarn lint-packages ${{ variables.lernaSinceFlag }}
   displayName: 'lint packages'
 - script: |
-    lerna run build
+    npm run build
   displayName: 'build packages'
 - script: |
     yarn coverage-packages


### PR DESCRIPTION
Fix the azure pipeline, ensure lerna uses the version from package.json and not the one installed in environment, when pipeline is running.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance
