### PR TITLE
[sitecore-jss-dev-tools] [Nextjs] [React] Introduce "components" configuration for ComponentBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Check the BYOC documentation for more info. ([#1568](https://github.com/Sitecore
 * `[sitecore-jss-nextjs]` Support for public URL resolution in Netlify ([#1585](https://github.com/Sitecore/jss/pull/1585))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` Better error handling for component-level data fetching ([#1586](https://github.com/Sitecore/jss/pull/1586))
 * `[sitecore-jss-react]` Fetch Data for FEaaS Components as part of Component SSR/SSG ([#1586](https://github.com/Sitecore/jss/pull/1590))
+* `[sitecore-jss-dev-tools]` `[templates/nextjs]` `[templates/react]` Introduce "components" configuration for ComponentBuilder ([#1598](https://github.com/Sitecore/jss/pull/1598))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/index.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/index.ts
@@ -1,10 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const plugins = require('scripts/temp/generate-component-builder-plugins');
-import { PackageDefinition } from '@sitecore-jss/sitecore-jss-dev-tools';
+import { PackageDefinition, ComponentFile } from '@sitecore-jss/sitecore-jss-dev-tools';
 
 export interface ComponentBuilderPluginConfig {
   watch?: boolean;
   packages?: PackageDefinition[];
+  components?: ComponentFile[];
 }
 
 export interface ComponentBuilderPlugin {

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/component-builder.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/component-builder.ts
@@ -11,7 +11,7 @@ class ComponentBuilderPlugin implements ComponentBuilderPluginType {
   order = 9999;
 
   exec(config: ComponentBuilderPluginConfig) {
-    generateComponentBuilder({ packages: config.packages, watch: config.watch });
+    generateComponentBuilder(config);
 
     return config;
   }

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/components.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/components.ts
@@ -1,0 +1,30 @@
+import { ComponentBuilderPlugin, ComponentBuilderPluginConfig } from '..';
+
+/**
+ * Provides custom components configuration
+ */
+class ComponentsPlugin implements ComponentBuilderPlugin {
+  order = 0;
+
+  exec(config: ComponentBuilderPluginConfig) {
+    /**
+     * You can specify components which you want to import using custom path in format:
+     * {
+     *   path: string; // path to component
+     *   moduleName: string; // module name to import
+     *   componentName: 'component name'; // component rendering name
+     * }
+     *
+     * Or you can register all components from a path using the below approach:
+     * import { getComponentList } from '@sitecore-jss/sitecore-jss-dev-tools';
+     * ...
+     * const componentsPath = 'src/extra';
+     * config.components = getComponentList(componentsPath);
+     */
+    config.components = [];
+
+    return config;
+  }
+}
+
+export const componentsPlugin = new ComponentsPlugin();

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/packages.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/generate-component-builder/plugins/packages.ts
@@ -20,14 +20,6 @@ class PackagesPlugin implements ComponentBuilderPlugin {
      *    ]
      *  }
      */
-
-    /**
-     * Or you can register all components from a path using the below approach:
-     * import { PackageDefinition, getComponentList } from '@sitecore-jss/sitecore-jss-dev-tools';
-     * ...
-     * const componentsPath = 'src/extra';
-     * config.packages = getComponentList(componentsPath) as PackageDefinition[];
-     */
     config.packages = [];
 
     return config;

--- a/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/component-builder.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/component-builder.js
@@ -7,7 +7,7 @@ class ComponentBuilderPlugin {
   order = 9999;
 
   exec(config) {
-    generateComponentBuilder({ packages: config.packages, watch: config.watch });
+    generateComponentBuilder(config);
   }
 }
 

--- a/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/components.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/components.js
@@ -1,0 +1,28 @@
+/**
+ * Provides custom components configuration
+ */
+class ComponentsPlugin {
+  order = 0;
+
+  exec(config) {
+    /**
+     * You can specify components which you want to import using custom path in format:
+     * {
+     *   path: string; // path to component
+     *   moduleName: string; // module name to import
+     *   componentName: 'component name'; // component rendering name
+     * }
+     *
+     * Or you can register all components from a path using the below approach:
+     * const { getComponentList } = require('@sitecore-jss/sitecore-jss-dev-tools');
+     * ...
+     * const componentsPath = 'src/extra';
+     * config.components = getComponentList(componentsPath);
+     */
+    config.components = [];
+
+    return config;
+  }
+}
+
+module.exports = new ComponentsPlugin();

--- a/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/packages.js
+++ b/packages/create-sitecore-jss/src/templates/react/scripts/generate-component-builder/plugins/packages.js
@@ -18,14 +18,6 @@ class PackagesPlugin {
      *    ]
      *  }
      */
-    
-    /**
-     * Or you can register all components from a path using the below approach:
-     * import { PackageDefinition, getComponentList } from '@sitecore-jss/sitecore-jss-dev-tools/templating';
-     * ...
-     * const componentsPath = 'src/extra';
-     * config.packages = getComponentList(extraPath) as PackageDefinition[];
-     */
     config.packages = [];
 
     return config;

--- a/packages/sitecore-jss-dev-tools/src/templating/components.ts
+++ b/packages/sitecore-jss-dev-tools/src/templating/components.ts
@@ -30,8 +30,8 @@ export interface PackageDefinition {
  * }
  * @param {string} path path to search
  */
-export function getComponentList(path: string): (PackageDefinition | ComponentFile)[] {
-  const components = getItems<PackageDefinition | ComponentFile>({
+export function getComponentList(path: string): ComponentFile[] {
+  const components = getItems<ComponentFile>({
     path,
     resolveItem: (path, name) => ({
       path: `${path}/${name}`,

--- a/packages/sitecore-jss-dev-tools/src/templating/nextjs/generate-component-builder.test.ts
+++ b/packages/sitecore-jss-dev-tools/src/templating/nextjs/generate-component-builder.test.ts
@@ -43,11 +43,13 @@ describe('generate-component-builder', () => {
           '\n' +
           "import { Foo } from 'custom-module';\n" +
           '\n' +
+          "import * as Text from 'src/custom-components/Text';\n" +
           "import * as barModule from 'bar';\n" +
           '\n' +
           'const components = new Map();\n' +
           "components.set('Foo', Foo);\n" +
           '\n' +
+          "components.set('TextComponent', Text);\n" +
           "components.set('BarComponent', barModule);\n" +
           '\n' +
           'export const componentBuilder = new ComponentBuilder({ components });\n' +
@@ -67,6 +69,13 @@ describe('generate-component-builder', () => {
                 moduleName: 'Foo',
               },
             ],
+          },
+        ],
+        components: [
+          {
+            path: 'src/custom-components/Text',
+            moduleName: 'Text',
+            componentName: 'TextComponent',
           },
         ],
       });
@@ -109,6 +118,11 @@ describe('generate-component-builder', () => {
           '\n' +
           "import { Foo } from 'custom-module';\n" +
           '\n' +
+          "import * as Text from 'src/custom-components/Text';\n" +
+          'const GraphQL = {\n' +
+          "  module: () => import('src/custom-components/GraphQL.dynamic'),\n" +
+          "  element: (isEditing?: boolean) => isEditing ? require('src/custom-components/GraphQL.dynamic')?.default : dynamic(GraphQL.module)\n" +
+          '}\n' +
           "import * as barModule from 'bar';\n" +
           'const carModule = {\n' +
           "  module: () => import('car.dynamic'),\n" +
@@ -118,6 +132,8 @@ describe('generate-component-builder', () => {
           'const components = new Map();\n' +
           "components.set('Foo', Foo);\n" +
           '\n' +
+          "components.set('TextComponent', Text);\n" +
+          "components.set('GraphQLComponent', GraphQL);\n" +
           "components.set('BarComponent', barModule);\n" +
           "components.set('CarComponent', carModule);\n" +
           '\n' +
@@ -138,6 +154,18 @@ describe('generate-component-builder', () => {
                 moduleName: 'Foo',
               },
             ],
+          },
+        ],
+        components: [
+          {
+            path: 'src/custom-components/Text',
+            moduleName: 'Text',
+            componentName: 'TextComponent',
+          },
+          {
+            path: 'src/custom-components/GraphQL.dynamic',
+            moduleName: 'GraphQL',
+            componentName: 'GraphQLComponent',
           },
         ],
       });

--- a/packages/sitecore-jss-dev-tools/src/templating/react/generate-component-builder.test.ts
+++ b/packages/sitecore-jss-dev-tools/src/templating/react/generate-component-builder.test.ts
@@ -41,11 +41,13 @@ describe('generate-component-builder', () => {
           "import { ComponentBuilder } from '@sitecore-jss/sitecore-jss-react';\n" +
           "import { Foo } from 'custom-module';\n" +
           '\n' +
+          "import Text from 'src/custom-components/Text';\n" +
           "import barModule from 'bar';\n" +
           '\n' +
           'const components = new Map();\n' +
           "components.set('Foo', Foo);\n" +
           '\n' +
+          "components.set('TextComponent', Text);\n" +
           "components.set('BarComponent', barModule);\n" +
           '\n' +
           'const componentBuilder = new ComponentBuilder({ components });\n' +
@@ -64,6 +66,13 @@ describe('generate-component-builder', () => {
                 moduleName: 'Foo',
               },
             ],
+          },
+        ],
+        components: [
+          {
+            path: 'src/custom-components/Text',
+            moduleName: 'Text',
+            componentName: 'TextComponent',
           },
         ],
       });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
* Introduced a new **components** property for _ComponentBuilder_ in order to be able to bring custom components that can be placed under a specific path that doesn't match the default one.
* Added a new **components** plugin (react, next), where you can configure the _components_ property.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - tested using disconnected mode, by providing custom components

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
