### PR TITLE
[Nextjs] [Context] Context's getSDK is non-enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Our versioning strategy is as follows:
 
 * `[templates/react]` `[templates/angular]` `[templates/vue]` `[templates/node-headless-ssr-proxy]` `[templates/node-headless-ssr-experience-edge]` ([#1647](https://github.com/Sitecore/jss/pull/1647)) Switch from using JSS_APP_NAME to SITE_NAME - environment and config variables in React, Vue, Angular templates as well as ssr node proxy apps templates have been renamed. 
 * `[sitecore-jss]` Support for both 'published' and 'staged' revisions of FEAAS stylesheets/themes ([#1644](https://github.com/Sitecore/jss/pull/1644))
-* `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` ([#1640](https://github.com/Sitecore/jss/pull/1640)) Sitecore Edge Platform and Context support:
+* `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` ([#1640](https://github.com/Sitecore/jss/pull/1640)) ([#1662](https://github.com/Sitecore/jss/pull/1662))([#1661](https://github.com/Sitecore/jss/pull/1661)) Sitecore Edge Platform and Context support:
   * Introducing the _clientFactory_ property. This property can be utilized by GraphQL-based services, the previously used _endpoint_ and _apiKey_ properties are deprecated. The _clientFactory_ serves as the central hub for executing GraphQL requests within the application.
   * New SITECORE_EDGE_CONTEXT_ID environment variable has been added.
   * The JSS_APP_NAME environment variable has been updated and is now referred to as SITE_NAME.

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -50,6 +50,18 @@ describe('Context', () => {
       expect(context.sitecoreEdgeContextId).to.equal(props.sitecoreEdgeContextId);
       expect(context.siteName).to.equal(props.siteName);
     });
+
+    it('should provide all the properties when context instance is merged as an object', () => {
+      const context = new Context<typeof sdks>(props);
+
+      const merged = { ...context };
+
+      expect(merged.sitecoreEdgeUrl).to.equal(props.sitecoreEdgeUrl);
+      expect(merged.sitecoreEdgeContextId).to.equal(props.sitecoreEdgeContextId);
+      expect(merged.siteName).to.equal(props.siteName);
+      expect(merged.getSDK).to.equal(context.getSDK);
+      expect(merged.isInitialized).to.equal(context.isInitialized);
+    });
   });
 
   describe('init', () => {

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -111,9 +111,11 @@ export class Context<SDKModules extends SDKModulesType> {
    * @param {string} name SDK name
    * @returns initialized SDK
    */
-  public getSDK<T extends keyof SDKModules>(name: T): Promise<SDKModules[T]['sdk']> | undefined {
+  public getSDK = <T extends keyof SDKModules>(
+    name: T
+  ): Promise<SDKModules[T]['sdk']> | undefined => {
     return this.sdkPromises[name];
-  }
+  };
 
   /**
    * Initializes the Software Development Kit (SDK)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
In case we are trying to merge _context_ instance as an object we lose all available methods, e.g _getSDK_.
This PR changes _getSDK_ to use arrow function, in this case it's available after the merge operation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
