### PR TITLE
Chain responses in middleware.

### DIFF
--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
@@ -58,6 +58,14 @@ describe('MiddlewareBase', () => {
           return { value: cookies[cookieName] };
         },
       },
+      headers: {
+        get(key: string) {
+          const headers = {
+            ...props?.headerValues,
+          };
+          return headers[key];
+        },
+      },
     } as NextResponse;
   };
 
@@ -207,6 +215,22 @@ describe('MiddlewareBase', () => {
       const res = createRes({
         cookies: {
           sc_site: 'xxx',
+        },
+      });
+      const siteResolver = new MockSiteResolver([]);
+      const middleware = new SampleMiddleware({ siteResolver });
+
+      expect(middleware['getSite'](req, res).name).to.equal('xxx');
+      expect(siteResolver.getByName).to.be.calledWith('xxx');
+    });
+  });
+
+  describe('getSite', () => {
+    it('should get site by name when site header is provided', () => {
+      const req = createReq();
+      const res = createRes({
+        headerValues: {
+          'x-sc-site': 'xxx',
         },
       });
       const siteResolver = new MockSiteResolver([]);

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
@@ -29,6 +29,8 @@ export type MiddlewareBaseConfig = {
 
 export abstract class MiddlewareBase {
   protected SITE_SYMBOL = 'sc_site';
+  protected SITE_HEADER_NAME = 'x-sc-site';
+  protected REWRITE_HEADER_NAME = 'x-sc-rewrite';
   protected defaultHostname: string;
 
   constructor(protected config: MiddlewareBaseConfig) {
@@ -92,6 +94,10 @@ export abstract class MiddlewareBase {
    * @returns {SiteInfo} site information
    */
   protected getSite(req: NextRequest, res?: NextResponse): SiteInfo {
+    const siteNameHeader = res?.headers.get(this.SITE_HEADER_NAME);
+
+    if (siteNameHeader) return this.config.siteResolver.getByName(siteNameHeader);
+
     const siteNameCookie = res?.cookies.get(this.SITE_SYMBOL)?.value;
 
     if (siteNameCookie) return this.config.siteResolver.getByName(siteNameCookie);
@@ -99,5 +105,24 @@ export abstract class MiddlewareBase {
     const hostname = this.getHostHeader(req) || this.defaultHostname;
 
     return this.config.siteResolver.getByHost(hostname);
+  }
+
+  /**
+   * Create a rewrite response
+   * @param {string} rewritePath the destionation path
+   * @param {NextRequest} req the current request
+   * @param {NextResponse} res the current response
+   */
+  protected rewrite(rewritePath: string, req: NextRequest, res: NextResponse): NextResponse {
+    // Note an absolute URL is required: https://nextjs.org/docs/messages/middleware-relative-urls
+    const rewriteUrl = req.nextUrl.clone();
+    rewriteUrl.pathname = rewritePath;
+
+    const response = NextResponse.rewrite(rewriteUrl, res);
+
+    // Share rewrite path with following executed middlewares
+    response.headers.set(this.REWRITE_HEADER_NAME, rewritePath);
+
+    return response;
   }
 }

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.test.ts
@@ -245,6 +245,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foo',
         headers: {
           'x-sc-rewrite': '/_site_foo/styleguide',
+          'x-sc-site': 'foo',
         },
         cookies: {
           ...res.cookies,
@@ -286,6 +287,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foo',
         headers: {
           'x-sc-rewrite': '/_site_foo/styleguide',
+          'x-sc-site': 'foo',
         },
         cookies: {
           ...res.cookies,
@@ -325,6 +327,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foo',
         headers: {
           'x-sc-rewrite': '/_site_foo/styleguide',
+          'x-sc-site': 'foo',
         },
         cookies: {
           ...res.cookies,
@@ -364,6 +367,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foo',
         headers: {
           'x-sc-rewrite': '/_site_foo/styleguide',
+          'x-sc-site': 'foo',
         },
         cookies: {
           ...res.cookies,
@@ -407,6 +411,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'qsFoo',
         headers: {
           'x-sc-rewrite': '/_site_qsFoo/styleguide',
+          'x-sc-site': 'qsFoo',
         },
         cookies: {
           ...res.cookies,
@@ -451,6 +456,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foobar',
         headers: {
           'x-sc-rewrite': '/_site_foobar/styleguide',
+          'x-sc-site': 'foobar',
         },
         cookies: {
           ...res.cookies,
@@ -493,6 +499,7 @@ describe('MultisiteMiddleware', () => {
         siteName: 'foo',
         headers: {
           'x-sc-rewrite': '/_site_foo/styleguide',
+          'x-sc-site': 'foo',
         },
         cookies: {
           ...res.cookies,

--- a/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/multisite-middleware.ts
@@ -75,18 +75,12 @@ export class MultisiteMiddleware extends MiddlewareBase {
     const rewritePath = getSiteRewrite(pathname, {
       siteName,
     });
+    response = this.rewrite(rewritePath, req, response);
 
-    // Note an absolute URL is required: https://nextjs.org/docs/messages/middleware-relative-urls
-    const rewriteUrl = req.nextUrl.clone();
-
-    rewriteUrl.pathname = rewritePath;
-
-    response = NextResponse.rewrite(rewriteUrl);
-
-    // Share site name with the following executed middlewares
+    // Share site name with the following executed middlewares as cookie for legacy
     response.cookies.set(this.SITE_SYMBOL, siteName);
-    // Share rewrite path with following executed middlewares
-    response.headers.set('x-sc-rewrite', rewritePath);
+    // Share site name with the following executed middlewares
+    response.headers.set(this.SITE_HEADER_NAME, siteName);
 
     debug.multisite('multisite middleware end in %dms: %o', Date.now() - startTimestamp, {
       rewritePath,

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -212,21 +212,14 @@ export class PersonalizeMiddleware extends MiddlewareBase {
 
     // Rewrite to persononalized path
     const rewritePath = getPersonalizedRewrite(basePath, { variantId });
-    // Note an absolute URL is required: https://nextjs.org/docs/messages/middleware-relative-urls
-    const rewriteUrl = req.nextUrl.clone();
-    rewriteUrl.pathname = rewritePath;
-    response = NextResponse.rewrite(rewriteUrl);
+    response = this.rewrite(rewritePath, req, response);
 
     // Disable preflight caching to force revalidation on client-side navigation (personalization may be influenced)
     // See https://github.com/vercel/next.js/issues/32727
     response.headers.set('x-middleware-cache', 'no-cache');
-    // Share rewrite path with following executed middlewares
-    response.headers.set('x-sc-rewrite', rewritePath);
 
     // Set browserId cookie on the response
     this.setBrowserId(response, browserId);
-    // Share site name with the following executed middlewares
-    response.cookies.set(this.SITE_SYMBOL, site.name);
 
     debug.personalize('personalize middleware end in %dms: %o', Date.now() - startTimestamp, {
       rewritePath,

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -352,13 +352,16 @@ describe('RedirectsMiddleware', () => {
           url: 'http://localhost:3000/found',
           status: 301,
           setCookies,
+          headers: new Headers({}),
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
+          const headers = typeof init === 'object' ? init?.headers : {};
           return ({
             url,
             status,
             cookies: { set: setCookies },
-            headers: res.headers,
+            headers: new Headers(headers),
           } as unknown) as NextResponse;
         });
         const req = createRequest({
@@ -411,7 +414,7 @@ describe('RedirectsMiddleware', () => {
           status: 301,
           setCookies,
         });
-        const nextRewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((url) => {
+        const nextRewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((url, init) => {
           return ({
             url,
             status: 301,
@@ -526,7 +529,8 @@ describe('RedirectsMiddleware', () => {
           status: 301,
           setCookies,
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
           return ({
             url,
             status,
@@ -610,7 +614,6 @@ describe('RedirectsMiddleware', () => {
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
           headers: {
-            'set-cookie': 'sc_site=nextjs-app; Path=/',
             'x-middleware-next': '1',
           },
           redirected: false,
@@ -687,7 +690,8 @@ describe('RedirectsMiddleware', () => {
           status: 302,
           setCookies,
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
           return ({
             url,
             status,
@@ -746,7 +750,8 @@ describe('RedirectsMiddleware', () => {
           status: 301,
           setCookies,
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
           return ({
             url,
             status,
@@ -857,7 +862,7 @@ describe('RedirectsMiddleware', () => {
           url: 'http://localhost:3000/found',
           setCookies,
         });
-        const nextRewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((url) => {
+        const nextRewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((url, init) => {
           return ({
             url,
             cookies: { set: setCookies },
@@ -908,7 +913,7 @@ describe('RedirectsMiddleware', () => {
 
       it('should use sc_site cookie', async () => {
         const siteName = 'foo';
-        const res = NextResponse.redirect('http://localhost:3000/found', 301);
+        const res = NextResponse.rewrite('http://localhost:3000/found');
         res.cookies.set('sc_site', siteName);
         const req = createRequest({
           nextUrl: {
@@ -929,6 +934,8 @@ describe('RedirectsMiddleware', () => {
           locale: 'en',
         });
 
+        const expected = NextResponse.redirect('http://localhost:3000/found', { status: 301, headers: res.headers });
+
         const finalRes = await middleware.getHandler()(req, res);
 
         validateDebugLog('redirects middleware start: %o', {
@@ -941,6 +948,7 @@ describe('RedirectsMiddleware', () => {
           headers: {
             location: 'http://localhost:3000/found',
             'set-cookie': 'sc_site=foo; Path=/',
+            'x-middleware-rewrite': 'http://localhost:3000/found',
           },
           redirected: false,
           status: 301,
@@ -950,8 +958,8 @@ describe('RedirectsMiddleware', () => {
         expect(siteResolver.getByHost).not.called.to.equal(true);
         expect(siteResolver.getByName).to.be.calledWith(siteName);
         expect(fetchRedirects).to.be.calledWith(siteName);
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
+        expect(finalRes).to.deep.equal(expected);
+        expect(finalRes.status).to.equal(expected.status);
       });
 
       it('should preserve site name from response data when provided, if no redirect type defined', async () => {
@@ -1058,7 +1066,8 @@ describe('RedirectsMiddleware', () => {
           status: 301,
           setCookies,
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
           return ({
             url,
             status,
@@ -1119,7 +1128,8 @@ describe('RedirectsMiddleware', () => {
           status: 301,
           setCookies,
         });
-        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, status) => {
+        const nextRedirectStub = sinon.stub(NextResponse, 'redirect').callsFake((url, init) => {
+          const status = typeof init === 'number' ? init : init?.status || 307;
           return ({
             url,
             status,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
By chaining the responses in rewrites, we can access headers set in earlier middleware.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other - I have implemented similar changes in our Sitecore solution. I don't have a personal Sitecore instance to fully test them on at this time.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
