### PR TITLE
[sitecore-jss-proxy] Setting "followRedirects" to true" breaks HEAD requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-proxy]` Setting "followRedirects" to "true" breaks HEAD requests ([#1630](https://github.com/Sitecore/jss/pull/1630))
 * `[templates/nextjs-sxa]` Fix shown horizontal scrollbar in EE mode. ([#1625](https://github.com/Sitecore/jss/pull/1625)), ([#1626](https://github.com/Sitecore/jss/pull/1626))
 
 ## 21.4.0

--- a/packages/sitecore-jss-proxy/src/index.ts
+++ b/packages/sitecore-jss-proxy/src/index.ts
@@ -518,7 +518,7 @@ function handleProxyRequest(
       if (config.debug) {
         console.log('DEBUG: Rewriting HEAD request to GET to create accurate headers');
       }
-    } else if (proxyReq.method === 'HEAD' && !isUrlIgnored(req.originalUrl, config, true)) {
+    } else if (proxyReq.method === 'HEAD') {
       if (config.debug) {
         console.log('DEBUG: Rewriting HEAD request to GET to create accurate headers');
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
When customers use `followRedirects: true` and try to send a _HEAD_ request, the proxy server crashes.
This PR addresses this problem. When _followRedirects_ is enabled, _http-proxy-middleware_ initializes a proxy request before _onProxyReq_ is called, after it's initialized there is no way to update the method without accessing to internal properties, so we swap **HEAD** with **GET** before _onProxyReq_ is called, and change it back in _onProxyReq_ event in case it's accessed later.

This change shouldn't be treated as a **_breaking_** change, since Express middleware accepts an array of handlers also.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
