### PR TITLE
[sitecore-jss-nextjs][templates/nextjs] Move graphql client imports - followup

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs/src/lib/graphql-client-factory/create.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/src/lib/graphql-client-factory/create.ts
@@ -1,8 +1,8 @@
 import {
   GraphQLRequestClientFactoryConfig,
   GraphQLRequestClient,
-} from '@sitecore-jss/sitecore-jss-nextjs/graphql-client';
-import { getEdgeProxyContentUrl } from '@sitecore-jss/sitecore-jss-nextjs/utils';
+  getEdgeProxyContentUrl
+} from '@sitecore-jss/sitecore-jss-nextjs/graphql';
 import { JssConfig } from 'lib/config';
 
 /**

--- a/packages/sitecore-jss-nextjs/graphql-client.d.ts
+++ b/packages/sitecore-jss-nextjs/graphql-client.d.ts
@@ -1,1 +1,0 @@
-export * from './types/graphql-client/index';

--- a/packages/sitecore-jss-nextjs/graphql-client.js
+++ b/packages/sitecore-jss-nextjs/graphql-client.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/cjs/graphql-client/index');

--- a/packages/sitecore-jss-nextjs/graphql.d.ts
+++ b/packages/sitecore-jss-nextjs/graphql.d.ts
@@ -1,0 +1,1 @@
+export * from './types/graphql/index';

--- a/packages/sitecore-jss-nextjs/graphql.js
+++ b/packages/sitecore-jss-nextjs/graphql.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/cjs/graphql/index');

--- a/packages/sitecore-jss-nextjs/src/graphql/index.ts
+++ b/packages/sitecore-jss-nextjs/src/graphql/index.ts
@@ -2,5 +2,5 @@ export {
   GraphQLRequestClient,
   GraphQLRequestClientFactory,
   GraphQLRequestClientFactoryConfig,
-  getEdgeProxyContentUrl
+  getEdgeProxyContentUrl,
 } from '@sitecore-jss/sitecore-jss/graphql';

--- a/packages/sitecore-jss-nextjs/src/graphql/index.ts
+++ b/packages/sitecore-jss-nextjs/src/graphql/index.ts
@@ -2,4 +2,5 @@ export {
   GraphQLRequestClient,
   GraphQLRequestClientFactory,
   GraphQLRequestClientFactoryConfig,
-} from '@sitecore-jss/sitecore-jss';
+  getEdgeProxyContentUrl
+} from '@sitecore-jss/sitecore-jss/graphql';

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -15,7 +15,7 @@ export {
 
 // we will remove the root exports for these later
 // we cannot mark exports as deprected directly, so we're using this hack instead
-import { GraphQLRequestClient as GraphQLRequestClientDep } from './graphql-client';
+import { GraphQLRequestClient as GraphQLRequestClientDep } from './graphql';
 import {
   isEditorActive as isEditorActiveDep,
   resetEditorChromes as resetEditorChromesDep,
@@ -43,7 +43,7 @@ const {
   handleEditorFastRefreshDep,
   getPublicUrlDep,
 };
-/** @deprecated use import from '@sitecore-jss/sitecore-jss-nextjs/graphql-client' instead */
+/** @deprecated use import from '@sitecore-jss/sitecore-jss-nextjs/graphql' instead */
 const { GraphQLRequestClientDep: GraphQLRequestClient } = {
   GraphQLRequestClientDep,
 };

--- a/packages/sitecore-jss-nextjs/src/utils/index.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/index.ts
@@ -5,4 +5,3 @@ export {
   resetEditorChromes,
   resolveUrl,
 } from '@sitecore-jss/sitecore-jss/utils';
-export { getEdgeProxyContentUrl } from '@sitecore-jss/sitecore-jss/graphql';

--- a/packages/sitecore-jss-nextjs/tsconfig.json
+++ b/packages/sitecore-jss-nextjs/tsconfig.json
@@ -18,7 +18,7 @@
     "editing.d.ts",
     "monitoring.d.ts",
     "site.d.ts",
-    "graphql-client.d.ts",
+    "graphql.d.ts",
     "utils.d.ts",
     "src/tests/*",
     "src/test-data/*",


### PR DESCRIPTION
Rework of https://github.com/Sitecore/jss/pull/1648 with a change to submodule name to align it with @sitecore-jss/sitecore-jss package's exports naming.
