### PR TITLE
[templates/nextjs][templates/nextjs-sxa] Extend retrier to ErrorPagesService and make it configurable through env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-dev-tools]` `[templates/nextjs]` `[templates/react]` Introduce "components" configuration for ComponentBuilder ([#1598](https://github.com/Sitecore/jss/pull/1598))
 * `[sitecore-jss-react]` `[sitecore-jss-nextjs]` Component level data fetching(SSR/SSG) for BYOC ([#1610](https://github.com/Sitecore/jss/pull/1610))
 * `[sitecore-jss-nextjs]` Reduce the amount of Edge API calls during fetch getStaticPaths ([#1612](https://github.com/Sitecore/jss/pull/1612))
-* `[sitecore-jss]` `[templates/nextjs]` GraphQL Layout and Dictionary services can handle endpoint rate limits through retryer functionality in GraphQLClient. To prevent SSG builds from failing and enable multiple retries, set retry amount in lib/dictionary-service-factory and lib/layout-service-factory ([#1618](https://github.com/Sitecore/jss/pull/1618))
+* `[sitecore-jss]` `[templates/nextjs] [templates/nextjs-sxa]` GraphQL Layout and Dictionary services in base remplate, and ErrorPages service in nextjs-sxa can handle endpoint rate limits through retryer functionality in GraphQLClient. To prevent SSG builds from failing and enable multiple retries, set retry amount in lib/dictionary-service-factory and lib/layout-service-factory ([#1618](https://github.com/Sitecore/jss/pull/1618) [#1619](https://github.com/Sitecore/jss/pull/1619))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` Upgrade Nextjs to 13.4.16([#1616](https://github.com/Sitecore/jss/pull/1616))
 
 ### 🧹 Chores

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/404.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/404.tsx
@@ -33,6 +33,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
     apiKey: config.sitecoreApiKey,
     siteName: site.name,
     language: context.locale || config.defaultLanguage,
+    retries:
+      (process.env.GRAPH_QL_SERVICE_RETRIES &&
+        parseInt(process.env.GRAPH_QL_SERVICE_RETRIES, 10)) ||
+      0,
   });
   let resultErrorPages: ErrorPages | null = null;
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/500.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/500.tsx
@@ -49,6 +49,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
     apiKey: config.sitecoreApiKey,
     siteName: site.name,
     language: context.locale || context.defaultLocale || config.defaultLanguage,
+    retries:
+      (process.env.GRAPH_QL_SERVICE_RETRIES &&
+        parseInt(process.env.GRAPH_QL_SERVICE_RETRIES, 10)) ||
+      0,
   });
   let resultErrorPages: ErrorPages | null = null;
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/.env
+++ b/packages/create-sitecore-jss/src/templates/nextjs/.env
@@ -42,6 +42,9 @@ JSS_APP_NAME=
 # Your default app language.
 DEFAULT_LANGUAGE=
 
+# How many times should GraphQL Layout, Dictionary and ErrorPages services retry a fetch when endpoint rate limit is reached
+GRAPH_QL_SERVICE_RETRIES=0
+
 # The way in which layout and dictionary data is fetched from Sitecore
 FETCH_WITH=<%- fetchWith %>
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/dictionary-service-factory.ts
@@ -34,6 +34,10 @@ export class DictionaryServiceFactory {
             It will only try the request once by default.
             retries: 'number' 
           */
+          retries:
+            (process.env.GRAPH_QL_SERVICE_RETRIES &&
+              parseInt(process.env.GRAPH_QL_SERVICE_RETRIES, 10)) ||
+            0,
         })
       : new RestDictionaryService({
           apiHost: config.sitecoreApiHost,

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/layout-service-factory.ts
@@ -27,6 +27,10 @@ export class LayoutServiceFactory {
             It will only try the request once by default.
             retries: 'number' 
           */
+          retries:
+            (process.env.GRAPH_QL_SERVICE_RETRIES &&
+              parseInt(process.env.GRAPH_QL_SERVICE_RETRIES, 10)) ||
+            0,
         })
       : new RestLayoutService({
           apiHost: config.sitecoreApiHost,

--- a/packages/sitecore-jss/src/site/graphql-error-pages-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-error-pages-service.ts
@@ -1,4 +1,4 @@
-import { GraphQLClient, GraphQLRequestClient } from '../graphql';
+import { GraphQLClient, GraphQLRequestClient, GraphQLRequestClientConfig } from '../graphql';
 import { siteNameError } from '../constants';
 import debug from '../debug';
 import { LayoutServiceData } from '../layout';
@@ -23,7 +23,7 @@ const defaultQuery = /* GraphQL */ `
   }
 `;
 
-export type GraphQLErrorPagesServiceConfig = {
+export interface GraphQLErrorPagesServiceConfig extends Pick<GraphQLRequestClientConfig, 'retries'> {
   /**
    * Your Graphql endpoint
    */
@@ -110,6 +110,7 @@ export class GraphQLErrorPagesService {
     return new GraphQLRequestClient(this.options.endpoint, {
       apiKey: this.options.apiKey,
       debugger: debug.errorpages,
+      retries: this.options.retries,
     });
   }
 }

--- a/packages/sitecore-jss/src/site/graphql-error-pages-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-error-pages-service.ts
@@ -23,7 +23,8 @@ const defaultQuery = /* GraphQL */ `
   }
 `;
 
-export interface GraphQLErrorPagesServiceConfig extends Pick<GraphQLRequestClientConfig, 'retries'> {
+export interface GraphQLErrorPagesServiceConfig
+  extends Pick<GraphQLRequestClientConfig, 'retries'> {
   /**
    * Your Graphql endpoint
    */
@@ -40,7 +41,7 @@ export interface GraphQLErrorPagesServiceConfig extends Pick<GraphQLRequestClien
    * The language
    */
   language: string;
-};
+}
 
 /**
  * Object model of Error Pages result

--- a/yarn.lock
+++ b/yarn.lock
@@ -6457,7 +6457,7 @@ __metadata:
     "@angular/platform-browser": ~15.2.9
     "@angular/platform-browser-dynamic": ~15.2.9
     "@angular/router": ~15.2.9
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/jasmine": ^3.4.1
     "@types/node": ^14.14.35
     codelyzer: ^6.0.1
@@ -6488,7 +6488,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-cli@workspace:packages/sitecore-jss-cli"
   dependencies:
-    "@sitecore-jss/sitecore-jss-dev-tools": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.5.0-canary.2
     "@types/chai": ^4.2.4
     "@types/cross-spawn": ^6.0.2
     "@types/mocha": ^10.0.1
@@ -6520,11 +6520,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-dev-tools@^21.5.0-canary.2, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
+"@sitecore-jss/sitecore-jss-dev-tools@21.5.0-canary.2, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools"
   dependencies:
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/chai": ^4.3.4
     "@types/chokidar": ^2.1.3
     "@types/del": ^4.0.0
@@ -6576,11 +6576,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-forms@^21.5.0-canary.2, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
+"@sitecore-jss/sitecore-jss-forms@21.5.0-canary.2, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/lodash.unescape": ^4.0.7
@@ -6603,9 +6603,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-nextjs@workspace:packages/sitecore-jss-nextjs"
   dependencies:
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
-    "@sitecore-jss/sitecore-jss-dev-tools": ^21.5.0-canary.2
-    "@sitecore-jss/sitecore-jss-react": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss-react": 21.5.0-canary.2
     "@types/chai": ^4.3.4
     "@types/chai-as-promised": ^7.1.5
     "@types/chai-string": ^1.4.2
@@ -6677,7 +6677,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react-forms@workspace:packages/sitecore-jss-react-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss-forms": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss-forms": 21.5.0-canary.2
     "@types/chai": ^4.3.4
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
@@ -6717,7 +6717,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": ^7.5.2
     "@babel/preset-env": ^7.6.2
     "@babel/preset-typescript": ^7.6.0
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/jest": ^24.0.18
     "@types/prop-types": ^15.7.3
     "@types/react": ^16.9.5
@@ -6747,12 +6747,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-react@^21.5.0-canary.2, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
+"@sitecore-jss/sitecore-jss-react@21.5.0-canary.2, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react"
   dependencies:
     "@sitecore-feaas/clientside": ^0.3.17
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/deep-equal": ^1.0.1
@@ -6826,7 +6826,7 @@ __metadata:
   resolution: "@sitecore-jss/sitecore-jss-vue@workspace:packages/sitecore-jss-vue"
   dependencies:
     "@babel/core": ^7.20.12
-    "@sitecore-jss/sitecore-jss": ^21.5.0-canary.2
+    "@sitecore-jss/sitecore-jss": 21.5.0-canary.2
     "@types/jest": ^29.2.6
     "@types/node": ^18.11.18
     "@vue/compiler-dom": ^3.2.45
@@ -6850,7 +6850,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss@^21.5.0-canary.2, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
+"@sitecore-jss/sitecore-jss@21.5.0-canary.2, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss"
   dependencies:


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
Follow up to rate limits PR.
ErrorPages service from SXA may cause trouble during build when rate limits are enabled. This PR extends retryer functionality to that service and makes retry count be configurable through env (GRAPH_QL_SERVICE_RETRIES).

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
