### PR TITLE
Fix `yarn watch` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "typedoc-plugin-markdown": "^3.11.3",
     "typescript": "~4.7.4"
   },
+  "resolutions": {
+    "eslint-plugin-jsx-a11y": "6.7.1"
+  },
   "workspaces": [
     "packages/*",
     "samples/*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Scaffolding of any app in monorepo fails with the latest release of `eslint` peer dependency `eslint-plugin-jsx-a11y: 6.8.0`

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
