### PR TITLE
[templates/nextjs] Fix monorepo sample failing on client

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/tsconfig.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/tsconfig.json
@@ -7,7 +7,7 @@
       "temp/*": ["src/temp/*"],
       "assets/*": ["src/assets/*"],
       "graphql-types": ["node_modules/@types/graphql-let/__generated__/__types__"],
-      "react": ["node_modules/@types/react"]
+      "react": ["node_modules/react"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
Monorepo was failing with 'useContext' error (cannot read properties of null). This PR should fix it.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
