### PR TITLE
[Netlify] Allow public URL detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]`  Introduce layout service REST configuration name environment variable ([#1543](https://github.com/Sitecore/jss/pull/1543))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` Support for out-of-process editing data caches was added. Vercel KV or a custom Redis cache can be used to improve editing in Pages and Experience Editor when using Vercel deployment as editing/rendering host ([#1530](https://github.com/Sitecore/jss/pull/1530))
 * `[sitecore-jss-react]` Built-in MissingComponent component can now accept "errorOverride" text in props - to be displayed in the yellow frame as a custom error message. ([#1568](https://github.com/Sitecore/jss/pull/1568))
+* `[sitecore-jss-nextjs]` Support for public URL resolution in Netlify ([#1585](https://github.com/Sitecore/jss/pull/1585))
 
 ### 🧹 Chores
 

--- a/packages/sitecore-jss-nextjs/src/utils/utils.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/utils.ts
@@ -7,6 +7,7 @@ import { isEditorActive, resetEditorChromes } from '@sitecore-jss/sitecore-jss/u
  * This is set to http://localhost:3000 by default.
  * VERCEL_URL is provided by Vercel in case if we are in Preview deployment (deployment based on the custom branch),
  * preview deployment has unique url, we don't know exact url.
+ * Similarly, DEPLOY_URL is provided by Netlify and would give us the deploy URL
  */
 export const getPublicUrl = (): string => {
   if (process.env.NETLIFY && process.env.DEPLOY_URL) return process.env.DEPLOY_URL;

--- a/packages/sitecore-jss-nextjs/src/utils/utils.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/utils.ts
@@ -9,8 +9,8 @@ import { isEditorActive, resetEditorChromes } from '@sitecore-jss/sitecore-jss/u
  * preview deployment has unique url, we don't know exact url.
  */
 export const getPublicUrl = (): string => {
-  if (process.env.URL) return process.env.URL; // Netlify public URL
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // Vercel public URL
+  if (process.env.NETLIFY && process.env.DEPLOY_URL) return process.env.DEPLOY_URL;
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
 
   let url = process.env.PUBLIC_URL;
   if (url === undefined) {

--- a/packages/sitecore-jss-nextjs/src/utils/utils.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/utils.ts
@@ -9,7 +9,8 @@ import { isEditorActive, resetEditorChromes } from '@sitecore-jss/sitecore-jss/u
  * preview deployment has unique url, we don't know exact url.
  */
 export const getPublicUrl = (): string => {
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+  if (process.env.URL) return process.env.URL; // Netlify public URL
+  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // Vercel public URL
 
   let url = process.env.PUBLIC_URL;
   if (url === undefined) {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
Part of the effort to improve Netlify support. Allows for public URL detection so that specifying PUBLIC_URL env variable is no longer needed.
Uses Netlify's DEPLOY_URL variable to be in line with our implementation for Vercel support.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
