### PR TITLE
[nextjs][feaas] pass optional component instance ID into FEAAS

### DIFF
--- a/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
@@ -104,6 +104,7 @@ export const FEaaSComponent = (props: FEaaSComponentProps): JSX.Element => {
       library={props.params?.LibraryId}
       version={props.params?.ComponentVersion}
       component={props.params?.ComponentId}
+      instance={props.params?.ComponentInstanceId}
       revision={computedRevision}
     />
   );


### PR DESCRIPTION
Passing an extra prop into FEAAS, per Components' team request. The prop is needed for correct parsing of FEAAS Components in multi-instance Sitecore setup.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated


## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
