### PR TITLE
[sitecore-jss][templates/nextjs] Handle rate limit errors in Layout and Dictionary Services through GraphQL Client

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
@@ -27,6 +27,12 @@ export class DictionaryServiceFactory {
             Otherwise, if your Sitecore instance only has 1 JSS App (i.e. in a Sitecore XP setup), you can specify the root item ID here.
             rootItemId: '{GUID}'
           */
+          /*
+            GraphQL Dictionary and Layout Services can handle 429 code errors from server.
+            For this, specify the number of retries the GraphQL server will attempt. 
+            It will only try the request once by default
+            retries: %number% 
+          */
         })
       : new RestDictionaryService({
           apiHost: config.sitecoreApiHost,

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
@@ -20,6 +20,12 @@ export class LayoutServiceFactory {
           endpoint: config.graphQLEndpoint,
           apiKey: config.sitecoreApiKey,
           siteName,
+          /*
+            GraphQL Dictionary and Layout Services can handle 429 code errors from server.
+            For this, specify the number of retries the GraphQL server will attempt. 
+            It will only try the request once by default
+            retries: %number% 
+          */
         })
       : new RestLayoutService({
           apiHost: config.sitecoreApiHost,

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -60,6 +60,7 @@
     "graphql-request": "^4.2.0",
     "lodash.unescape": "^4.0.1",
     "memory-cache": "^0.2.0",
+    "p-throttle": "4.1.1",
     "url-parse": "^1.5.9"
   },
   "description": "",

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -60,7 +60,6 @@
     "graphql-request": "^4.2.0",
     "lodash.unescape": "^4.0.1",
     "memory-cache": "^0.2.0",
-    "p-throttle": "4.1.1",
     "url-parse": "^1.5.9"
   },
   "description": "",

--- a/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
+++ b/packages/sitecore-jss/src/i18n/graphql-dictionary-service.ts
@@ -1,4 +1,4 @@
-import { GraphQLClient, GraphQLRequestClient } from '../graphql-request-client';
+import { GraphQLClient, GraphQLRequestClient, GraphQLServiceRetryConfig } from '../graphql-request-client';
 import { SitecoreTemplateId } from '../constants';
 import { DictionaryPhrases, DictionaryServiceBase } from './dictionary-service';
 import { CacheOptions } from '../cache-client';
@@ -48,7 +48,7 @@ const query = /* GraphQL */ `
 /**
  * Configuration options for @see GraphQLDictionaryService instances
  */
-export interface GraphQLDictionaryServiceConfig extends SearchServiceConfig, CacheOptions {
+export interface GraphQLDictionaryServiceConfig extends SearchServiceConfig, CacheOptions, GraphQLServiceRetryConfig {
   /**
    * The URL of the graphQL endpoint.
    */
@@ -95,7 +95,7 @@ export class GraphQLDictionaryService extends DictionaryServiceBase {
    */
   constructor(public options: GraphQLDictionaryServiceConfig) {
     super(options);
-    this.graphQLClient = this.getGraphQLClient();
+    this.graphQLClient = this.getGraphQLClient(options.retries);
     this.searchService = new SearchQueryService<DictionaryQueryResult>(this.graphQLClient);
   }
 
@@ -153,10 +153,11 @@ export class GraphQLDictionaryService extends DictionaryServiceBase {
    * want to use something else.
    * @returns {GraphQLClient} implementation
    */
-  protected getGraphQLClient(): GraphQLClient {
+  protected getGraphQLClient(retries?: number): GraphQLClient {
     return new GraphQLRequestClient(this.options.endpoint, {
       apiKey: this.options.apiKey,
       debugger: debug.dictionary,
+      retries,
     });
   }
 }

--- a/packages/sitecore-jss/src/layout/graphql-layout-service.ts
+++ b/packages/sitecore-jss/src/layout/graphql-layout-service.ts
@@ -2,6 +2,7 @@ import { LayoutServiceBase } from './layout-service';
 import { LayoutServiceData } from './models';
 import { GraphQLClient, GraphQLRequestClient } from '../graphql-request-client';
 import debug from '../debug';
+import pThrottle from 'p-throttle';
 
 export type GraphQLLayoutServiceConfig = {
   /**
@@ -47,6 +48,8 @@ export class GraphQLLayoutService extends LayoutServiceBase {
     this.graphQLClient = this.getGraphQLClient();
   }
 
+  private throttle = pThrottle({limit: 5, interval: 1000})
+
   /**
    * Fetch layout data for an item.
    * @param {string} itemPath item path to fetch layout data for.
@@ -73,6 +76,13 @@ export class GraphQLLayoutService extends LayoutServiceBase {
       }
     );
   }
+
+  throttledFetch = this.throttle(async (itemPath: string, language?: string) => {
+
+    const data = await this.fetchLayoutData(itemPath, language);
+
+    return data
+})
 
   /**
    * Gets a GraphQL client that can make requests to the API. Uses graphql-request as the default

--- a/packages/sitecore-jss/src/layout/graphql-layout-service.ts
+++ b/packages/sitecore-jss/src/layout/graphql-layout-service.ts
@@ -1,9 +1,9 @@
 import { LayoutServiceBase } from './layout-service';
 import { LayoutServiceData } from './models';
-import { GraphQLClient, GraphQLRequestClient } from '../graphql-request-client';
+import { GraphQLClient, GraphQLRequestClient, GraphQLServiceRetryConfig } from '../graphql-request-client';
 import debug from '../debug';
 
-export type GraphQLLayoutServiceConfig = {
+export interface GraphQLLayoutServiceConfig extends GraphQLServiceRetryConfig {
   /**
    * Your Graphql endpoint
    */
@@ -44,7 +44,7 @@ export class GraphQLLayoutService extends LayoutServiceBase {
    */
   constructor(public serviceConfig: GraphQLLayoutServiceConfig) {
     super();
-    this.graphQLClient = this.getGraphQLClient();
+    this.graphQLClient = this.getGraphQLClient(serviceConfig.retries);
   }
 
   /**
@@ -80,10 +80,11 @@ export class GraphQLLayoutService extends LayoutServiceBase {
    * want to use something else.
    * @returns {GraphQLClient} implementation
    */
-  protected getGraphQLClient(): GraphQLClient {
+  protected getGraphQLClient(retries?: number): GraphQLClient {
     return new GraphQLRequestClient(this.serviceConfig.endpoint, {
       apiKey: this.serviceConfig.apiKey,
       debugger: debug.layout,
+      retries
     });
   }
 

--- a/packages/sitecore-jss/src/layout/graphql-layout-service.ts
+++ b/packages/sitecore-jss/src/layout/graphql-layout-service.ts
@@ -2,7 +2,6 @@ import { LayoutServiceBase } from './layout-service';
 import { LayoutServiceData } from './models';
 import { GraphQLClient, GraphQLRequestClient } from '../graphql-request-client';
 import debug from '../debug';
-import pThrottle from 'p-throttle';
 
 export type GraphQLLayoutServiceConfig = {
   /**
@@ -48,8 +47,6 @@ export class GraphQLLayoutService extends LayoutServiceBase {
     this.graphQLClient = this.getGraphQLClient();
   }
 
-  private throttle = pThrottle({limit: 5, interval: 1000})
-
   /**
    * Fetch layout data for an item.
    * @param {string} itemPath item path to fetch layout data for.
@@ -76,13 +73,6 @@ export class GraphQLLayoutService extends LayoutServiceBase {
       }
     );
   }
-
-  throttledFetch = this.throttle(async (itemPath: string, language?: string) => {
-
-    const data = await this.fetchLayoutData(itemPath, language);
-
-    return data
-})
 
   /**
    * Gets a GraphQL client that can make requests to the API. Uses graphql-request as the default

--- a/yarn.lock
+++ b/yarn.lock
@@ -5432,100 +5432,72 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/env@npm:13.1.6"
-  checksum: 0f911a18f0b3372007632fffa87f5d7f802c00d07b3bf757d2d09574735ae43f60000ecdf64b6f06e195971c508c2bcee82dd1e3aab27a08a4300eb0317652bb
+"@next/env@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/env@npm:13.5.2"
+  checksum: f6ef14b7643049dafc2d53b5091e3f74eed0af14743cfd61f1db7782a99e69b5bef63f36ba700034b23656a264c7ec498aac8fa4f9377dad01e544ffa507388f
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm-eabi@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-android-arm-eabi@npm:13.1.6"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@next/swc-android-arm64@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-android-arm64@npm:13.1.6"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@next/swc-darwin-arm64@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-darwin-arm64@npm:13.1.6"
+"@next/swc-darwin-arm64@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-darwin-arm64@npm:13.5.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-darwin-x64@npm:13.1.6"
+"@next/swc-darwin-x64@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-darwin-x64@npm:13.5.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-freebsd-x64@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-freebsd-x64@npm:13.1.6"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-arm-gnueabihf@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-linux-arm-gnueabihf@npm:13.1.6"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@next/swc-linux-arm64-gnu@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-linux-arm64-gnu@npm:13.1.6"
+"@next/swc-linux-arm64-gnu@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-linux-arm64-gnu@npm:13.5.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-linux-arm64-musl@npm:13.1.6"
+"@next/swc-linux-arm64-musl@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-linux-arm64-musl@npm:13.5.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-linux-x64-gnu@npm:13.1.6"
+"@next/swc-linux-x64-gnu@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-linux-x64-gnu@npm:13.5.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-linux-x64-musl@npm:13.1.6"
+"@next/swc-linux-x64-musl@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-linux-x64-musl@npm:13.5.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-win32-arm64-msvc@npm:13.1.6"
+"@next/swc-win32-arm64-msvc@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-win32-arm64-msvc@npm:13.5.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-win32-ia32-msvc@npm:13.1.6"
+"@next/swc-win32-ia32-msvc@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-win32-ia32-msvc@npm:13.5.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:13.1.6":
-  version: 13.1.6
-  resolution: "@next/swc-win32-x64-msvc@npm:13.1.6"
+"@next/swc-win32-x64-msvc@npm:13.5.2":
+  version: 13.5.2
+  resolution: "@next/swc-win32-x64-msvc@npm:13.5.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6446,12 +6418,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sitecore-feaas/clientside@npm:^0.3.14":
-  version: 0.3.14
-  resolution: "@sitecore-feaas/clientside@npm:0.3.14"
+"@sitecore-feaas/clientside@npm:^0.3.17":
+  version: 0.3.17
+  resolution: "@sitecore-feaas/clientside@npm:0.3.17"
   peerDependencies:
     react-dom: ">=16.8.0"
-  checksum: e793a475862dfb4d9aaeff1e74745578c8eb2fe168ea85ac133a1f7b20f63c225ad2e82b536377e1b63dfc8f03e6a5d83f24217e89b03d035d329a0356f492aa
+  checksum: 2a3d7eec204fdb71c2787feedc5966ff0fbbd0387f38bb1d5ae8ca75ea63d5588ae79e0f06ba393bc66932186d76bdcf8a970ec3f55ef73016b85bd9bf9f141a
   languageName: node
   linkType: hard
 
@@ -6485,7 +6457,7 @@ __metadata:
     "@angular/platform-browser": ~15.2.9
     "@angular/platform-browser-dynamic": ~15.2.9
     "@angular/router": ~15.2.9
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/jasmine": ^3.4.1
     "@types/node": ^14.14.35
     codelyzer: ^6.0.1
@@ -6516,7 +6488,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-cli@workspace:packages/sitecore-jss-cli"
   dependencies:
-    "@sitecore-jss/sitecore-jss-dev-tools": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.5.0-canary.1
     "@types/chai": ^4.2.4
     "@types/cross-spawn": ^6.0.2
     "@types/mocha": ^10.0.1
@@ -6548,11 +6520,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-dev-tools@21.4.0-canary.4, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
+"@sitecore-jss/sitecore-jss-dev-tools@21.5.0-canary.1, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/chai": ^4.3.4
     "@types/chokidar": ^2.1.3
     "@types/del": ^4.0.0
@@ -6604,11 +6576,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-forms@21.4.0-canary.4, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
+"@sitecore-jss/sitecore-jss-forms@21.5.0-canary.1, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/lodash.unescape": ^4.0.7
@@ -6631,9 +6603,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-nextjs@workspace:packages/sitecore-jss-nextjs"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
-    "@sitecore-jss/sitecore-jss-dev-tools": 21.4.0-canary.4
-    "@sitecore-jss/sitecore-jss-react": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.5.0-canary.1
+    "@sitecore-jss/sitecore-jss-react": 21.5.0-canary.1
     "@types/chai": ^4.3.4
     "@types/chai-as-promised": ^7.1.5
     "@types/chai-string": ^1.4.2
@@ -6659,7 +6631,7 @@ __metadata:
     eslint-plugin-react: ^7.32.1
     jsdom: ^21.1.0
     mocha: ^10.2.0
-    next: ^13.1.6
+    next: ^13.4.16
     nock: ^13.3.0
     node-html-parser: ^6.1.4
     nyc: ^15.1.0
@@ -6673,7 +6645,7 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ~4.9.4
   peerDependencies:
-    next: ^13.1.6
+    next: ^13.4.16
     react: ^18.2.0
     react-dom: ^18.2.0
   languageName: unknown
@@ -6705,7 +6677,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react-forms@workspace:packages/sitecore-jss-react-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss-forms": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss-forms": 21.5.0-canary.1
     "@types/chai": ^4.3.4
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
@@ -6745,7 +6717,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": ^7.5.2
     "@babel/preset-env": ^7.6.2
     "@babel/preset-typescript": ^7.6.0
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/jest": ^24.0.18
     "@types/prop-types": ^15.7.3
     "@types/react": ^16.9.5
@@ -6775,12 +6747,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-react@21.4.0-canary.4, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
+"@sitecore-jss/sitecore-jss-react@21.5.0-canary.1, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react"
   dependencies:
-    "@sitecore-feaas/clientside": ^0.3.14
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-feaas/clientside": ^0.3.17
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/deep-equal": ^1.0.1
@@ -6854,7 +6826,7 @@ __metadata:
   resolution: "@sitecore-jss/sitecore-jss-vue@workspace:packages/sitecore-jss-vue"
   dependencies:
     "@babel/core": ^7.20.12
-    "@sitecore-jss/sitecore-jss": 21.4.0-canary.4
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.1
     "@types/jest": ^29.2.6
     "@types/node": ^18.11.18
     "@vue/compiler-dom": ^3.2.45
@@ -6878,7 +6850,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss@21.4.0-canary.4, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
+"@sitecore-jss/sitecore-jss@21.5.0-canary.1, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss"
   dependencies:
@@ -6920,12 +6892,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:0.4.14":
-  version: 0.4.14
-  resolution: "@swc/helpers@npm:0.4.14"
+"@swc/helpers@npm:0.5.2":
+  version: 0.5.2
+  resolution: "@swc/helpers@npm:0.5.2"
   dependencies:
     tslib: ^2.4.0
-  checksum: 273fd3f3fc461a92f3790cc551ea054745c6d6959afbe1232e6d7aa1c722bbc114d308aab96bef5c78fc0303c85c7b472ef00e2253251cc89737f3b1af56e5a5
+  checksum: 51d7e3d8bd56818c49d6bfbd715f0dbeedc13cf723af41166e45c03e37f109336bbcb57a1f2020f4015957721aeb21e1a7fff281233d797ff7d3dd1f447fa258
   languageName: node
   linkType: hard
 
@@ -11118,6 +11090,15 @@ __metadata:
   dependencies:
     semver: ^7.0.0
   checksum: 66d204657fe36522822a95b288943ad11b58f5eaede235b11d8c4edaa28ce4800087d44a2681524c340494aadb120a0068011acabe99d30e8f11a7d826d83515
+  languageName: node
+  linkType: hard
+
+"busboy@npm:1.6.0":
+  version: 1.6.0
+  resolution: "busboy@npm:1.6.0"
+  dependencies:
+    streamsearch: ^1.1.0
+  checksum: 32801e2c0164e12106bf236291a00795c3c4e4b709ae02132883fe8478ba2ae23743b11c5735a0aae8afe65ac4b6ca4568b91f0d9fed1fdbc32ede824a73746e
   languageName: node
   linkType: hard
 
@@ -21479,46 +21460,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^13.1.6":
-  version: 13.1.6
-  resolution: "next@npm:13.1.6"
+"next@npm:^13.4.16":
+  version: 13.5.2
+  resolution: "next@npm:13.5.2"
   dependencies:
-    "@next/env": 13.1.6
-    "@next/swc-android-arm-eabi": 13.1.6
-    "@next/swc-android-arm64": 13.1.6
-    "@next/swc-darwin-arm64": 13.1.6
-    "@next/swc-darwin-x64": 13.1.6
-    "@next/swc-freebsd-x64": 13.1.6
-    "@next/swc-linux-arm-gnueabihf": 13.1.6
-    "@next/swc-linux-arm64-gnu": 13.1.6
-    "@next/swc-linux-arm64-musl": 13.1.6
-    "@next/swc-linux-x64-gnu": 13.1.6
-    "@next/swc-linux-x64-musl": 13.1.6
-    "@next/swc-win32-arm64-msvc": 13.1.6
-    "@next/swc-win32-ia32-msvc": 13.1.6
-    "@next/swc-win32-x64-msvc": 13.1.6
-    "@swc/helpers": 0.4.14
+    "@next/env": 13.5.2
+    "@next/swc-darwin-arm64": 13.5.2
+    "@next/swc-darwin-x64": 13.5.2
+    "@next/swc-linux-arm64-gnu": 13.5.2
+    "@next/swc-linux-arm64-musl": 13.5.2
+    "@next/swc-linux-x64-gnu": 13.5.2
+    "@next/swc-linux-x64-musl": 13.5.2
+    "@next/swc-win32-arm64-msvc": 13.5.2
+    "@next/swc-win32-ia32-msvc": 13.5.2
+    "@next/swc-win32-x64-msvc": 13.5.2
+    "@swc/helpers": 0.5.2
+    busboy: 1.6.0
     caniuse-lite: ^1.0.30001406
     postcss: 8.4.14
     styled-jsx: 5.1.1
+    watchpack: 2.4.0
+    zod: 3.21.4
   peerDependencies:
-    fibers: ">= 3.1.0"
-    node-sass: ^6.0.0 || ^7.0.0
+    "@opentelemetry/api": ^1.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.3.0
   dependenciesMeta:
-    "@next/swc-android-arm-eabi":
-      optional: true
-    "@next/swc-android-arm64":
-      optional: true
     "@next/swc-darwin-arm64":
       optional: true
     "@next/swc-darwin-x64":
-      optional: true
-    "@next/swc-freebsd-x64":
-      optional: true
-    "@next/swc-linux-arm-gnueabihf":
       optional: true
     "@next/swc-linux-arm64-gnu":
       optional: true
@@ -21535,15 +21506,13 @@ __metadata:
     "@next/swc-win32-x64-msvc":
       optional: true
   peerDependenciesMeta:
-    fibers:
-      optional: true
-    node-sass:
+    "@opentelemetry/api":
       optional: true
     sass:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 584977e382bd826c21e7fc5f67bca50e4d95741a854b1686394d45331404479c7266569671227421975fc18e5cf70769a4ad7edede7450d4497213205bba77c8
+  checksum: cc0635ad5aaab9fc1f4315b9506361b1abf1a12146542d6054b9434e2e892e967f19fbabd3f3763ba5e227306aa91627c1d73af089e9b853b84c74e20bb0be00
   languageName: node
   linkType: hard
 
@@ -26388,6 +26357,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"streamsearch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "streamsearch@npm:1.1.0"
+  checksum: 1cce16cea8405d7a233d32ca5e00a00169cc0e19fbc02aa839959985f267335d435c07f96e5e0edd0eadc6d39c98d5435fb5bbbdefc62c41834eadc5622ad942
+  languageName: node
+  linkType: hard
+
 "string-length@npm:^2.0.0":
   version: 2.0.0
   resolution: "string-length@npm:2.0.0"
@@ -28171,6 +28147,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"watchpack@npm:2.4.0, watchpack@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "watchpack@npm:2.4.0"
+  dependencies:
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.1.2
+  checksum: 23d4bc58634dbe13b86093e01c6a68d8096028b664ab7139d58f0c37d962d549a940e98f2f201cecdabd6f9c340338dc73ef8bf094a2249ef582f35183d1a131
+  languageName: node
+  linkType: hard
+
 "watchpack@npm:^2.2.0":
   version: 2.2.0
   resolution: "watchpack@npm:2.2.0"
@@ -28178,16 +28164,6 @@ __metadata:
     glob-to-regexp: ^0.4.1
     graceful-fs: ^4.1.2
   checksum: e275f48fae29edee3195c51a8312b609581b9be5ce323d3102ffd082cb124f48d7a393ce05e4110239e4354379e04d78a97ceb26ae367746e7e218bf258135c8
-  languageName: node
-  linkType: hard
-
-"watchpack@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "watchpack@npm:2.4.0"
-  dependencies:
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.1.2
-  checksum: 23d4bc58634dbe13b86093e01c6a68d8096028b664ab7139d58f0c37d962d549a940e98f2f201cecdabd6f9c340338dc73ef8bf094a2249ef582f35183d1a131
   languageName: node
   linkType: hard
 
@@ -29166,6 +29142,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.21.4":
+  version: 3.21.4
+  resolution: "zod@npm:3.21.4"
+  checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
GraphQL endpoints can reply with a code 429 response when too many requests are launched (i.e. during static page generation). This PR adds a retryer functionality to GraphQL Client in sitecore-jss package to prevent 429 errors crashing a nextjs build.
To enable it, specify the number of retries for GraphQL services in dictionary-service-factory and layout-service-factory.

Retry will either read the 'Retry-After' header and send another request after the specified timespan, or use 1 second between retries by default.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - Limited testing with Throttling Strategies in Sitecore:
https://doc.sitecore.com/xp/en/developers/103/sitecore-experience-manager/throttle-requests.html

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
