### PR TITLE
[Next.js] Fixes for `nextjs-xmcloud` Initializer Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` (Vercel/Sitecore) Deployment Protection Bypass support for editing integration. ([#1634](https://github.com/Sitecore/jss/pull/1634))
 * `[sitecore-jss]` `[templates/nextjs]` Load environment-specific FEAAS theme stylesheets based on Sitecore Edge Platform URL ([#1645](https://github.com/Sitecore/jss/pull/1645))
 * `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use import from _@sitecore-jss/sitecore-jss-nextjs/graphql_ submodule instead ([#1650](https://github.com/Sitecore/jss/pull/1650) [#1648](https://github.com/Sitecore/jss/pull/1648))
-* `[create-sitecore-jss]` Introduced `nextjs-xmcloud` initializer template. This will include all base XM Cloud features, including Personalize, FEaaS, BYOC, Sitecore Edge Platform and Context support. ([#1653](https://github.com/Sitecore/jss/pull/1653))
+* `[create-sitecore-jss]` Introduced `nextjs-xmcloud` initializer template. This will include all base XM Cloud features, including Personalize, FEaaS, BYOC, Sitecore Edge Platform and Context support. ([#1653](https://github.com/Sitecore/jss/pull/1653)) ([#1657](https://github.com/Sitecore/jss/pull/1657))
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/init-runner.test.ts
+++ b/packages/create-sitecore-jss/src/init-runner.test.ts
@@ -75,7 +75,7 @@ describe('initRunner', () => {
   });
 
   it('should process returned initializers', async () => {
-    const templates = ['foo', 'bar'];
+    const templates = ['foo', 'bar', 'zoo'];
     const appName = 'test-app';
     const args = {
       silent: false,
@@ -87,11 +87,13 @@ describe('initRunner', () => {
     const mockBar = mockInitializer(false, { appName, initializers: ['baz'] });
     const mockBaz = mockInitializer(false, { appName, initializers: ['huh'] });
     const mockHuh = mockInitializer(false, { appName, initializers: [] });
+    const mockZoo = mockInitializer(false, { appName, initializers: [] });
     createStub = sinon.stub(InitializerFactory.prototype, 'create');
     createStub.withArgs('foo').returns(mockFoo);
     createStub.withArgs('bar').returns(mockBar);
     createStub.withArgs('baz').returns(mockBaz);
     createStub.withArgs('huh').returns(mockHuh);
+    createStub.withArgs('zoo').returns(mockZoo);
 
     await initRunner(templates, args);
 
@@ -99,7 +101,8 @@ describe('initRunner', () => {
     expect(mockBar.init).to.be.calledOnceWith(args);
     expect(mockBaz.init).to.be.calledOnceWith(args);
     expect(mockHuh.init).to.be.calledOnceWith(args);
-    expect(args.templates).to.deep.equal(['foo', 'bar', 'baz', 'huh']);
+    expect(mockZoo.init).to.be.calledOnceWith(args);
+    expect(args.templates).to.deep.equal(['foo', 'bar', 'zoo', 'baz', 'huh']);
   });
 
   it('should aggregate nextSteps', async () => {

--- a/packages/create-sitecore-jss/src/init-runner.ts
+++ b/packages/create-sitecore-jss/src/init-runner.ts
@@ -16,7 +16,7 @@ export const initRunner = async (initializers: string[], args: BaseArgs) => {
 
   const initFactory = new InitializerFactory();
   const runner = async (inits: string[]): Promise<void> => {
-    for (const init of inits) {
+    for (const init of [...inits]) {
       const initializer = await initFactory.create(init);
       if (!initializer) {
         throw new RangeError(`Unknown template '${init}'`);
@@ -34,7 +34,7 @@ export const initRunner = async (initializers: string[], args: BaseArgs) => {
         // add-ons will not have information about the initial
         // list of templates, as it has `nextjs` initializer for example
         args.templates.push(...response.initializers);
-        return await runner(response.initializers);
+        await runner(response.initializers);
       }
     }
   };

--- a/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
@@ -3,10 +3,12 @@ import {
   Initializer,
   openPackageJson,
   transform,
+  isDevEnvironment,
   DEFAULT_APPNAME,
   ClientAppArgs,
   incompatibleAddonsMsg,
 } from '../../common';
+import { removeDevDependencies } from './remove-dev-dependencies';
 
 export default class NextjsXMCloudInitializer implements Initializer {
   get isBase(): boolean {
@@ -25,6 +27,10 @@ export default class NextjsXMCloudInitializer implements Initializer {
     const templatePath = path.resolve(__dirname, '../../templates/nextjs-xmcloud');
 
     await transform(templatePath, mergedArgs);
+
+    if (!isDevEnvironment(args.destination)) {
+      removeDevDependencies(args.destination);
+    }
 
     if (
       args.templates.includes('nextjs-styleguide-tracking') ||

--- a/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/remove-dev-dependencies.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/remove-dev-dependencies.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+export const removeDevDependencies = (projectPath: string) => {
+  // remove monorepo next.config.js plugin
+  const monorepoPlugin = path.join(projectPath, 'src/lib/next-config/plugins/monorepo-xmcloud.js');
+  if (fs.existsSync(monorepoPlugin)) {
+    fs.unlinkSync(monorepoPlugin);
+  }
+};

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/monorepo-xmcloud.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/monorepo-xmcloud.js
@@ -7,9 +7,6 @@ const CWD = process.cwd();
 const monorepoPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
     webpack: (config, options) => {
-      if (options.isServer) {
-        config.externals = ['react', 'vertx', ...config.externals];
-      }
       // Monorepo support for @sitecore-feaas/clientside/react
       config.resolve.alias['@sitecore-feaas/clientside/react'] = path.resolve(
         CWD, options.isServer ? 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Follow-up to https://github.com/Sitecore/jss/pull/1653 which fixes the following issues:
- Fix issue where nextjs-xmcloud template's /src/lib/next-config/plugins/monorepo.js wasn't being cleaned up properly. Use dedicated monorepo-xmcloud.js instead.
- Fix issue with init-runner where response.initializers would prevent any following initializers to be skipped (return statement caused early exit)

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
