### PR TITLE
[nextjs] Fix double placeholder in Experience Editor in production mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-react]` Remove use of reactDom/server from React Image ([1544](https://github.com/Sitecore/jss/pull/1544))
 * `[sitecore-jss-nextjs]` Referrer is not captured by Personalize middleware ([#1542](https://github.com/Sitecore/jss/pull/1542))
 * `[sitecore-jss-nextjs]` Fix of redirects middleware. Add possible to use tokens like $1, $2, $3, etc. ([#1547](https://github.com/Sitecore/jss/pull/1547))
+* `[sitecore.jss-react]` Fix double placeholder in Experience Editor in production mode ([#1557](https://github.com/Sitecore/jss/pull/1557))
 
 ## 21.2.1
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { PlaceholderCommon, PlaceholderProps } from './PlaceholderCommon';
 import { withComponentFactory } from '../enhancers/withComponentFactory';
 import { ComponentRendering, HtmlElementRendering } from '@sitecore-jss/sitecore-jss/layout';
-import { HorizonEditor, ExperienceEditor } from '@sitecore-jss/sitecore-jss/utils';
+import { HorizonEditor } from '@sitecore-jss/sitecore-jss/utils';
 
 export interface PlaceholderComponentProps extends PlaceholderProps {
   /**
@@ -90,11 +90,11 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
       this.props.name
     );
 
+    const components = this.getComponentsForRenderingData(placeholderData);
+
     this.isEmpty = placeholderData.every((rendering: ComponentRendering | HtmlElementRendering) =>
       isRawRendering(rendering)
     );
-
-    const components = this.getComponentsForRenderingData(placeholderData);
 
     if (this.props.renderEmpty && this.isEmpty) {
       const rendered = this.props.renderEmpty(components);

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -94,38 +94,6 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
       isRawRendering(rendering)
     );
 
-    // This is a workaround to insert Experience Editor-specific markup on the page for empty placeholders.
-    // It makes sure the markup is inserted by react and thus avoiding hydration errors when in editing mode
-    if (this.isEmpty && ExperienceEditor.isActive()) {
-      const codePos = placeholderData.findIndex(
-        (component) =>
-          (component as HtmlElementRendering).name === 'code' &&
-          (component as HtmlElementRendering).attributes.kind === 'open'
-      );
-      const plhId = (placeholderData[codePos] as HtmlElementRendering).attributes.id;
-      const emptyPlaceholderMarkup: HtmlElementRendering[] = [
-        {
-          name: 'span',
-          contents: null,
-          attributes: {
-            type: 'text/sitecore',
-            'sc-part-of': 'placeholder rendering',
-            style: 'display: none;',
-          },
-        },
-        {
-          name: 'div',
-          contents: null,
-          attributes: {
-            class: 'scEnabledChrome scEmptyPlaceholder',
-            'sc-part-of': 'placeholder',
-            'sc-placeholder-id': plhId,
-          },
-        },
-      ];
-      placeholderData.splice(codePos + 1, 0, ...emptyPlaceholderMarkup);
-    }
-
     const components = this.getComponentsForRenderingData(placeholderData);
 
     if (this.props.renderEmpty && this.isEmpty) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove workaround from bug 540957 (https://github.com/Sitecore/jss/pull/1161) that addressed placeholder hydration errors.
This will bring back hydration console errors when using jss connected mode in rendering host, but will get rid of issues when using rendering host in production mode instead (which is a better tradeoff).
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

