### PR TITLE
[sitecore-jss-nextjs] Reduce the amount of Edge API calls during fetch `getStaticPaths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-react]` Fetch Data for FEaaS Components as part of Component SSR/SSG ([#1586](https://github.com/Sitecore/jss/pull/1590))
 * `[sitecore-jss-dev-tools]` `[templates/nextjs]` `[templates/react]` Introduce "components" configuration for ComponentBuilder ([#1598](https://github.com/Sitecore/jss/pull/1598))
 * `[sitecore-jss-react]` `[sitecore-jss-nextjs]` Component level data fetching(SSR/SSG) for BYOC ([#1610](https://github.com/Sitecore/jss/pull/1610))
+* `[sitecore-jss-nextjs]` Reduce the amount of Edge API calls during fetch getStaticPaths ([#1612](https://github.com/Sitecore/jss/pull/1612))
 
 ### 🧹 Chores
 

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -27,7 +27,7 @@ query ${usesPersonalize ? 'PersonalizeSitemapQuery' : 'DefaultSitemapQuery'}(
   $language: String!
   $includedPaths: [String]
   $excludedPaths: [String]
-  $pageSize: Int = 10
+  $pageSize: Int = 100
   $after: String
 ) {
   site {
@@ -86,7 +86,7 @@ interface SiteRouteQueryVariables {
   /** common variable for all GraphQL queries
    * it will be used for every type of query to regulate result batch size
    * Optional. How many result items to fetch in each GraphQL call. This is needed for pagination.
-   * @default 10
+   * @default 100
    */
   pageSize?: number;
 }
@@ -223,21 +223,24 @@ export abstract class BaseGraphQLSitemapService {
     formatStaticPath: (path: string[], language: string) => StaticPath
   ) {
     const paths = new Array<StaticPath>();
-    await Promise.all(
-      languages.map(async (language) => {
-        if (language === '') {
-          throw new RangeError(languageEmptyError);
-        }
-        debug.sitemap('fetching sitemap data for %s %s', language, siteName);
-        const results = await this.fetchLanguageSitePaths(language, siteName);
-        const transformedPaths = await this.transformLanguageSitePaths(
-          results,
-          formatStaticPath,
-          language
-        );
-        paths.push(...transformedPaths);
-      })
-    );
+
+    for (const language of languages) {
+      if (language === '') {
+        throw new RangeError(languageEmptyError);
+      }
+
+      debug.sitemap('fetching sitemap data for %s %s', language, siteName);
+
+      const results = await this.fetchLanguageSitePaths(language, siteName);
+      const transformedPaths = await this.transformLanguageSitePaths(
+        results,
+        formatStaticPath,
+        language
+      );
+
+      paths.push(...transformedPaths);
+    }
+
     return paths;
   }
 

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -439,7 +439,8 @@ describe('GraphQLSitemapService', () => {
           .post(
             '/',
             (body) =>
-              body.query.indexOf('$pageSize: Int = 10') > 0 && body.variables.pageSize === undefined
+              body.query.indexOf('$pageSize: Int = 100') > 0 &&
+              body.variables.pageSize === undefined
           )
           .reply(200, sitemapDefaultQueryResult);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Set default page size for the sitemap GraphQL request to 100
- Switch from using a parallel approach (Promise.all) to a serial approach when fetching each language.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
