### PR TITLE
[Next.js][FEaaS] Prevent extra components client-side requests for SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-react]` [FEaaS] Prevent extra components client-side requests for SSR ([1541](https://github.com/Sitecore/jss/pull/1541))
+
 ## 21.2.1
 
 ### 🧹 Chores

--- a/packages/sitecore-jss-react/src/components/FEaaSComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/components/FEaaSComponent.test.tsx
@@ -51,14 +51,23 @@ describe('<FEaaSComponent />', () => {
     expect(wrapper.html()).to.equal(null);
   });
 
-  it('should render with template and last-modified when provided', () => {
-    const template = '<div>test output</div>';
-    const lastModified = 'March 1 2020';
-    const wrapper = shallow(<FEaaSComponent template={template} lastModified={lastModified} />);
+  it('should render when fallback server props provided', () => {
+    const props: FEaaSComponentProps = {
+      params: requiredParams,
+      revisionFallback: 'staged',
+    };
+    const wrapper = shallow(<FEaaSComponent {...props} />);
     expect(wrapper).to.have.length(1);
     expect(wrapper.html()).to.equal(
-      `<feaas-component last-modified="${lastModified}">${template}</feaas-component>`
+      '<feaas-component cdn="host123" library="library123" version="version123" component="component123" revision="staged"></feaas-component>'
     );
+  });
+
+  it('should render with template when provided', () => {
+    const template = '<div>test output</div>';
+    const wrapper = shallow(<FEaaSComponent template={template} />);
+    expect(wrapper).to.have.length(1);
+    expect(wrapper.html()).to.equal(`<feaas-component>${template}</feaas-component>`);
   });
 
   it('should render when only params are provided', () => {

--- a/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
@@ -35,10 +35,6 @@ type FEaaSComponentServerProps = {
    */
   template?: string;
   /**
-   * the date component data was last modified
-   */
-  lastModified?: string;
-  /**
    * Default revision to be fetched. Should be 'staged' for editing/preview. Can be overriden by params.ComponentRevision
    */
   revisionFallback?: RevisionType;
@@ -67,7 +63,7 @@ export type FEaaSComponentProps = FEaaSComponentServerProps & FEaaSComponentClie
 export const FEaaSComponent = (props: FEaaSComponentProps): JSX.Element => {
   const computedRevision = props.params?.ComponentRevision || props.revisionFallback;
   if (
-    (!props.lastModified || !props.template) &&
+    !props.template &&
     (!props.params ||
       !props.params.LibraryId ||
       !props.params.ComponentId ||
@@ -99,7 +95,6 @@ export const FEaaSComponent = (props: FEaaSComponentProps): JSX.Element => {
     <FEAAS.Component
       data={data}
       template={props.template || ''}
-      last-modified={props.lastModified}
       cdn={props.params?.ComponentHostName}
       library={props.params?.LibraryId}
       version={props.params?.ComponentVersion}
@@ -126,11 +121,10 @@ export async function fetchFEaaSComponentServerProps(
     pageState && pageState !== LayoutServicePageState.Normal ? 'staged' : 'published';
   const src = endpointOverride || composeComponentEndpoint(params, revisionFallback);
   try {
-    const { template, lastModified } = await FEAAS.fetchComponent(src);
+    const { template } = await FEAAS.fetchComponent(src);
     return {
       revisionFallback,
       template,
-      lastModified,
     };
   } catch (e) {
     console.error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Components SDK makes requests on the client-side to check for latest version. These extra requests are unnecessary for SSR.
We omit the last-modified attribute in the component and just give it the "template". It will not do the cache-busting behavior

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
