### PR TITLE
[nextjs] Only fetch dictionary data when layout data is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ Our versioning strategy is as follows:
 * `[templates/nextjs-sxa]` Fix styles of Image component for Banner variant when we try to edit image in EE for Basic Site ([#1588](https://github.com/Sitecore/jss/pull/1588)) ([#1596](https://github.com/Sitecore/jss/pull/1596))
 * `[templates/nextjs-sxa]` Fix style for main layout(horizontal scrollbar). ([#1589](https://github.com/Sitecore/jss/pull/1589))
 * `[templates/nextjs-sxa]` Don't let Image component wrap <img> with <a> tag when TargetUrl is not configured. ([#1593](https://github.com/Sitecore/jss/issues/1593))
-* `[template/nextjs]` Next config header plugin for CORS. ([#1597](https://github.com/Sitecore/jss/pull/1597))
+* `[templates/nextjs]` Next config header plugin for CORS. ([#1597](https://github.com/Sitecore/jss/pull/1597))
+* `[templates/nextjs]` Ensure dictionary data is only fetched when layout data is present for a route ([#1608](https://github.com/Sitecore/jss/pull/1608)) 
 
 ## 21.2.3
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/normal-mode.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/page-props-factory/plugins/normal-mode.ts
@@ -44,9 +44,11 @@ class NormalModePlugin implements Plugin {
       props.notFound = true;
     }
 
-    // Fetch dictionary data
-    const dictionaryService = this.getDictionaryService(props.site.name);
-    props.dictionary = await dictionaryService.fetchDictionaryData(props.locale);
+    // Fetch dictionary data if layout data was present
+    if (!props.notFound) {      
+      const dictionaryService = this.getDictionaryService(props.site.name);
+      props.dictionary = await dictionaryService.fetchDictionaryData(props.locale);
+    }
 
     // Initialize links to be inserted on the page
     props.headLinks = [];


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Dictionary service can fail and throw a 5xx error when requesting a language on a page with no version in this language. This PR fixes it.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - connected, production modes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
