### PR TITLE
[nextjs][react][vue][angular] Add support for layout service REST configuration name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[templates]` Add support for layout service REST configuration name
 * `[templates/nexts]` `[sitecore-jss-dev-tools]` Move template related script to the base package ([#1520](https://github.com/Sitecore/jss/pull/1520)):
   * `[sitecore-jss-nextjs]`:
     * Introduced _ComponentBuilder_ class for generating component factories and module factories.

--- a/packages/create-sitecore-jss/src/templates/angular/.env
+++ b/packages/create-sitecore-jss/src/templates/angular/.env
@@ -23,6 +23,9 @@ DEFAULT_LANGUAGE=
 # The way in which layout and dictionary data is fetched from Sitecore
 FETCH_WITH=<%- fetchWith %>
 
+# Your Layout Service configuration name. This is relevant for REST fetching approach only.
+CONFIGURATION_NAME=default
+
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the DEBUG environment variable to 'sitecore-jss:*' to see all logs:

--- a/packages/create-sitecore-jss/src/templates/angular/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/scripts/generate-config.ts
@@ -19,6 +19,7 @@ export function generateConfig(configOverrides?: { [key: string]: unknown }, out
     sitecoreLayoutServiceConfig: 'jss',
     defaultLanguage: 'en',
     defaultServerRoute: '/',
+    configurationName: 'default',
   };
 
   if (!outputPath) {

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/lib/layout-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/lib/layout-service-factory.ts
@@ -18,7 +18,7 @@ export class LayoutServiceFactory {
           apiHost: environment.sitecoreApiHost,
           apiKey: environment.sitecoreApiKey,
           siteName: environment.jssAppName,
-          configurationName: 'default',
+          configurationName: environment.configurationName,
         });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -1,4 +1,4 @@
-# For development purposes, note Next.js supports a .env.local 
+# For development purposes, note Next.js supports a .env.local
 # file, which is already configured to be git ignored.
 # Read more about Next.js support of environment variables here:
 # https://nextjs.org/docs/basic-features/environment-variables
@@ -42,10 +42,13 @@ DEFAULT_LANGUAGE=
 # The way in which layout and dictionary data is fetched from Sitecore
 FETCH_WITH=<%- fetchWith %>
 
+# Your Layout Service configuration name. This is relevant for REST fetching approach only.
+CONFIGURATION_NAME=default
+
 <% if (prerender === 'SSG') { -%>
 # Indicates whether SSG `getStaticPaths` pre-render any pages
 # Set the environment variable DISABLE_SSG_FETCH=true
-# to enable full ISR (Incremental Static Regeneration) flow 
+# to enable full ISR (Incremental Static Regeneration) flow
 DISABLE_SSG_FETCH=
 
 <% } -%>

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-config.ts
@@ -17,6 +17,7 @@ const defaultConfig: JssConfig = {
   graphQLEndpointPath: process.env[`${constantCase('graphQLEndpointPath')}`],
   defaultLanguage: process.env[`${constantCase('defaultLanguage')}`],
   graphQLEndpoint: process.env[`${constantCase('graphQLEndpoint')}`],
+  configurationName: process.env[`${constantCase('configurationName')}`],
 };
 
 generateConfig(defaultConfig);

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
@@ -25,7 +25,7 @@ export class LayoutServiceFactory {
           apiHost: config.sitecoreApiHost,
           apiKey: config.sitecoreApiKey,
           siteName,
-          configurationName: 'default',
+          configurationName: config.configurationName,
         });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/react/.env
+++ b/packages/create-sitecore-jss/src/templates/react/.env
@@ -26,6 +26,9 @@ REACT_APP_DEFAULT_LANGUAGE=
 # The way in which layout and dictionary data is fetched from Sitecore
 REACT_APP_FETCH_WITH=<%- fetchWith %>
 
+# Your Layout Service configuration name. This is relevant for REST fetching approach only.
+CONFIGURATION_NAME=default
+
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the REACT_APP_DEBUG environment variable to 'sitecore-jss:*' to see all logs:

--- a/packages/create-sitecore-jss/src/templates/react/scripts/generate-config.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/generate-config.js
@@ -16,6 +16,7 @@ const defaultConfig = {
   graphQLEndpointPath: process.env[`${constantCase('reactAppGraphQLEndpointPath')}`],
   defaultLanguage: process.env[`${constantCase('reactAppDefaultLanguage')}`],
   graphQLEndpoint: process.env[`${constantCase('reactAppGraphQLEndpoint')}`],
+  configurationName: process.env[`${constantCase('configurationName')}`],
 };
 
 generateConfig()

--- a/packages/create-sitecore-jss/src/templates/react/src/lib/layout-service-factory.js
+++ b/packages/create-sitecore-jss/src/templates/react/src/lib/layout-service-factory.js
@@ -17,7 +17,7 @@ export class LayoutServiceFactory {
           apiHost: config.sitecoreApiHost,
           apiKey: config.sitecoreApiKey,
           siteName: config.jssAppName,
-          configurationName: 'default',
+          configurationName: config.configurationName,
         });
   }
 }

--- a/packages/create-sitecore-jss/src/templates/vue/.env
+++ b/packages/create-sitecore-jss/src/templates/vue/.env
@@ -25,6 +25,9 @@ VUE_APP_DEFAULT_LANGUAGE=
 # The way in which layout and dictionary data is fetched from Sitecore
 VUE_APP_FETCH_WITH=<%- fetchWith %>
 
+# Your Layout Service configuration name. This is relevant for REST fetching approach only.
+CONFIGURATION_NAME=default
+
 # Sitecore JSS npm packages utilize the debug module for debug logging.
 # https://www.npmjs.com/package/debug
 # Set the VUE_APP_DEBUG environment variable to 'sitecore-jss:*' to see all logs:

--- a/packages/create-sitecore-jss/src/templates/vue/scripts/generate-config.js
+++ b/packages/create-sitecore-jss/src/templates/vue/scripts/generate-config.js
@@ -18,6 +18,7 @@ module.exports = function generateConfig(configOverrides) {
     sitecoreApiKey: 'no-api-key-set',
     sitecoreApiHost: '',
     jssAppName: 'Unknown',
+    configurationName: 'default',
   };
 
   // require + combine config sources

--- a/packages/create-sitecore-jss/src/templates/vue/src/lib/layout-service-factory.js
+++ b/packages/create-sitecore-jss/src/templates/vue/src/lib/layout-service-factory.js
@@ -13,7 +13,7 @@ export class LayoutServiceFactory {
           apiHost: config.sitecoreApiHost,
           apiKey: config.sitecoreApiKey,
           siteName: config.jssAppName,
-          configurationName: 'default',
+          configurationName: config.configurationName,
         });
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
This PR adds support to define what Layout Service configuration name should be used for REST calls to Layout Service in **Next.js**, **React**, **Vue** and **Angular** packages: 
- It adds a new `CONFIGURATION_NAME` environment variable, which by default holds the value `default`
- It consumes the new variable in the `config-generator` and adds a new property in the returned configuration object
- It consumes the new `configurationName` config property in the `layout-service-factory` to configure the `RestLayoutService`

<!--- Why is this change required? What problem does it solve? -->
REST calls to layout service can have [multiple configurations in Sitecore](https://doc.sitecore.com/xp/en/developers/hd/210/sitecore-headless-development/using-a-custom-layout-service-configuration-with-jss.html#layout-service-configuration). The linked documentation also exposes a configuration named `jss`.

However, the `RestLayoutService` has hard-coded that the configuration name has to be `default`, which contradicts (IMHO) the provided example in the documentation.

<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
### Prerequisits

- A deployed Sitecore instance with:
   - a headless topology
   - a custom LayoutService configuration named `jss` (for instance)
- A JSS project with Next.js flavour with:
   - proper configuration to be able to connect to the above mentioned Sitecore instance
   - DEBUG environment variable set to `sitecore-jss:*`
   - run `jss start:connected`

### Test case

- Load the reported URL where Next.js can be reached in the browser (http://localhost:3000 by default)
- Check the call that Next.js makes to the layout service: it's path ends with `/default`. 
 
When the `default` layout service configuration is not configured, miss configured, or configured in a special dedicated way, it may not return the `sitecore.route` object in the response, which causes the default assumptions from the routing in JSS frontend to fail and therefor to error.

<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)
   Tested manually as reported in the `Testing Details` section

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
