### PR TITLE
[sitecore-jss-nextjs] Referrer is not captured by Personalize middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-nextjs]` Referrer is not captured by Personalize middleware ([#1542](https://github.com/Sitecore/jss/pull/1542))
 * `[templates/nextjs-sxa]` Fix font awesome - added CDN instead of using node_modules(problem with CORS) ([#1536](https://github.com/Sitecore/jss/pull/1536))
 * `[templates/nextjs-sxa]` Fix menu component of third-level menu. ([#1540](https://github.com/Sitecore/jss/pull/1540))
 * `[sitecore-jss-react]` [FEaaS] Prevent extra components client-side requests for SSR ([1541](https://github.com/Sitecore/jss/pull/1541))

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -79,8 +79,8 @@ describe('PersonalizeMiddleware', () => {
         get(key: string) {
           return req.headers[key];
         },
-        ...props.headerValues,
         referer: referrer,
+        ...props.headerValues,
       },
       referrer: 'about:client',
     } as NextRequest;
@@ -859,7 +859,7 @@ describe('PersonalizeMiddleware', () => {
     it('optional experiece params are not present', async () => {
       userAgentStub.returns({ ua: '' } as any);
 
-      const req = createRequest();
+      const req = createRequest({ headerValues: { referer: null } });
 
       const res = createResponse();
 
@@ -884,7 +884,7 @@ describe('PersonalizeMiddleware', () => {
 
       expect(
         executeExperience.calledWith(contentId, browserId, '', pointOfSale, {
-          referrer,
+          referrer: 'about:client',
           utm: {
             campaign: 'utm_campaign',
             content: null,

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -80,8 +80,9 @@ describe('PersonalizeMiddleware', () => {
           return req.headers[key];
         },
         ...props.headerValues,
+        referer: referrer,
       },
-      referrer,
+      referrer: 'about:client',
     } as NextRequest;
 
     return req;

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -102,7 +102,10 @@ export class PersonalizeMiddleware extends MiddlewareBase {
 
   protected getExperienceParams(req: NextRequest): ExperienceParams {
     return {
-      referrer: req.referrer,
+      // It's expected that the header name "referer" is actually a misspelling of the word "referrer"
+      // req.referrer is used during fetching to determine the value of the Referer header of the request being made,
+      // used as a fallback
+      referrer: req.headers.get('referer') || req.referrer,
       utm: {
         campaign: req.nextUrl.searchParams.get('utm_campaign'),
         content: req.nextUrl.searchParams.get('utm_content'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Personalize middleware doesn't access a real referrer value (from headers), instead, it provided a default "about:client" value from the request
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
