### PR TITLE
[sitecore-jss-nextjs][templates/nextjs] Move graphql client imports to allow usage in middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` Import SitecoreForm component into sample nextjs app ([#1628](https://github.com/Sitecore/jss/pull/1628))
 * `[sitecore-jss-nextjs]` (Vercel/Sitecore) Deployment Protection Bypass support for editing integration. ([#1634](https://github.com/Sitecore/jss/pull/1634))
 * `[sitecore-jss]` `[templates/nextjs]` Load environment-specific FEAAS theme stylesheets based on Sitecore Edge Platform URL ([#1645](https://github.com/Sitecore/jss/pull/1645))
+* `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use imnport from _@sitecore-jss/sitecore-jss-nextjs/graphql-client_ submodule instead ([#1648](https://github.com/Sitecore/jss/pull/1648))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` Import SitecoreForm component into sample nextjs app ([#1628](https://github.com/Sitecore/jss/pull/1628))
 * `[sitecore-jss-nextjs]` (Vercel/Sitecore) Deployment Protection Bypass support for editing integration. ([#1634](https://github.com/Sitecore/jss/pull/1634))
 * `[sitecore-jss]` `[templates/nextjs]` Load environment-specific FEAAS theme stylesheets based on Sitecore Edge Platform URL ([#1645](https://github.com/Sitecore/jss/pull/1645))
-* `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use imnport from _@sitecore-jss/sitecore-jss-nextjs/graphql-client_ submodule instead ([#1648](https://github.com/Sitecore/jss/pull/1648))
+* `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use import from _@sitecore-jss/sitecore-jss-nextjs/graphql-client_ submodule instead ([#1648](https://github.com/Sitecore/jss/pull/1648))
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/graphql-client-factory/create.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/graphql-client-factory/create.ts
@@ -1,8 +1,8 @@
 import {
   GraphQLRequestClientFactoryConfig,
-  getEdgeProxyContentUrl,
   GraphQLRequestClient,
-} from '@sitecore-jss/sitecore-jss-nextjs';
+} from '@sitecore-jss/sitecore-jss-nextjs/graphql-client';
+import { getEdgeProxyContentUrl } from '@sitecore-jss/sitecore-jss-nextjs/utils';
 import { JssConfig } from 'lib/config';
 
 /**

--- a/packages/sitecore-jss-nextjs/graphql-client.d.ts
+++ b/packages/sitecore-jss-nextjs/graphql-client.d.ts
@@ -1,0 +1,1 @@
+export * from './types/graphql-client/index';

--- a/packages/sitecore-jss-nextjs/graphql-client.js
+++ b/packages/sitecore-jss-nextjs/graphql-client.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/graphql-client/index');

--- a/packages/sitecore-jss-nextjs/src/graphql-client/index.ts
+++ b/packages/sitecore-jss-nextjs/src/graphql-client/index.ts
@@ -1,0 +1,5 @@
+export {
+  GraphQLRequestClient,
+  GraphQLRequestClientFactory,
+  GraphQLRequestClientFactoryConfig,
+} from '@sitecore-jss/sitecore-jss';

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -8,9 +8,6 @@ export {
   AxiosDataFetcherConfig,
   NativeDataFetcher,
   NativeDataFetcherConfig,
-  GraphQLRequestClient,
-  GraphQLRequestClientFactory,
-  GraphQLRequestClientFactoryConfig,
   HTMLLink,
   enableDebug,
   debug,
@@ -18,6 +15,7 @@ export {
 
 // we will remove the root exports for these later
 // we cannot mark exports as deprected directly, so we're using this hack instead
+import { GraphQLRequestClient as GraphQLRequestClientDep } from './graphql-client';
 import {
   isEditorActive as isEditorActiveDep,
   resetEditorChromes as resetEditorChromesDep,
@@ -28,6 +26,7 @@ import {
   handleEditorFastRefresh as handleEditorFastRefreshDep,
   getPublicUrl as getPublicUrlDep,
 } from './utils';
+
 /** @deprecated use import from '@sitecore-jss/sitecore-jss-nextjs/utils' instead */
 const {
   isEditorActiveDep: isEditorActive,
@@ -44,6 +43,12 @@ const {
   handleEditorFastRefreshDep,
   getPublicUrlDep,
 };
+/** @deprecated use import from '@sitecore-jss/sitecore-jss-nextjs/graphql-client' instead */
+const { GraphQLRequestClientDep: GraphQLRequestClient } = {
+  GraphQLRequestClientDep,
+};
+
+export { GraphQLRequestClient };
 export { handleEditorFastRefresh, getPublicUrl };
 export { isEditorActive, resetEditorChromes, resolveUrl, tryParseEnvValue };
 
@@ -72,7 +77,6 @@ export {
   EDITING_COMPONENT_PLACEHOLDER,
   EDITING_COMPONENT_ID,
 } from '@sitecore-jss/sitecore-jss/layout';
-export { getEdgeProxyContentUrl } from '@sitecore-jss/sitecore-jss/graphql';
 export { mediaApi } from '@sitecore-jss/sitecore-jss/media';
 export {
   trackingApi,

--- a/packages/sitecore-jss-nextjs/src/utils/index.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/index.ts
@@ -5,3 +5,4 @@ export {
   resetEditorChromes,
   resolveUrl,
 } from '@sitecore-jss/sitecore-jss/utils';
+export { getEdgeProxyContentUrl } from '@sitecore-jss/sitecore-jss/graphql';

--- a/packages/sitecore-jss-nextjs/tsconfig.json
+++ b/packages/sitecore-jss-nextjs/tsconfig.json
@@ -18,6 +18,7 @@
     "editing.d.ts",
     "monitoring.d.ts",
     "site.d.ts",
+    "graphql-client.d.ts",
     "utils.d.ts",
     "src/tests/*",
     "src/test-data/*",


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Nextjs app fails if imports from the main '@sitecore-jss/sitecore-jss-nextjs' module are used in middeware. This PR moves some of the needed imports to submodules to fix middleware-related build issues.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - build, production mode work when connected to XMC Preview

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
