### PR TITLE
 #563014: [templates/nextjs-sxa] sitemap. reverted chanegs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore
 * `[sitecore.jss-react]` Fix double placeholder in Experience Editor in production mode ([#1557](https://github.com/Sitecore/jss/pull/1557))
 * `[sitecore-jss-nextjs]` Fix of redirects middleware. Add possible to use tokens like $1, $2, $3, etc. ([#1547](https://github.com/Sitecore/jss/pull/1547)) ([#1559](https://github.com/Sitecore/jss/pull/1559)) ([#1561](https://github.com/Sitecore/jss/pull/1561)) ([#1562](https://github.com/Sitecore/jss/pull/1562))
 * `[templates/nextjs-sxa]` Change Content-Type of robots.txt response (`text/html;charset=utf-8`➡`text/plain`).
-* `[templates/nextjs-sxa]` Fixed opening sitemap.xml ([#1581](https://github.com/Sitecore/jss/pull/1581))
 
 ## 21.2.3
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -49,14 +49,8 @@ const sitemapApi = async (
   const sitemaps = await sitemapXmlService.fetchSitemaps();
 
   if (!sitemaps.length) {
-    return new AxiosDataFetcher()
-      .get(`${config.sitecoreApiHost}/sitemap.xml`, {
-        responseType: 'stream',
-      })
-      .then((response: AxiosResponse) => {
-        response.data.pipe(res);
-      })
-      .catch(() => res.redirect('/404'));  }
+    return res.redirect('/404');
+  }
 
   const SitemapLinks = sitemaps
     .map((item) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
Reverted changes. Reason: it was not a bug. Redirect to 404 if sitemap isn't generated - it's ok
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
