### PR TITLE
[sitecore-jss-vue] Link component renders link description even when children are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-vue]` Link component renders link description even when children are provided ([#1570](https://github.com/Sitecore/jss/pull/1570))
 * `[sitecore-jss]` GraphQLSiteInfoService does not fetch more than 10 sites ([#1569](https://github.com/Sitecore/jss/pull/1569))
 * `[tempaltes/nextjs]` `[templates/nextjs-sxa]` `[sitecore-jss-nexjts]` Redirects don't work when file extensions present in a route ([#1566](https://github.com/Sitecore/jss/pull/1566))
 * `[templates/vue]` "lint" command is failing due to bug introduced by eslint-plugin-prettier ([#1563](https://github.com/Sitecore/jss/pull/1563))

--- a/packages/sitecore-jss-vue/src/components/Link.test.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.test.ts
@@ -76,6 +76,43 @@ describe('<Link />', () => {
     expect(rendered.text()).toBe(props.field.text);
   });
 
+  it('should render with provided children', () => {
+    const props = {
+      field: {
+        href: '/lorem',
+        text: '[ipsum]',
+      },
+    };
+    const rendered = mount(Link, {
+      props,
+      slots: {
+        default: ['<p>Custom description</p>'],
+      },
+    }).find('a');
+
+    expect(rendered.attributes().href).toBe(props.field.href);
+    expect(rendered.text()).toBe('Custom description');
+  });
+
+  it('should render link text with provided children', () => {
+    const props = {
+      field: {
+        href: '/lorem',
+        text: '[ipsum]',
+      },
+      showLinkTextWithChildrenPresent: true,
+    };
+    const rendered = mount(Link, {
+      props,
+      slots: {
+        default: ['<p>Custom description</p>'],
+      },
+    }).find('a');
+
+    expect(rendered.attributes().href).toBe(props.field.href);
+    expect(rendered.text()).toBe('[ipsum]Custom description');
+  });
+
   it('should render ee HTML', () => {
     const props = {
       field: {

--- a/packages/sitecore-jss-vue/src/components/Link.ts
+++ b/packages/sitecore-jss-vue/src/components/Link.ts
@@ -94,7 +94,7 @@ export const Link = defineComponent({
     }
 
     const linkText =
-      showLinkTextWithChildrenPresent || !children || children.length === 0
+      showLinkTextWithChildrenPresent || !children || children().length === 0
         ? link.text || link.href
         : null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
* Pulled changes from #1407 
* Added unit tests to cover this case
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - manual testing using connected mode

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
