### PR TITLE
[Nextjs] Better error handling for component-level data fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]`  Introduce layout service REST configuration name environment variable ([#1543](https://github.com/Sitecore/jss/pull/1543))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` Support for out-of-process editing data caches was added. Vercel KV or a custom Redis cache can be used to improve editing in Pages and Experience Editor when using Vercel deployment as editing/rendering host ([#1530](https://github.com/Sitecore/jss/pull/1530))
 * `[sitecore-jss-react]` Built-in MissingComponent component can now accept "errorOverride" text in props - to be displayed in the yellow frame as a custom error message. ([#1568](https://github.com/Sitecore/jss/pull/1568))
+* `[templates/nextjs]` `[sitecore-jss-nextjs]` Better error handling for component-level data fetching ([#1586](https://github.com/Sitecore/jss/pull/1586))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/component-props.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/component-props.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsService } from '@sitecore-jss/sitecore-jss-nextjs';
+import { ComponentPropsService, ComponentPropsError } from '@sitecore-jss/sitecore-jss-nextjs';
 import { SitecorePageProps } from 'lib/page-props';
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import { moduleFactory } from 'temp/componentBuilder';
@@ -29,6 +29,20 @@ class ComponentPropsPlugin implements Plugin {
         context,
         moduleFactory,
       });
+    }
+
+    const errors = Object.keys(props.componentProps)
+      .map(id => {
+        const component = props.componentProps[id] as ComponentPropsError;
+
+        return component.error
+          ? `\nUnable to get component props for ${component.componentName} (${id}): ${component.error}`
+          : '';
+      })
+      .join('');
+
+    if (errors.length) {
+      throw new Error(errors);
     }
 
     return props;

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -99,6 +99,7 @@ export { GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
 
 export {
   ComponentPropsCollection,
+  ComponentPropsError,
   GetStaticComponentProps,
   GetServerSideComponentProps,
 } from './sharedTypes/component-props';

--- a/packages/sitecore-jss-nextjs/src/services/component-props-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/component-props-service.test.ts
@@ -105,7 +105,8 @@ describe('ComponentPropsService', () => {
     expect(result).to.deep.equal({
       x11: 'x11SSRData',
       x14: {
-        error: 'Error during preload data for component x14: whoops',
+        error: 'Error during preload data for component namex14 (x14): whoops',
+        componentName: 'namex14',
       },
       x16: 'myCustomComponentSSRData',
       x161: 'myCustomComponentSSRData',
@@ -156,7 +157,8 @@ describe('ComponentPropsService', () => {
     expect(result).to.deep.equal({
       x11: 'x11SSRData',
       x14: {
-        error: 'Error during preload data for component x14: whoops',
+        error: 'Error during preload data for component namex14 (x14): whoops',
+        componentName: 'namex14',
       },
       x16: 'myCustomComponentSSRData',
       x161: 'myCustomComponentSSRData',
@@ -198,7 +200,8 @@ describe('ComponentPropsService', () => {
     expect(result).to.deep.equal({
       x11: 'x11StaticData',
       x14: {
-        error: 'Error during preload data for component x14: whoops',
+        error: 'Error during preload data for component namex14 (x14): whoops',
+        componentName: 'namex14',
       },
       x16: 'myCustomComponentStaticData',
       x161: 'myCustomComponentStaticData',
@@ -234,7 +237,8 @@ describe('ComponentPropsService', () => {
     expect(result).to.deep.equal({
       x11: 'x11StaticData',
       x14: {
-        error: 'Error during preload data for component x14: whoops',
+        error: 'Error during preload data for component namex14 (x14): whoops',
+        componentName: 'namex14',
       },
       x16: 'myCustomComponentStaticData',
       x161: 'myCustomComponentStaticData',

--- a/packages/sitecore-jss-nextjs/src/services/component-props-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/component-props-service.ts
@@ -182,13 +182,15 @@ export class ComponentPropsService {
           componentProps[uid] = result;
         })
         .catch((error) => {
-          const errLog = `Error during preload data for component ${uid}: ${error.message ||
-            error}`;
+          const errLog = `Error during preload data for component ${
+            req.rendering.componentName
+          } (${uid}): ${error.message || error}`;
 
           console.error(chalk.red(errLog));
 
           componentProps[uid] = {
             error: error.message || errLog,
+            componentName: req.rendering.componentName,
           };
         });
     });

--- a/packages/sitecore-jss-nextjs/src/sharedTypes/component-props.ts
+++ b/packages/sitecore-jss-nextjs/src/sharedTypes/component-props.ts
@@ -1,11 +1,13 @@
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import { ComponentRendering, LayoutServiceData } from '@sitecore-jss/sitecore-jss/layout';
 
+export type ComponentPropsError = { error: string; componentName: string };
+
 /**
  * Shape of component props storage
  */
 export type ComponentPropsCollection = {
-  [componentUid: string]: unknown;
+  [componentUid: string]: unknown | ComponentPropsError;
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Previously, if an error was thrown in component-level getStatic/ServerSideProps, it was swallowed and the page was rendered without the specific component.
* This PR provides better error handling, it will throw an error by accumulating all the component-level errors
* Added _componentName_ in the error log for a better understating of the root cause
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - connected, production modes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
