### PR TITLE
[node-headless-ssr-proxy] Add sc_site qs parameter to Layout Service requests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[templates/node-headless-ssr-proxy]` [node-headless-ssr-proxy] Add sc_site qs parameter to Layout Service requests by default ([#1660](https://github.com/Sitecore/jss/pull/1660))
+
 ## 21.6.0
 
 ### 🎉 New Features & Improvements

--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/src/config.ts
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/src/config.ts
@@ -116,6 +116,10 @@ export const config: ProxyConfig = {
     delete proxyRes.headers['content-security-policy'];
   },
   /**
+   * Query string parameters to add to Layout Service requests.
+   */
+  qsParams: `sc_site=${siteName}`,
+  /**
    * Custom error handling in case our app fails to render.
    * Return null to pass through server response, or { content, statusCode }
    * to override server response.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
The `sc_site` query string parameter is now added to Layout Service requests by default. This is to ensure that the Layout Service request is routed to the correct Sitecore site when using the proxy. It ensures that the target site is resolved correctly for both Layout and Dictionary Service requests (For Dictionary Service requests, the `sc_site` parameter is already added to the request path, see [config.ts](https://github.com/Sitecore/jss/blob/dev/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/src/config.ts#L32), [path](https://github.com/Sitecore/jss/blob/dev/packages/sitecore-jss/src/i18n/rest-dictionary-service.ts#L84)).
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
