### PR TITLE
[Next.js] Fixes (part 2) for `nextjs-xmcloud` Initializer Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` (Vercel/Sitecore) Deployment Protection Bypass support for editing integration. ([#1634](https://github.com/Sitecore/jss/pull/1634))
 * `[sitecore-jss]` `[templates/nextjs]` Load environment-specific FEAAS theme stylesheets based on Sitecore Edge Platform URL ([#1645](https://github.com/Sitecore/jss/pull/1645))
 * `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use import from _@sitecore-jss/sitecore-jss-nextjs/graphql_ submodule instead ([#1650](https://github.com/Sitecore/jss/pull/1650) [#1648](https://github.com/Sitecore/jss/pull/1648))
-* `[create-sitecore-jss]` Introduced `nextjs-xmcloud` initializer template. This will include all base XM Cloud features, including Personalize, FEaaS, BYOC, Sitecore Edge Platform and Context support. ([#1653](https://github.com/Sitecore/jss/pull/1653)) ([#1657](https://github.com/Sitecore/jss/pull/1657))
+* `[create-sitecore-jss]` Introduced `nextjs-xmcloud` initializer template. This will include all base XM Cloud features, including Personalize, FEaaS, BYOC, Sitecore Edge Platform and Context support. ([#1653](https://github.com/Sitecore/jss/pull/1653)) ([#1657](https://github.com/Sitecore/jss/pull/1657)) ([#1658](https://github.com/Sitecore/jss/pull/1658))
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
@@ -2,6 +2,7 @@ import { QuestionCollection } from 'inquirer';
 import CheckboxPrompt from 'inquirer/lib/prompts/checkbox';
 
 import { clientAppPrompts, ClientAppAnswer, incompatibleAddonsMsg } from '../../common';
+import { NextjsArgs } from './args';
 
 export enum Prerender {
   SSG = 'SSG',
@@ -35,8 +36,15 @@ export const prompts: QuestionCollection<NextjsAnswer> = [
     name: 'xmcloud',
     message: 'Are you building for Sitecore XM Cloud?',
     default: false,
-    when: (answers: NextjsAnswer): boolean => {
-      return !answers.yes;
+    when: (answers: NextjsAnswer & NextjsArgs): boolean => {
+      // don't prompt if --yes or nextjs-xmcloud template was specified
+      if (answers.yes) {
+        return false;
+      } else if (answers.templates.includes('nextjs-xmcloud')) {
+        answers.xmcloud = true;
+        return false;
+      }
+      return true;
     },
   },
 ];


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Minor fix to prevent "Are you building for XM Cloud?" prompt if `nextjs-xmcloud` template was specified on CLI.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
