### PR TITLE
[Next.js] [Multisite] Skip site info fetch on XM Cloud rendering/editing host builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fix issue when redirects works each every other times. ([#1629](https://github.com/Sitecore/jss/pull/1629))
 * `[templates/nextjs]` Fix custom headers. Now in cors-header plugin extends custom headers from next.config.js file. ([#1637](https://github.com/Sitecore/jss/pull/1637))
 * `[sitecore-jss-react]` Fix PlaceholderCommon with using two and more dynamic placeholders. ([#1641](https://github.com/Sitecore/jss/pull/1641))
+* `[templates/nextjs-multisite]` Fix site info fetch errors (now skipped) on XM Cloud rendering/editing host builds. ([#1649](https://github.com/Sitecore/jss/pull/1649))
 
 
 ## 21.5.0

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -17,8 +17,14 @@ class MultisitePlugin implements ConfigPlugin {
 
     const endpoint = config.sitecoreEdgeContextId ? config.sitecoreEdgeUrl : config.graphQLEndpoint;
 
-    if (!endpoint) {
-      console.warn(chalk.yellow('Skipping site information fetch (missing GraphQL endpoint).'));
+    if (!endpoint || process.env.SITECORE) {
+      console.warn(
+        chalk.yellow(
+          `Skipping site information fetch (${
+            !endpoint ? 'missing GraphQL endpoint' : 'building on XM Cloud'
+          })`
+        )
+      );
     } else {
       console.log(`Fetching site information from ${endpoint}`);
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
When building on XM Cloud, the CM instance is not necessarily provisioned and available. The site info fetch fails in this case (but build continues). This change prevents site fetch from even being attempted. Note we're already disabling CM usage during static generation (via `DISABLE_SSG_FETCH`).

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
