### PR TITLE
[nextjs] Bring your own code (BYOC) feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs-sxa]` `[sitecore-jss-nextjs]` "Bring Your Own Code" (BYOC) feature is introduced. This allows developers and editors more flexibility when developing and working with new components, i.e.:
   * Avoid the jss deploy process for components, and use FEAAS registration instead
-  * Put components anywhere in the project, with any prop type that is not dependent on Layout Service data
-  * (As soon as the feature is fully integrated for editing) Set component props on the fly when editing a page
+  * Put components anywhere in the project, 
+  * Use any prop type, without dependence on Layout Service data 
 Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore/jss/pull/1568))
 * `[templates]` Add JSS_APP_NAME to .env files ([#1571](https://github.com/Sitecore/jss/pull/1571))
 * `[sitecore-jss]` `[sitecore-jss-nextjs]` `[templates/nextjs]` Introduce performance metrics for debug logging ([#1555](https://github.com/Sitecore/jss/pull/1555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[templates/nextjs-sxa]` `[sitecore-jss-nextjs]` "Bring Your Own Code" (BYOC) feature is introduced. This allows developers and editors more flexibility when developing and working with new components, i.e.:
+  * Avoid the jss deploy process for components, and use FEAAS registration instead
+  * Put components anywhere in the project, with any prop type that is not dependent on Layout Service data
+  * (As soon as the feature is fully integrated for editing) Set component props on the fly when editing a page
+Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore/jss/pull/1568))
 * `[templates]` Add JSS_APP_NAME to .env files ([#1571](https://github.com/Sitecore/jss/pull/1571))
 * `[sitecore-jss]` `[sitecore-jss-nextjs]` `[templates/nextjs]` Introduce performance metrics for debug logging ([#1555](https://github.com/Sitecore/jss/pull/1555))
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]`  Introduce layout service REST configuration name environment variable ([#1543](https://github.com/Sitecore/jss/pull/1543))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` Support for out-of-process editing data caches was added. Vercel KV or a custom Redis cache can be used to improve editing in Pages and Experience Editor when using Vercel deployment as editing/rendering host ([#1530](https://github.com/Sitecore/jss/pull/1530))
+* `[sitecore-jss-react]` Built-in MissingComponent component can now accept "errorOverride" text in props - to be displayed in the yellow frame as a custom error message. ([#1568](https://github.com/Sitecore/jss/pull/1568))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/BYOCWrapper.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/BYOCWrapper.tsx
@@ -1,0 +1,15 @@
+import { BYOCProps, BYOCRenderer } from '@sitecore-jss/sitecore-jss-nextjs';
+import React from 'react';
+import * as FEAAS from '@sitecore-feaas/clientside/react';
+
+export const Default = (props: BYOCProps): JSX.Element => {
+  const rendererProps = {
+    components: FEAAS.External.registered,
+    ...props,
+  };
+  return (
+    <div className="component-content">
+      <BYOCRenderer {...rendererProps} />
+    </div>
+  );
+};

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/BYOCWrapper.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/BYOCWrapper.tsx
@@ -3,13 +3,17 @@ import React from 'react';
 import * as FEAAS from '@sitecore-feaas/clientside/react';
 
 export const Default = (props: BYOCProps): JSX.Element => {
+  const styles = props.params?.styles?.trimEnd();
+  const id = props.params?.RenderingIdentifier;
   const rendererProps = {
     components: FEAAS.External.registered,
     ...props,
   };
   return (
-    <div className="component-content">
-      <BYOCRenderer {...rendererProps} />
+    <div className={styles ? styles : undefined} id={id ? id : undefined}>
+      <div className="component-content">
+        <BYOCRenderer {...rendererProps} />
+      </div>
     </div>
   );
 };

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -173,6 +173,7 @@ export {
   BYOCProps,
   BYOCRenderingParams,
   BYOCRenderer,
+  BYOCRendererProps,
   File,
   FileField,
   RichTextField,

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -170,6 +170,8 @@ export {
   FEaaSComponentProps,
   FEaaSComponentParams,
   fetchFEaaSComponentServerProps,
+  BYOCProps,
+  BYOCRenderer,
   File,
   FileField,
   RichTextField,

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -171,6 +171,7 @@ export {
   FEaaSComponentParams,
   fetchFEaaSComponentServerProps,
   BYOCProps,
+  BYOCRenderingParams,
   BYOCRenderer,
   File,
   FileField,

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { BYOCRenderer } from './BYOCRenderer';
-import { MissingComponent } from './MissingComponent';
+import { MissingComponent, MissingComponentProps } from './MissingComponent';
 import { ComponentFields } from '@sitecore-jss/sitecore-jss/layout';
 
 describe('<BYOCRenderer />', () => {
@@ -14,6 +14,10 @@ describe('<BYOCRenderer />', () => {
     <div className="byoc">I display this: {props.text || 'nothing'}</div>
   );
 
+  const ThrowingComponent = () => {
+    throw Error('error thrown');
+  };
+
   const getBaseByocProps = (
     registeredComponent: React.ComponentType<any>,
     componentProps?: string,
@@ -23,6 +27,10 @@ describe('<BYOCRenderer />', () => {
       RegisteredComponent: {
         name: 'RegisteredComponent',
         component: registeredComponent,
+      },
+      ThrowingComponent: {
+        name: 'ThrowingComponent',
+        component: ThrowingComponent,
       },
     };
 
@@ -43,26 +51,6 @@ describe('<BYOCRenderer />', () => {
     const wrapper = mount(<BYOCRenderer {...props} />);
 
     expect(wrapper.find('div.byoc').text()).to.equal('Registered Component');
-  });
-
-  it('should render missing component frame when component isnt registered', () => {
-    const props = { params: { ComponentName: 'NonExistentComponent' }, components: {} };
-
-    const wrapper = mount(<BYOCRenderer {...props} />);
-
-    expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
-    expect(wrapper.find('div p').text()).to.contain('This component was not registered');
-  });
-
-  it('should render missing component frame when component name is not provided', () => {
-    const props = { params: { ComponentName: '' }, components: {} };
-
-    const wrapper = mount(<BYOCRenderer {...props} />);
-
-    expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
-    expect(wrapper.find('div p').text()).to.contain(
-      'The ComponentName for this rendering is missing'
-    );
   });
 
   it('should use props from rendering params when present', () => {
@@ -107,25 +95,131 @@ describe('<BYOCRenderer />', () => {
     expect(wrapper.find('div.byoc').text()).to.contain('this is data source text');
   });
 
-  it('should use props from data source if params have invalid JSON', () => {
-    const dataSourceFields: ComponentFields = {
-      text: {
-        value: 'this is data source text',
-      },
-    };
-    const props = getBaseByocProps(ComponentWithProps, 'this is not a JSON', dataSourceFields);
-
-    const wrapper = mount(<BYOCRenderer {...props} />);
-
-    expect(wrapper.find('div.byoc').text()).to.contain('I display this');
-    expect(wrapper.find('div.byoc').text()).to.contain('this is data source text');
-  });
-
   it('should fallback to empty props when other sources fail', () => {
     const props = getBaseByocProps(ComponentWithProps, '', {});
 
     const wrapper = mount(<BYOCRenderer {...props} />);
 
     expect(wrapper.find('div.byoc').text()).to.equal('I display this: nothing');
+  });
+
+  describe('error handling', () => {
+    it('should render error if params have invalid JSON', () => {
+      const dataSourceFields: ComponentFields = {
+        text: {
+          value: 'this is data source text',
+        },
+      };
+      const props = getBaseByocProps(ComponentWithProps, 'this is not a JSON', dataSourceFields);
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('A rendering error occurred:');
+      expect(wrapper.find('div').text()).to.contain('Unexpected token');
+    });
+
+    it('should render custom error component when provided, when params have invalid JSON', () => {
+      const dataSourceFields: ComponentFields = {
+        text: {
+          value: 'this is data source text',
+        },
+      };
+      const customErrorComponent = () => <div>custom error</div>;
+      const props = {
+        errorComponent: customErrorComponent,
+        ...getBaseByocProps(ComponentWithProps, 'this is not a JSON', dataSourceFields),
+      };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('custom error');
+    });
+
+    it('should render error if underlying component throws', () => {
+      const props = {
+        ...getBaseByocProps(ComponentWithProps),
+        params: {
+          ComponentName: 'ThrowingComponent',
+        },
+      };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('A rendering error occurred: error thrown');
+    });
+
+    it('should render custom error component when provided, when underlying component throws', () => {
+      const customErrorComponent = (props) => <div>custom error: {props?.error?.message}</div>;
+      const props = {
+        ...getBaseByocProps(ComponentWithProps),
+        errorComponent: customErrorComponent,
+        params: {
+          ComponentName: 'ThrowingComponent',
+        },
+      };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('custom error: error thrown');
+    });
+
+    it('should render missing component frame when component isnt registered', () => {
+      const props = { params: { ComponentName: 'NonExistentComponent' }, components: {} };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
+      expect(wrapper.find('div p').text()).to.contain('This component was not registered');
+    });
+
+    it('should render custom missing component when provided, when component isnt registered', () => {
+      const missingComponent = (props: MissingComponentProps) => (
+        <div>
+          Custom missive for {props.rendering?.componentName}: {props.errorOverride}
+        </div>
+      );
+
+      const props = {
+        missingComponentComponent: missingComponent,
+        params: { ComponentName: 'NonExistentComponent' },
+        components: {},
+      };
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('Custom missive for NonExistentComponent');
+      expect(wrapper.find('div').text()).to.contain('This component was not registered');
+    });
+
+    it('should render missing component frame when component name is not provided', () => {
+      const props = { params: { ComponentName: '' }, components: {} };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
+      expect(wrapper.find('div p').text()).to.contain(
+        'The ComponentName for this rendering is missing'
+      );
+    });
+
+    it('should render custom missing component when provided, when component name is not provided', () => {
+      const missingComponent = (props: MissingComponentProps) => (
+        <div>
+          Custom missive for {props.rendering?.componentName}: {props.errorOverride}
+        </div>
+      );
+
+      const props = {
+        missingComponentComponent: missingComponent,
+        params: { ComponentName: '' },
+        components: {},
+      };
+
+      const wrapper = mount(<BYOCRenderer {...props} />);
+
+      expect(wrapper.find('div').text()).to.contain('Custom missive');
+      expect(wrapper.find('div').text()).to.contain(
+        'The ComponentName for this rendering is missing'
+      );
+    });
   });
 });

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
@@ -51,6 +51,16 @@ describe('<BYOCRenderer />', () => {
     const wrapper = mount(<BYOCRenderer {...props} />);
 
     expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
+    expect(wrapper.find('div p').text()).to.contain('This component was not registered');
+  });
+
+  it('should render missing component frame when component name is not provided', () => {
+    const props = { params: { ComponentName: '' }, components: {} };
+
+    const wrapper = mount(<BYOCRenderer {...props} />);
+
+    expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
+    expect(wrapper.find('div p').text()).to.contain('The ComponentName for this rendering is missing');
   });
 
   it('should use props from rendering params when present', () => {

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
@@ -60,7 +60,9 @@ describe('<BYOCRenderer />', () => {
     const wrapper = mount(<BYOCRenderer {...props} />);
 
     expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
-    expect(wrapper.find('div p').text()).to.contain('The ComponentName for this rendering is missing');
+    expect(wrapper.find('div p').text()).to.contain(
+      'The ComponentName for this rendering is missing'
+    );
   });
 
   it('should use props from rendering params when present', () => {

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+import { BYOCProps, BYOCRenderer } from './BYOCRenderer';
+import * as FEAAS from '@sitecore-feaas/clientside/react';
+import { afterEach } from 'node:test';
+
+describe('<BYOCRenderer />', () => {
+  const ExternalComponent = () => {
+    <div className="byoc">I was rendered, woo!</div>;
+  };
+
+  type TestProps = {
+    message: string;
+  };
+
+  const ExternalWithPropsComponent = (props: TestProps) => {
+    <div className="byoc">My message to you is {props.message}</div>;
+  };
+
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should render component', () => {
+    const components: Record<string, unknown> = {};
+    components['ExternalComponent'] = { name: 'ExternalComponent', component: ExternalComponent };
+    sandbox.stub(FEAAS.External, 'registered').value(components);
+    const props: BYOCProps = {
+      params: {
+        ComponentName: 'ExternalComponent',
+      },
+    };
+    const rendered = mount(<BYOCRenderer {...props} />);
+    // const wrapper = shallow(<BYOCRenderer {...props} />);
+    expect(rendered).to.have.length(1);
+    expect(rendered.text()).to.contain('I was rendered, woo!');
+  });
+
+  xit('should render missing component frame when component isnt registered', () => {});
+  xit('should use props from rendering params when present', () => {});
+  xit('should use props from data source as fallback', () => {});
+  xit('should use props from data source if params have invalid JSON', () => {});
+  xit('should fallback to empty props when other sources fail', () => {});
+});

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.test.tsx
@@ -1,48 +1,82 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { BYOCProps, BYOCRenderer } from './BYOCRenderer';
+import { MissingComponent } from './MissingComponent';
 import * as FEAAS from '@sitecore-feaas/clientside/react';
-import { afterEach } from 'node:test';
 
 describe('<BYOCRenderer />', () => {
-  const ExternalComponent = () => {
-    <div className="byoc">I was rendered, woo!</div>;
-  };
+  // const ExternalComponent = () => {
+  //   <div className="byoc">I was rendered, woo!</div>;
+  // };
 
-  type TestProps = {
-    message: string;
-  };
+  // type TestProps = {
+  //   message: string;
+  // };
 
-  const ExternalWithPropsComponent = (props: TestProps) => {
-    <div className="byoc">My message to you is {props.message}</div>;
-  };
+  // const ExternalWithPropsComponent = (props: TestProps) => {
+  //   <div className="byoc">My message to you is {props.message}</div>;
+  // };
 
-  const sandbox = sinon.createSandbox();
+  // const sandbox = sinon.createSandbox();
 
-  afterEach(() => {
-    sandbox.restore();
-  });
+  // afterEach(() => {
+  //   sandbox.restore();
+  // });
 
-  it('should render component', () => {
-    const components: Record<string, unknown> = {};
-    components['ExternalComponent'] = { name: 'ExternalComponent', component: ExternalComponent };
-    sandbox.stub(FEAAS.External, 'registered').value(components);
-    const props: BYOCProps = {
-      params: {
-        ComponentName: 'ExternalComponent',
+  // it('should render component', () => {
+  //   const components: Record<string, unknown> = {};
+  //   components['ExternalComponent'] = { name: 'ExternalComponent', component: ExternalComponent };
+  //   sandbox.stub(FEAAS.External, 'registered').value(components);
+  //   const props: BYOCProps = {
+  //     params: {
+  //       ComponentName: 'ExternalComponent',
+  //     },
+  //   };
+  //   const rendered = mount(<BYOCRenderer {...props} />);
+  //   // const wrapper = shallow(<BYOCRenderer {...props} />);
+  //   expect(rendered).to.have.length(1);
+  //   expect(rendered.text()).to.contain('I was rendered, woo!');
+  // });
+
+  it('should render the registered component with provided props', () => {
+    const registeredComponents = {
+      RegisteredComponent: {
+        name: 'RegisteredComponent',
+        component: () => <div>Registered Component</div>,
       },
     };
-    const rendered = mount(<BYOCRenderer {...props} />);
-    // const wrapper = shallow(<BYOCRenderer {...props} />);
-    expect(rendered).to.have.length(1);
-    expect(rendered.text()).to.contain('I was rendered, woo!');
+
+    // Mocking the FEAAS.External.registered
+    const registeredStub = sinon.stub(FEAAS.External, 'registered').value(registeredComponents);
+
+    const props: BYOCProps = {
+      params: {
+        ComponentName: 'RegisteredComponent',
+        ComonentProps: JSON.stringify({ text: 'Hello, World!' }),
+      },
+    };
+
+    const wrapper = mount(<BYOCRenderer {...props} />);
+    expect(wrapper.find('div').text()).to.equal('Registered Component');
+
+    registeredStub.restore();
   });
 
-  xit('should render missing component frame when component isnt registered', () => {});
+  it('should render missing component frame when component isnt registered', () => {
+    const registeredStub = sinon.stub(FEAAS.External, 'registered').value({});
+
+    const props = { params: { ComponentName: 'NonExistentComponent' } };
+
+    const wrapper = mount(<BYOCRenderer {...props} />);
+    expect(wrapper.find(MissingComponent)).to.have.lengthOf(1);
+
+    registeredStub.restore();
+  });
+
   xit('should use props from rendering params when present', () => {});
   xit('should use props from data source as fallback', () => {});
   xit('should use props from data source if params have invalid JSON', () => {});

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -7,7 +7,7 @@ import { RegisteredComponents } from '@sitecore-feaas/clientside/types/ui/FEAASE
 /**
  * Data from rendering params on Sitecore's BYOC rendering
  */
-type BYOCRenderingParams = {
+export type BYOCRenderingParams = {
   /**
    * Name of the component to render
    */
@@ -16,6 +16,9 @@ type BYOCRenderingParams = {
    * JSON props to pass into rendered component
    */
   ComponentProps?: string;
+  /**
+   * A string with classes that can be used to apply themes, via SXA functionality
+   */
   styles?: string;
   RenderingIdentifier?: string;
 };

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -51,7 +51,7 @@ export const BYOCRenderer = (props: ByocRendererProps) => {
   if (!componentName) {
     const noNameProps = {
       errorOverride: 'BYOC: The ComponentName for this rendering is missing',
-    }
+    };
     return <MissingComponent {...noNameProps} />;
   }
   // props.components would contain component from internal FEAAS regsitered component collection (registered in app)

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import * as FEAAS from '@sitecore-feaas/clientside/react';
+import { ComponentFields } from '@sitecore-jss/sitecore-jss/layout';
+import { getDataFromFields } from '../utils';
+import { MissingComponent } from './MissingComponent';
+
+type BYOCRenderingParams = {
+  ComponentName: string;
+  ComonentProps?: string;
+};
+
+export type BYOCProps = {
+  params?: BYOCRenderingParams;
+  fields?: ComponentFields;
+};
+
+/**
+ * BYOCRenderer helps us
+ * @param props
+ * @returns
+ */
+export const BYOCRenderer = (props: BYOCProps) => {
+  const { ComponentName: componentName } = props.params || {};
+  if (!componentName) return <MissingComponent />;
+
+  const Component = Object.keys(FEAAS.External.registered).length
+    ? Object.values(FEAAS.External.registered).find((component) => component.name === componentName)
+        ?.component
+    : null;
+
+  if (!Component) {
+    const missingProps = {
+      rendering: {
+        componentName: componentName,
+      },
+      errorOverride: 'BYOC: The component you requested is not registered',
+    };
+    return <MissingComponent {...missingProps} />;
+  }
+
+  let componentProps: { [key: string]: unknown } = {};
+
+  if (props.params?.ComonentProps) {
+    try {
+      componentProps = JSON.parse(props.params.ComonentProps) ?? {};
+    } catch (e) {
+      console.warn(
+        `Parsing props for ${componentName} component from rendering params failed. Attempting to parse from data source`
+      );
+    }
+  }
+  if (!componentProps && props.fields) {
+    componentProps = getDataFromFields(props.fields) ?? {};
+  }
+
+  return <>{Component && <Component {...componentProps} />}</>;
+};
+// this will be in initializer/nextjs app
+export const BYOCWrapper = () => <BYOCRenderer></BYOCRenderer>;

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -58,11 +58,14 @@ export const BYOCRenderer = (props: ByocRendererProps) => {
     : null;
 
   if (!Component) {
+    console.warn(
+      `Component "${componentName}" was not registered, please ensure the FEEAS.External.registerComponent call is made.`
+    );
     const missingProps = {
       rendering: {
         componentName: componentName,
       },
-      errorOverride: 'BYOC: The component you requested is not registered',
+      errorOverride: 'BYOC: This component was not registered.',
     };
     return <MissingComponent {...missingProps} />;
   }

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -40,9 +40,19 @@ export type BYOCProps = {
 /**
  * Props for BYOCRenderer component. Includes components list to load external components from.
  */
-type BYOCRendererProps = BYOCProps & {
+export type BYOCRendererProps = BYOCProps & {
+  /**
+   * Registered component collection. Would be taken from FEAAS.External.registered
+   */
   components: RegisteredComponents;
+  /**
+   * Error component override. To be shown when Renderer or underlying component throws
+   */
   errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
+  /**
+   * Override to indicate missing component situations. Would be shown when BYOC component is not registered
+   * or ComponentName is missing
+   */
   missingComponentComponent?:
     | React.ComponentClass<MissingComponentProps>
     | React.FC<MissingComponentProps>;
@@ -54,7 +64,7 @@ type ErrorComponentProps = {
 };
 
 const DefaultErrorComponent = (props: ErrorComponentProps) => (
-  <div>A rendering error occurred: {props.error.message}.</div>
+  <div>A rendering error occurred: {props.error?.message}.</div>
 );
 
 /**

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -48,14 +48,15 @@ type ByocRendererProps = BYOCProps & {
  */
 export const BYOCRenderer = (props: ByocRendererProps) => {
   const { ComponentName: componentName } = props.params || {};
-  if (!componentName) return <MissingComponent />;
-
+  if (!componentName) {
+    const noNameProps = {
+      errorOverride: 'BYOC: The ComponentName for this rendering is missing',
+    }
+    return <MissingComponent {...noNameProps} />;
+  }
   // props.components would contain component from internal FEAAS regsitered component collection (registered in app)
   // we can't access this collection here directly, as the collection from packages's dependency would be different from the one in app
-  const Component = Object.keys(props.components).length
-    ? Object.values(props.components).find((component) => component.name === componentName)
-        ?.component
-    : null;
+  const Component = props.components[componentName]?.component;
 
   if (!Component) {
     console.warn(

--- a/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCRenderer.tsx
@@ -39,7 +39,7 @@ export const BYOCRenderer = (props: BYOCProps) => {
     return <MissingComponent {...missingProps} />;
   }
 
-  let componentProps: { [key: string]: unknown } = {};
+  let componentProps: { [key: string]: unknown } = undefined;
 
   if (props.params?.ComonentProps) {
     try {
@@ -50,11 +50,11 @@ export const BYOCRenderer = (props: BYOCProps) => {
       );
     }
   }
-  if (!componentProps && props.fields) {
-    componentProps = getDataFromFields(props.fields) ?? {};
+  if (!componentProps) {
+    componentProps = props.fields ? getDataFromFields(props.fields) : {};
   }
 
-  return <>{Component && <Component {...componentProps} />}</>;
+  return <Component {...componentProps} />;
 };
 // this will be in initializer/nextjs app
 export const BYOCWrapper = () => <BYOCRenderer></BYOCRenderer>;

--- a/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/FEaaSComponent.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import * as FEAAS from '@sitecore-feaas/clientside/react';
-import {
-  ComponentFields,
-  LayoutServicePageState,
-  getFieldValue,
-} from '@sitecore-jss/sitecore-jss/layout';
+import { ComponentFields, LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
+import { getDataFromFields } from '../utils';
 
 export const FEAAS_COMPONENT_RENDERING_NAME = 'FEaaSComponent';
 
@@ -138,15 +135,6 @@ export async function fetchFEaaSComponentServerProps(
     };
   }
 }
-
-const getDataFromFields = (fields: ComponentFields): { [key: string]: unknown } => {
-  let data: { [key: string]: unknown } = {};
-  data = Object.entries(fields).reduce((acc, [key]) => {
-    acc[key] = getFieldValue(fields, key);
-    return acc;
-  }, data);
-  return data;
-};
 
 /**
  * Build component endpoint URL from component's params

--- a/packages/sitecore-jss-react/src/components/MissingComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/components/MissingComponent.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { MissingComponent } from './MissingComponent';
+
+describe('<MissingComponent>', () => {
+  it('should accept and display custom error', () => {
+    const errorMsg = 'Oops, I errored again';
+    const props = {
+      rendering: {
+        componentName: 'test',
+      },
+      errorOverride: errorMsg,
+    };
+
+    const wrapper = mount(<MissingComponent {...props} />);
+
+    expect(wrapper.find('div p').text()).to.contain(errorMsg);
+  });
+});

--- a/packages/sitecore-jss-react/src/components/MissingComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/MissingComponent.tsx
@@ -5,6 +5,7 @@ export interface MissingComponentProps {
   rendering?: {
     componentName?: string;
   };
+  errorOverride?: string;
 }
 
 export const MissingComponent: React.FC<MissingComponentProps> = (props) => {
@@ -14,7 +15,9 @@ export const MissingComponent: React.FC<MissingComponentProps> = (props) => {
       : 'Unnamed Component';
 
   console.log(`Component props for unimplemented '${componentName}' component`, props);
-
+  const errorMessage =
+    props.errorOverride ||
+    'JSS component is missing React implementation. See the developer console for more information.';
   return (
     <div
       style={{
@@ -26,10 +29,7 @@ export const MissingComponent: React.FC<MissingComponentProps> = (props) => {
       }}
     >
       <h2>{componentName}</h2>
-      <p>
-        JSS component is missing React implementation. See the developer console for more
-        information.
-      </p>
+      <p>{errorMessage}</p>
     </div>
   );
 };

--- a/packages/sitecore-jss-react/src/components/MissingComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/MissingComponent.tsx
@@ -14,7 +14,9 @@ export const MissingComponent: React.FC<MissingComponentProps> = (props) => {
       ? props.rendering.componentName
       : 'Unnamed Component';
 
-  console.log(`Component props for unimplemented '${componentName}' component`, props);
+  // error override would mean component is not unimplemented
+  !props.errorOverride &&
+    console.log(`Component props for unimplemented '${componentName}' component`, props);
   const errorMessage =
     props.errorOverride ||
     'JSS component is missing React implementation. See the developer console for more information.';

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -62,6 +62,7 @@ export {
   FEaaSComponentParams,
   fetchFEaaSComponentServerProps,
 } from './components/FEaaSComponent';
+export { BYOCProps, BYOCRenderer } from './components/BYOCRenderer';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';
 export { VisitorIdentification } from './components/VisitorIdentification';

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -62,7 +62,12 @@ export {
   FEaaSComponentParams,
   fetchFEaaSComponentServerProps,
 } from './components/FEaaSComponent';
-export { BYOCProps, BYOCRenderer, BYOCRenderingParams } from './components/BYOCRenderer';
+export {
+  BYOCProps,
+  BYOCRenderer,
+  BYOCRenderingParams,
+  BYOCRendererProps,
+} from './components/BYOCRenderer';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';
 export { VisitorIdentification } from './components/VisitorIdentification';

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -62,7 +62,7 @@ export {
   FEaaSComponentParams,
   fetchFEaaSComponentServerProps,
 } from './components/FEaaSComponent';
-export { BYOCProps, BYOCRenderer } from './components/BYOCRenderer';
+export { BYOCProps, BYOCRenderer, BYOCRenderingParams } from './components/BYOCRenderer';
 export { Link, LinkField, LinkFieldValue, LinkProps, LinkPropTypes } from './components/Link';
 export { File, FileField } from './components/File';
 export { VisitorIdentification } from './components/VisitorIdentification';

--- a/packages/sitecore-jss-react/src/utils.test.ts
+++ b/packages/sitecore-jss-react/src/utils.test.ts
@@ -102,11 +102,11 @@ describe('jss-react utils', () => {
           value: 'we count to',
         },
         number: {
-          value: 10
+          value: 10,
         },
         message: {
           value: 'well done counting',
-        }
+        },
       };
       const expectedResult = {
         text: 'we count to',

--- a/packages/sitecore-jss-react/src/utils.test.ts
+++ b/packages/sitecore-jss-react/src/utils.test.ts
@@ -4,7 +4,9 @@ import {
   convertAttributesToReactProps,
   convertStyleAttribute,
   getAttributesString,
+  getDataFromFields,
 } from './utils';
+import { ComponentFields } from '@sitecore-jss/sitecore-jss/layout';
 
 describe('jss-react utils', () => {
   describe('convertStyleAttribute', () => {
@@ -90,6 +92,29 @@ describe('jss-react utils', () => {
       const result = getAttributesString(attributes);
 
       expect(result).to.eql('');
+    });
+  });
+
+  describe('getDataFromFields', () => {
+    it('should parse fields into JSON', () => {
+      const fields: ComponentFields = {
+        text: {
+          value: 'we count to',
+        },
+        number: {
+          value: 10
+        },
+        message: {
+          value: 'well done counting',
+        }
+      };
+      const expectedResult = {
+        text: 'we count to',
+        number: 10,
+        message: 'well done counting',
+      };
+
+      expect(getDataFromFields(fields)).to.deep.equal(expectedResult);
     });
   });
 });

--- a/packages/sitecore-jss-react/src/utils.ts
+++ b/packages/sitecore-jss-react/src/utils.ts
@@ -1,3 +1,4 @@
+import { ComponentFields, getFieldValue } from '@sitecore-jss/sitecore-jss/layout';
 import { parse as styleParse } from 'style-attr';
 
 // https://stackoverflow.com/a/10426674/9324
@@ -97,4 +98,18 @@ export const getAttributesString = (attributes: { [key: string]: unknown }): str
   }
 
   return attributesEntries.join(' ');
+};
+
+/**
+ * Used in FEAAS and BYOC implementations to convert datasource item field values into component props
+ * @param fields field collection from Sitecore
+ * @returns JSON object that can be used as props
+ */
+export const getDataFromFields = (fields: ComponentFields): { [key: string]: unknown } => {
+  let data: { [key: string]: unknown } = {};
+  data = Object.entries(fields).reduce((acc, [key]) => {
+    acc[key] = getFieldValue(fields, key);
+    return acc;
+  }, data);
+  return data;
 };

--- a/packages/sitecore-jss-react/src/utils.ts
+++ b/packages/sitecore-jss-react/src/utils.ts
@@ -102,7 +102,7 @@ export const getAttributesString = (attributes: { [key: string]: unknown }): str
 
 /**
  * Used in FEAAS and BYOC implementations to convert datasource item field values into component props
- * @param fields field collection from Sitecore
+ * @param {ComponentFields} fields field collection from Sitecore
  * @returns JSON object that can be used as props
  */
 export const getDataFromFields = (fields: ComponentFields): { [key: string]: unknown } => {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
BYOC unwrapped allows developers to create components and then use them without following the component deployment guidelines. It means that components:
- Can use any prop type, without consideration for layout service data
- Be located anywhere
- Are not required to be deployed to Sitecore as rendering items

Right now BYOC can be used with Component Builder, but this PR allows using registered components on a page, directly.

Minor side effect of this PR is changes to MissingComponent - it can now display custom error messages to accommodate BYOC usecases.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - tested in connected mode with and without providing props to inner component

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
