### PR TITLE
[FEAAS][BYOC] Stylesheet loading support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Our versioning strategy is as follows:
   * Use any prop type, without dependence on Layout Service data 
 Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore/jss/pull/1568))
 * `[templates/nextjs-sxa]` Scaffolding components for BYOC is added. Use '--byoc' flag at the end of `jss scaffold` command to create a boilerplate component for BYOC ([#1572](https://github.com/Sitecore/jss/pull/1572))
+* `[sitecore-jss-nextjs]` Stylesheet loading via page head links for FEAAS and BYOC is implemented. This allows stylesheets to be loaded during SSR and avoid extra calls on client. ([#1587](https://github.com/Sitecore/jss/pull/1587))
 * `[templates/nextjs]` Scaffold new components outside of 'src/components' folder by specifying a path with src in it, i.e. `jss scaffold src/new-folder/NewComponent` ([#1572](https://github.com/Sitecore/jss/pull/1572))
 * `[templates]` Add JSS_APP_NAME to .env files ([#1571](https://github.com/Sitecore/jss/pull/1571))
 * `[sitecore-jss]` `[sitecore-jss-nextjs]` `[templates/nextjs]` Introduce performance metrics for debug logging ([#1555](https://github.com/Sitecore/jss/pull/1555))

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/page-props-factory/plugins/feaas-themes.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/lib/page-props-factory/plugins/feaas-themes.ts
@@ -1,0 +1,16 @@
+import { SitecorePageProps } from 'lib/page-props';
+import { getFEAASLibraryStylesheetLinks } from '@sitecore-jss/sitecore-jss-nextjs';
+import { Plugin } from '..';
+
+class FEeaSThemesPlugin implements Plugin {
+  order = 2;
+
+  async exec(props: SitecorePageProps) {
+    // Collect FEAAS themes
+    props.headLinks.push(...getFEAASLibraryStylesheetLinks(props.layoutData));
+
+    return props;
+  }
+}
+
+export const feaasThemesPlugin = new FEeaSThemesPlugin();

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -174,6 +174,7 @@ export {
   BYOCRenderingParams,
   BYOCRenderer,
   BYOCRendererProps,
+  getFEAASLibraryStylesheetLinks,
   File,
   FileField,
   RichTextField,

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -43,6 +43,7 @@ export {
   RestDictionaryService,
 } from '@sitecore-jss/sitecore-jss/i18n';
 export { mediaApi } from '@sitecore-jss/sitecore-jss/media';
+export { getFEAASLibraryStylesheetLinks } from '@sitecore-jss/sitecore-jss/feaas';
 export { ComponentFactory } from './components/sharedTypes';
 export { Placeholder, PlaceholderComponentProps } from './components/Placeholder';
 export {

--- a/packages/sitecore-jss/feaas.d.ts
+++ b/packages/sitecore-jss/feaas.d.ts
@@ -1,0 +1,1 @@
+export * from './types/feaas/index';

--- a/packages/sitecore-jss/feaas.js
+++ b/packages/sitecore-jss/feaas.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/feaas/index');

--- a/packages/sitecore-jss/src/feaas/index.ts
+++ b/packages/sitecore-jss/src/feaas/index.ts
@@ -1,0 +1,1 @@
+export { getFEAASLibraryStylesheetLinks } from './themes';

--- a/packages/sitecore-jss/src/feaas/themes.test.ts
+++ b/packages/sitecore-jss/src/feaas/themes.test.ts
@@ -1,0 +1,435 @@
+import { expect } from 'chai';
+import { FEAAS_SERVER_URL, getFEAASLibraryStylesheetLinks, getStylesheetUrl } from './themes';
+import { ComponentRendering, HtmlElementRendering } from '../layout';
+
+describe('utils', () => {
+  describe('getFEAASLibraryStylesheetLinks', () => {
+    const setBasicLayoutData = (component: ComponentRendering | HtmlElementRendering) => {
+      return {
+        sitecore: {
+          context: {},
+          route: {
+            name: 'home',
+            placeholders: {
+              main: [component],
+            },
+          },
+        },
+      };
+    };
+
+    it('should return empty array route data is not provided', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks({
+          sitecore: {
+            context: {},
+            route: null,
+          },
+        })
+      ).to.deep.equal([]);
+    });
+
+    describe('normal mode', () => {
+      it('should return links using CSSStyles field', () => {
+        expect(
+          getFEAASLibraryStylesheetLinks(
+            setBasicLayoutData({
+              componentName: 'test',
+              fields: {
+                CSSStyles: {
+                  value: '-library--foo',
+                },
+                LibraryId: {
+                  value: 'bar',
+                },
+              },
+            })
+          )
+        ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'style' }]);
+      });
+
+      it('should return links using LibraryId field', () => {
+        expect(
+          getFEAASLibraryStylesheetLinks(
+            setBasicLayoutData({
+              componentName: 'test',
+              fields: {
+                LibraryId: {
+                  value: 'bar',
+                },
+              },
+            })
+          )
+        ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'style' }]);
+      });
+
+      describe('normal mode', () => {
+        it('should return links using CSSStyles param', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {
+                  CSSStyles: '-library--foo',
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'style' }]);
+        });
+
+        it('should return links using LibraryId param', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {
+                  LibraryId: 'bar',
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'style' }]);
+        });
+
+        it('should return prefer params over fields', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {
+                  CSSStyles: '-library--foo',
+                },
+                fields: {
+                  CSSStyles: {
+                    value: '-library--not-foo',
+                  },
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'style' }]);
+
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {
+                  LibraryId: 'bar',
+                },
+                fields: {
+                  LibraryId: {
+                    value: 'not-bar',
+                  },
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'style' }]);
+        });
+
+        it('should read LibraryId from class when matching param or field is not found', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {
+                  NotCSSStyles: '-library--not-foo',
+                  NotLibraryId: 'not-foo',
+                },
+                fields: {
+                  NotCSSStyles: {
+                    value: '-library--not-foo',
+                  },
+                  NotLibraryId: {
+                    value: 'not-foo',
+                  },
+                },
+                attributes: {
+                  class: '-library--foo',
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'style' }]);
+        });
+
+        it('should return links using custom server url', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'test',
+                fields: {
+                  LibraryId: {
+                    value: 'bar',
+                  },
+                },
+              }),
+              'https://foo.net'
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('bar', 'https://foo.net'), rel: 'style' }]);
+        });
+
+        it('should return empty links array when required fields are not provided', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks({
+              sitecore: {
+                context: {},
+                route: {
+                  name: 'home',
+                  fields: {},
+                  placeholders: {},
+                },
+              },
+            })
+          ).to.deep.equal([]);
+        });
+
+        it('should return empty links array when required params are not provided', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                componentName: 'styled',
+                params: {},
+              })
+            )
+          ).to.deep.equal([]);
+        });
+
+        it('should traverse nested nodes and return only unique links', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks({
+              sitecore: {
+                context: {},
+                route: {
+                  name: 'home',
+                  fields: {
+                    CSSStyles: {
+                      value: '-library--foo',
+                    },
+                    LibraryId: {
+                      value: 'bar',
+                    },
+                  },
+                  placeholders: {
+                    x: [
+                      {
+                        componentName: 'x1-component',
+                        fields: {
+                          LibraryId: {
+                            value: 'foo',
+                          },
+                        },
+                        placeholders: {
+                          x1: [
+                            {
+                              componentName: 'x11-component',
+                              fields: {
+                                CSSStyles: {
+                                  value: '-library--x11',
+                                },
+                              },
+                            },
+                            {
+                              componentName: 'x12-component',
+                              fields: {
+                                CSSStyles: {
+                                  value: '-library--x12',
+                                },
+                                LibraryId: {
+                                  value: 'x12-id',
+                                },
+                              },
+                            },
+                          ],
+                          x2: [
+                            {
+                              componentName: 'x21-component',
+                              fields: {
+                                LibraryId: {
+                                  value: 'x21',
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    y: [
+                      {
+                        componentName: 'y1-component',
+                        fields: {
+                          LibraryId: {
+                            value: 'y1',
+                          },
+                        },
+                      },
+                      {
+                        componentName: 'y2-component',
+                        fields: {
+                          CSSStyles: {
+                            value: 'custom-style',
+                          },
+                          LibraryId: {
+                            value: 'y2',
+                          },
+                        },
+                      },
+                    ],
+                    z: [
+                      {
+                        componentName: 'z1-component',
+                        fields: {
+                          CSSStyles: {
+                            value: '-library--z1',
+                          },
+                        },
+                        placeholders: {
+                          z1: [
+                            {
+                              componentName: 'z11-component',
+                              fields: {
+                                CSSStyles: {
+                                  value: '-library--z11',
+                                },
+                              },
+                            },
+                          ],
+                          z2: [
+                            {
+                              componentName: 'z21-component',
+                              fields: {
+                                LibraryId: {
+                                  value: 'z21',
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            })
+          ).to.deep.equal(
+            ['foo', 'x11', 'x12', 'x21', 'y1', 'y2', 'z1', 'z11', 'z21'].map((id) => ({
+              href: getStylesheetUrl(id),
+              rel: 'style',
+            }))
+          );
+        });
+      });
+
+      describe('editing mode', () => {
+        it('should return links using class attribute', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                name: 'foo-component',
+                contents: null,
+                attributes: {
+                  class: '-library--bar',
+                },
+              })
+            )
+          ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'style' }]);
+        });
+
+        it('should return links using custom server url', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                name: 'foo-component',
+                contents: null,
+                attributes: {
+                  class: '-library--bar',
+                },
+              }),
+              'https://foo.net'
+            )
+          ).to.deep.equal([{ rel: 'style', href: getStylesheetUrl('bar', 'https://foo.net') }]);
+        });
+
+        it('should not return id when class does not match pattern', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks(
+              setBasicLayoutData({
+                name: 'foo-component',
+                contents: null,
+                attributes: {
+                  class: 'bar',
+                },
+              })
+            )
+          ).to.deep.equal([]);
+        });
+
+        it('should return only unique links', () => {
+          expect(
+            getFEAASLibraryStylesheetLinks({
+              sitecore: {
+                context: {},
+                route: {
+                  name: 'home',
+                  placeholders: {
+                    x: [
+                      {
+                        name: 'x1-component',
+                        contents: null,
+                        attributes: {
+                          class: '-library--x1',
+                        },
+                      },
+                    ],
+                    y: [
+                      {
+                        name: 'x2-component',
+                        contents: null,
+                        attributes: {
+                          class: '-library--x1',
+                        },
+                      },
+                      {
+                        name: 'y1-component',
+                        contents: null,
+                        attributes: {
+                          class: '-library--y1',
+                        },
+                      },
+                    ],
+                    z: [
+                      {
+                        name: 'z-component',
+                        contents: null,
+                        attributes: {
+                          class: '-library--z1',
+                        },
+                      },
+                      {
+                        name: 'z-component',
+                        contents: null,
+                        attributes: {
+                          class: '-library--z2',
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            })
+          ).to.deep.equal(
+            ['x1', 'y1', 'z1', 'z2'].map((id) => ({ rel: 'style', href: getStylesheetUrl(id) }))
+          );
+        });
+      });
+    });
+
+    describe('getStylesheetUrl', () => {
+      it('should return stylesheet url using default server url', () => {
+        expect(getStylesheetUrl('foo')).to.equal(`${FEAAS_SERVER_URL}/styles/foo/published.css`);
+      });
+
+      it('should return stylesheet url using custom server url', () => {
+        expect(getStylesheetUrl('foo', 'https://bar.net')).to.equal(
+          'https://bar.net/styles/foo/published.css'
+        );
+      });
+    });
+  });
+});

--- a/packages/sitecore-jss/src/feaas/themes.ts
+++ b/packages/sitecore-jss/src/feaas/themes.ts
@@ -1,0 +1,96 @@
+import {
+  ComponentRendering,
+  HtmlElementRendering,
+  LayoutServiceData,
+  RouteData,
+  getFieldValue,
+} from '../layout';
+import { HTMLLink } from '../models';
+
+/**
+ * Pattern for library ids
+ * @example -library--foo
+ */
+const FEAAS_LIBRARY_ID_REGEX = /-library--([^\s]+)/;
+
+export const FEAAS_SERVER_URL = 'https://feaas.blob.core.windows.net';
+
+/**
+ * Walks through rendering tree and returns list of links of all FEAAS Component Library Stylesheets that are used
+ * @param {LayoutServiceData} layoutData Layout service data
+ * @param {string} [serverUrl] server URL, default is @see {FEAAS_SERVER_URL} url
+ * @returns {HTMLLink[]} library stylesheet links
+ */
+export function getFEAASLibraryStylesheetLinks(
+  layoutData: LayoutServiceData,
+  serverUrl?: string
+): HTMLLink[] {
+  const ids = new Set<string>();
+
+  if (!layoutData.sitecore.route) return [];
+
+  traverseComponent(layoutData.sitecore.route, ids);
+  [...ids].forEach((id) => {
+    console.log(getStylesheetUrl(id, serverUrl));
+  });
+  return [...ids].map((id) => ({ href: getStylesheetUrl(id, serverUrl), rel: 'style' }));
+}
+
+export const getStylesheetUrl = (id: string, serverUrl?: string) =>
+  `${serverUrl || FEAAS_SERVER_URL}/styles/${id}/published.css`;
+
+/**
+ * Traverse placeholder and components to add library ids
+ * @param {Array<ComponentRendering | HtmlElementRendering>} components
+ * @param {Set<string>} ids library ids
+ */
+const traversePlaceholder = (
+  components: Array<ComponentRendering | HtmlElementRendering>,
+  ids: Set<string>
+) => {
+  components.map((component) => {
+    const rendering = component as ComponentRendering;
+
+    return traverseComponent(rendering, ids);
+  });
+};
+
+/**
+ * Traverse component and children to add library ids
+ * @param {RouteData | ComponentRendering | HtmlElementRendering} component component data
+ * @param {Set<string>} ids library ids
+ */
+const traverseComponent = (
+  component: RouteData | ComponentRendering | HtmlElementRendering,
+  ids: Set<string>
+) => {
+  let libraryId: string | undefined = undefined;
+  if ('params' in component && component.params) {
+    // LibraryID in css class name takes precedence over LibraryId attribute
+    libraryId =
+      component.params.CSSStyles?.match(FEAAS_LIBRARY_ID_REGEX)?.[1] ||
+      component.params.LibraryId ||
+      undefined;
+  }
+  // if params are empty we try to fall back to data source or attributes
+  if (!libraryId && 'fields' in component && component.fields) {
+    libraryId =
+      getFieldValue(component.fields, 'CSSStyles', '').match(FEAAS_LIBRARY_ID_REGEX)?.[1] ||
+      getFieldValue(component.fields, 'LibraryId', '') ||
+      undefined;
+  }
+  // HTMLRendering its class attribute
+  if (!libraryId && 'attributes' in component && typeof component.attributes.class === 'string') {
+    libraryId = component.attributes.class.match(FEAAS_LIBRARY_ID_REGEX)?.[1];
+  }
+  console.log(libraryId);
+  if (libraryId) {
+    ids.add(libraryId);
+  }
+
+  const placeholders = (component as ComponentRendering).placeholders || {};
+
+  Object.keys(placeholders).forEach((placeholder) => {
+    traversePlaceholder(placeholders[placeholder], ids);
+  });
+};

--- a/packages/sitecore-jss/src/feaas/themes.ts
+++ b/packages/sitecore-jss/src/feaas/themes.ts
@@ -30,9 +30,7 @@ export function getFEAASLibraryStylesheetLinks(
   if (!layoutData.sitecore.route) return [];
 
   traverseComponent(layoutData.sitecore.route, ids);
-  [...ids].forEach((id) => {
-    console.log(getStylesheetUrl(id, serverUrl));
-  });
+
   return [...ids].map((id) => ({ href: getStylesheetUrl(id, serverUrl), rel: 'style' }));
 }
 
@@ -83,7 +81,6 @@ const traverseComponent = (
   if (!libraryId && 'attributes' in component && typeof component.attributes.class === 'string') {
     libraryId = component.attributes.class.match(FEAAS_LIBRARY_ID_REGEX)?.[1];
   }
-  console.log(libraryId);
   if (libraryId) {
     ids.add(libraryId);
   }

--- a/packages/sitecore-jss/tsconfig.json
+++ b/packages/sitecore-jss/tsconfig.json
@@ -19,6 +19,7 @@
     "tracking.d.ts",
     "site.d.ts",
     "personalize.d.ts",
+    "feaas.d.ts",
     "src/**/*.test.ts",
     "src/test-data/*"
   ]


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
This PR builds upon @illiakovalenko 's original work on supporting stylesheets (https://github.com/Sitecore/jss/pull/1359).
The basic idea is for JSS to load stylesheets in SSR whenever FEAAS themes are applied to components on page.
Current PR ensures style parameters can be read from component params, component data source or component class.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
