### PR TITLE
[Next.js] Use Edge Platform file proxy for FEaaS stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Our versioning strategy is as follows:
 ### 🎉 New Features & Improvements
 
 * `[templates/react]` `[templates/angular]` `[templates/vue]` `[templates/node-headless-ssr-proxy]` `[templates/node-headless-ssr-experience-edge]` ([#1647](https://github.com/Sitecore/jss/pull/1647)) Switch from using JSS_APP_NAME to SITE_NAME - environment and config variables in React, Vue, Angular templates as well as ssr node proxy apps templates have been renamed. 
-* `[sitecore-jss]` Support for both 'published' and 'staged' revisions of FEAAS stylesheets/themes ([#1644](https://github.com/Sitecore/jss/pull/1644))
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` ([#1640](https://github.com/Sitecore/jss/pull/1640)) ([#1662](https://github.com/Sitecore/jss/pull/1662))([#1661](https://github.com/Sitecore/jss/pull/1661)) Sitecore Edge Platform and Context support:
   * Introducing the _clientFactory_ property. This property can be utilized by GraphQL-based services, the previously used _endpoint_ and _apiKey_ properties are deprecated. The _clientFactory_ serves as the central hub for executing GraphQL requests within the application.
   * New SITECORE_EDGE_CONTEXT_ID environment variable has been added.
@@ -24,7 +23,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` Enable client-only BYOC component imports. Client-only components can be imported through src/byoc/index.client.ts. Hybrid (server render with client hydration) components can be imported through src/byoc/index.hybrid.ts. BYOC scaffold logic is also moved from nextjs-sxa addon into base template ([#1628](https://github.com/Sitecore/jss/pull/1628)[#1636](https://github.com/Sitecore/jss/pull/1636))
 * `[templates/nextjs]` Import SitecoreForm component into sample nextjs app ([#1628](https://github.com/Sitecore/jss/pull/1628))
 * `[sitecore-jss-nextjs]` (Vercel/Sitecore) Deployment Protection Bypass support for editing integration. ([#1634](https://github.com/Sitecore/jss/pull/1634))
-* `[sitecore-jss]` `[templates/nextjs]` Load environment-specific FEAAS theme stylesheets based on Sitecore Edge Platform URL ([#1645](https://github.com/Sitecore/jss/pull/1645))
+* `[sitecore-jss]` Support for both 'published' and 'staged' revisions of FEAAS stylesheets/themes based on Sitecore Edge Platform and Context ([#1644](https://github.com/Sitecore/jss/pull/1644)) ([#1645](https://github.com/Sitecore/jss/pull/1645)) ([#1666](https://github.com/Sitecore/jss/pull/1666))
 * `[sitecore-jss-nextjs]` The _GraphQLRequestClient_ import from _@sitecore-jss/sitecore-jss-nextjs_ is deprecated, use import from _@sitecore-jss/sitecore-jss-nextjs/graphql_ submodule instead ([#1650](https://github.com/Sitecore/jss/pull/1650) [#1648](https://github.com/Sitecore/jss/pull/1648))
 * `[create-sitecore-jss]` Introduced `nextjs-xmcloud` initializer template. This will include all base XM Cloud features, including Personalize, FEaaS, BYOC, Sitecore Edge Platform and Context support. ([#1653](https://github.com/Sitecore/jss/pull/1653)) ([#1657](https://github.com/Sitecore/jss/pull/1657)) ([#1658](https://github.com/Sitecore/jss/pull/1658))
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/page-props-factory/plugins/feaas-themes.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/page-props-factory/plugins/feaas-themes.ts
@@ -8,8 +8,13 @@ class FEeaSThemesPlugin implements Plugin {
 
   async exec(props: SitecorePageProps) {
     // Collect FEAAS themes
-    props.headLinks.push(...getFEAASLibraryStylesheetLinks(props.layoutData, config.sitecoreEdgeUrl));
-
+    props.headLinks.push(
+      ...getFEAASLibraryStylesheetLinks(
+        props.layoutData,
+        config.sitecoreEdgeContextId,
+        config.sitecoreEdgeUrl
+      )
+    );
     return props;
   }
 }

--- a/packages/sitecore-jss/src/feaas/themes.test.ts
+++ b/packages/sitecore-jss/src/feaas/themes.test.ts
@@ -1,25 +1,16 @@
 import { expect } from 'chai';
-import {
-  FEAAS_SERVER_URL_STAGING,
-  FEAAS_SERVER_URL_BETA,
-  FEAAS_SERVER_URL_PROD,
-  getFEAASLibraryStylesheetLinks,
-  getStylesheetUrl,
-} from './themes';
+import { getFEAASLibraryStylesheetLinks, getStylesheetUrl } from './themes';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
-import { ComponentRendering, HtmlElementRendering, LayoutServicePageState } from '../layout';
+import { ComponentRendering, HtmlElementRendering } from '../layout';
 
 describe('themes', () => {
+  const sitecoreEdgeContextId = 'test';
+
   describe('getFEAASLibraryStylesheetLinks', () => {
-    const setBasicLayoutData = (
-      component: ComponentRendering | HtmlElementRendering,
-      pageState?: LayoutServicePageState
-    ) => {
+    const setBasicLayoutData = (component: ComponentRendering | HtmlElementRendering) => {
       return {
         sitecore: {
-          context: {
-            pageState,
-          },
+          context: {},
           route: {
             name: 'home',
             placeholders: {
@@ -32,162 +23,187 @@ describe('themes', () => {
 
     it('should return empty array route data is not provided', () => {
       expect(
-        getFEAASLibraryStylesheetLinks({
-          sitecore: {
-            context: {},
-            route: null,
+        getFEAASLibraryStylesheetLinks(
+          {
+            sitecore: {
+              context: {},
+              route: null,
+            },
           },
-        })
+          sitecoreEdgeContextId
+        )
       ).to.deep.equal([]);
     });
 
-    describe('normal mode', () => {
-      it('should return links using CSSStyles field', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'test',
-              fields: {
-                CSSStyles: {
-                  value: '-library--foo',
-                },
-                LibraryId: {
-                  value: 'bar',
-                },
+    it('should return links using CSSStyles field', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'test',
+            fields: {
+              CSSStyles: {
+                value: '-library--foo',
               },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'stylesheet' }]);
-      });
+              LibraryId: {
+                value: 'bar',
+              },
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('foo', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should return links using LibraryId field', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'test',
-              fields: {
-                LibraryId: {
-                  value: 'bar',
-                },
+    it('should return links using LibraryId field', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'test',
+            fields: {
+              LibraryId: {
+                value: 'bar',
               },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'stylesheet' }]);
-      });
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('bar', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should return links using CSSStyles param', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {
-                CSSStyles: '-library--foo',
-              },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'stylesheet' }]);
-      });
+    it('should return links using CSSStyles param', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {
+              CSSStyles: '-library--foo',
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('foo', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should return links using LibraryId param', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {
-                LibraryId: 'bar',
-              },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'stylesheet' }]);
-      });
+    it('should return links using LibraryId param', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {
+              LibraryId: 'bar',
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('bar', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should return prefer params over fields', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {
-                CSSStyles: '-library--foo',
+    it('should return prefer params over fields', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {
+              CSSStyles: '-library--foo',
+            },
+            fields: {
+              CSSStyles: {
+                value: '-library--not-foo',
               },
-              fields: {
-                CSSStyles: {
-                  value: '-library--not-foo',
-                },
-              },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'stylesheet' }]);
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('foo', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
 
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {
-                LibraryId: 'bar',
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {
+              LibraryId: 'bar',
+            },
+            fields: {
+              LibraryId: {
+                value: 'not-bar',
               },
-              fields: {
-                LibraryId: {
-                  value: 'not-bar',
-                },
-              },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('bar'), rel: 'stylesheet' }]);
-      });
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('bar', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should read LibraryId from class when matching param or field is not found', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {
-                NotCSSStyles: '-library--not-foo',
-                NotLibraryId: 'not-foo',
+    it('should read LibraryId from class when matching param or field is not found', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {
+              NotCSSStyles: '-library--not-foo',
+              NotLibraryId: 'not-foo',
+            },
+            fields: {
+              NotCSSStyles: {
+                value: '-library--not-foo',
               },
-              fields: {
-                NotCSSStyles: {
-                  value: '-library--not-foo',
-                },
-                NotLibraryId: {
-                  value: 'not-foo',
-                },
+              NotLibraryId: {
+                value: 'not-foo',
               },
-              attributes: {
-                class: '-library--foo',
-              },
-            })
-          )
-        ).to.deep.equal([{ href: getStylesheetUrl('foo'), rel: 'stylesheet' }]);
-      });
+            },
+            attributes: {
+              class: '-library--foo',
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('foo', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-      it('should return links using non-prod server url', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'test',
-              fields: {
-                LibraryId: {
-                  value: 'bar',
-                },
+    it('should return links using non-prod edge url', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'test',
+            fields: {
+              LibraryId: {
+                value: 'bar',
               },
-            }),
+            },
+          }),
+          sitecoreEdgeContextId,
+          'https://edge-platform-dev.sitecorecloud.io'
+        )
+      ).to.deep.equal([
+        {
+          href: getStylesheetUrl(
+            'bar',
+            sitecoreEdgeContextId,
             'https://edge-platform-dev.sitecorecloud.io'
-          )
-        ).to.deep.equal([
-          {
-            href: getStylesheetUrl(
-              'bar',
-              LayoutServicePageState.Normal,
-              'https://edge-platform-dev.sitecorecloud.io'
-            ),
-            rel: 'stylesheet',
-          },
-        ]);
-      });
+          ),
+          rel: 'stylesheet',
+        },
+      ]);
+    });
 
-      it('should return empty links array when required fields are not provided', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks({
+    it('should return empty links array when required fields are not provided', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          {
             sitecore: {
               context: {},
               route: {
@@ -196,24 +212,28 @@ describe('themes', () => {
                 placeholders: {},
               },
             },
-          })
-        ).to.deep.equal([]);
-      });
+          },
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([]);
+    });
 
-      it('should return empty links array when required params are not provided', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData({
-              componentName: 'styled',
-              params: {},
-            })
-          )
-        ).to.deep.equal([]);
-      });
+    it('should return empty links array when required params are not provided', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            componentName: 'styled',
+            params: {},
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([]);
+    });
 
-      it('should traverse nested nodes and return only unique links', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks({
+    it('should traverse nested nodes and return only unique links', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          {
             sitecore: {
               context: {},
               route: {
@@ -326,202 +346,62 @@ describe('themes', () => {
                 },
               },
             },
-          })
-        ).to.deep.equal(
-          ['foo', 'x11', 'x12', 'x21', 'y1', 'y2', 'z1', 'z11', 'z21'].map((id) => ({
-            href: getStylesheetUrl(id),
-            rel: 'stylesheet',
-          }))
-        );
-      });
-    });
-
-    describe('editing mode', () => {
-      it('should return links using class attribute', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData(
-              {
-                name: 'foo-component',
-                contents: null,
-                attributes: {
-                  class: '-library--bar',
-                },
-              },
-              LayoutServicePageState.Edit
-            )
-          )
-        ).to.deep.equal([
-          { href: getStylesheetUrl('bar', LayoutServicePageState.Edit), rel: 'stylesheet' },
-        ]);
-      });
-
-      it('should return links using non-prod server url', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData(
-              {
-                name: 'foo-component',
-                contents: null,
-                attributes: {
-                  class: '-library--bar',
-                },
-              },
-              LayoutServicePageState.Edit
-            ),
-            'https://edge-platform-dev.sitecorecloud.io'
-          )
-        ).to.deep.equal([
-          {
-            rel: 'stylesheet',
-            href: getStylesheetUrl(
-              'bar',
-              LayoutServicePageState.Edit,
-              'https://edge-platform-dev.sitecorecloud.io'
-            ),
           },
-        ]);
-      });
-
-      it('should not return id when class does not match pattern', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks(
-            setBasicLayoutData(
-              {
-                name: 'foo-component',
-                contents: null,
-                attributes: {
-                  class: 'bar',
-                },
-              },
-              LayoutServicePageState.Edit
-            )
-          )
-        ).to.deep.equal([]);
-      });
-
-      it('should return only unique links', () => {
-        expect(
-          getFEAASLibraryStylesheetLinks({
-            sitecore: {
-              context: {
-                pageState: LayoutServicePageState.Edit,
-              },
-              route: {
-                name: 'home',
-                placeholders: {
-                  x: [
-                    {
-                      name: 'x1-component',
-                      contents: null,
-                      attributes: {
-                        class: '-library--x1',
-                      },
-                    },
-                  ],
-                  y: [
-                    {
-                      name: 'x2-component',
-                      contents: null,
-                      attributes: {
-                        class: '-library--x1',
-                      },
-                    },
-                    {
-                      name: 'y1-component',
-                      contents: null,
-                      attributes: {
-                        class: '-library--y1',
-                      },
-                    },
-                  ],
-                  z: [
-                    {
-                      name: 'z-component',
-                      contents: null,
-                      attributes: {
-                        class: '-library--z1',
-                      },
-                    },
-                    {
-                      name: 'z-component',
-                      contents: null,
-                      attributes: {
-                        class: '-library--z2',
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          })
-        ).to.deep.equal(
-          ['x1', 'y1', 'z1', 'z2'].map((id) => ({
-            rel: 'stylesheet',
-            href: getStylesheetUrl(id, LayoutServicePageState.Edit),
-          }))
-        );
-      });
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal(
+        ['foo', 'x11', 'x12', 'x21', 'y1', 'y2', 'z1', 'z11', 'z21'].map((id) => ({
+          href: getStylesheetUrl(id, sitecoreEdgeContextId),
+          rel: 'stylesheet',
+        }))
+      );
     });
 
-    describe('getStylesheetUrl', () => {
-      it('should use published css url in Normal mode', () => {
-        const pageState = LayoutServicePageState.Normal;
+    it('should return links using class attribute', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            name: 'foo-component',
+            contents: null,
+            attributes: {
+              class: '-library--bar',
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([
+        { href: getStylesheetUrl('bar', sitecoreEdgeContextId), rel: 'stylesheet' },
+      ]);
+    });
 
-        expect(getStylesheetUrl('foo', pageState)).to.equal(
-          `${FEAAS_SERVER_URL_PROD}/styles/foo/published.css`
-        );
-      });
+    it('should not return id when class does not match pattern', () => {
+      expect(
+        getFEAASLibraryStylesheetLinks(
+          setBasicLayoutData({
+            name: 'foo-component',
+            contents: null,
+            attributes: {
+              class: 'bar',
+            },
+          }),
+          sitecoreEdgeContextId
+        )
+      ).to.deep.equal([]);
+    });
+  });
 
-      it('should use staged css url in Edit mode', () => {
-        const pageState = LayoutServicePageState.Edit;
+  describe('getStylesheetUrl', () => {
+    it('should use prod edge url by default', () => {
+      expect(getStylesheetUrl('foo', sitecoreEdgeContextId)).to.equal(
+        `${SITECORE_EDGE_URL_DEFAULT}/v1/files/components/styles/foo.css?sitecoreContextId=${sitecoreEdgeContextId}`
+      );
+    });
 
-        expect(getStylesheetUrl('foo', pageState)).to.equal(
-          `${FEAAS_SERVER_URL_PROD}/styles/foo/staged.css`
-        );
-      });
-
-      it('should use staged css url in Preview mode', () => {
-        const pageState = LayoutServicePageState.Preview;
-
-        expect(getStylesheetUrl('foo', pageState)).to.equal(
-          `${FEAAS_SERVER_URL_PROD}/styles/foo/staged.css`
-        );
-      });
-
-      ['dev', 'qa', 'staging'].map((env) => {
-        it(`should use staging server url for edge ${env} url`, () => {
-          const pageState = LayoutServicePageState.Normal;
-
-          expect(
-            getStylesheetUrl(
-              'foo',
-              pageState,
-              `https://edge-platform-${env}.sitecore-staging.cloud`
-            )
-          ).to.equal(`${FEAAS_SERVER_URL_STAGING}/styles/foo/published.css`);
-        });
-      });
-
-      it('should use beta server url for edge preprod url', () => {
-        const pageState = LayoutServicePageState.Normal;
-
-        expect(
-          getStylesheetUrl(
-            'foo',
-            pageState,
-            'https://edge-platform-pre-production.sitecorecloud.io'
-          )
-        ).to.equal(`${FEAAS_SERVER_URL_BETA}/styles/foo/published.css`);
-      });
-
-      it('should use prod server url for edge prod url', () => {
-        const pageState = LayoutServicePageState.Normal;
-
-        expect(getStylesheetUrl('foo', pageState, SITECORE_EDGE_URL_DEFAULT)).to.equal(
-          `${FEAAS_SERVER_URL_PROD}/styles/foo/published.css`
-        );
-      });
+    it('should use non-prod edge url', () => {
+      const nonProdUrl = 'https://edge-platform-pre-production.sitecorecloud.io';
+      expect(getStylesheetUrl('foo', sitecoreEdgeContextId, nonProdUrl)).to.equal(
+        `${nonProdUrl}/v1/files/components/styles/foo.css?sitecoreContextId=${sitecoreEdgeContextId}`
+      );
     });
   });
 });

--- a/packages/sitecore-jss/src/feaas/themes.ts
+++ b/packages/sitecore-jss/src/feaas/themes.ts
@@ -2,7 +2,6 @@ import {
   ComponentRendering,
   HtmlElementRendering,
   LayoutServiceData,
-  LayoutServicePageState,
   RouteData,
   getFieldValue,
 } from '../layout';
@@ -10,30 +9,21 @@ import { HTMLLink } from '../models';
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 
 /**
- * Stylesheets revision type
- * 'staged': Editing/Preview mode
- * 'published': Normal mode
- */
-type RevisionType = 'staged' | 'published';
-
-/**
  * Pattern for library ids
  * @example -library--foo
  */
 const FEAAS_LIBRARY_ID_REGEX = /-library--([^\s]+)/;
 
-export const FEAAS_SERVER_URL_STAGING = 'https://feaasstaging.blob.core.windows.net';
-export const FEAAS_SERVER_URL_BETA = 'https://feaasbeta.blob.core.windows.net';
-export const FEAAS_SERVER_URL_PROD = 'https://feaas.blob.core.windows.net';
-
 /**
  * Walks through rendering tree and returns list of links of all FEAAS Component Library Stylesheets that are used
  * @param {LayoutServiceData} layoutData Layout service data
+ * @param {string} sitecoreEdgeContextId Sitecore Edge Context ID
  * @param {string} [sitecoreEdgeUrl] Sitecore Edge Platform URL. Default is https://edge-platform.sitecorecloud.io
  * @returns {HTMLLink[]} library stylesheet links
  */
 export function getFEAASLibraryStylesheetLinks(
   layoutData: LayoutServiceData,
+  sitecoreEdgeContextId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
 ): HTMLLink[] {
   const ids = new Set<string>();
@@ -43,30 +33,17 @@ export function getFEAASLibraryStylesheetLinks(
   traverseComponent(layoutData.sitecore.route, ids);
 
   return [...ids].map((id) => ({
-    href: getStylesheetUrl(id, layoutData.sitecore.context.pageState, sitecoreEdgeUrl),
+    href: getStylesheetUrl(id, sitecoreEdgeContextId, sitecoreEdgeUrl),
     rel: 'stylesheet',
   }));
 }
 
 export const getStylesheetUrl = (
   id: string,
-  pageState?: LayoutServicePageState,
+  sitecoreEdgeContextId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
 ) => {
-  const revision: RevisionType =
-    pageState && pageState !== LayoutServicePageState.Normal ? 'staged' : 'published';
-
-  let serverUrl = FEAAS_SERVER_URL_PROD;
-  if (
-    sitecoreEdgeUrl.toLowerCase().includes('edge-platform-dev') ||
-    sitecoreEdgeUrl.toLowerCase().includes('edge-platform-qa') ||
-    sitecoreEdgeUrl.toLowerCase().includes('edge-platform-staging')
-  ) {
-    serverUrl = FEAAS_SERVER_URL_STAGING;
-  } else if (sitecoreEdgeUrl.toLowerCase().includes('edge-platform-pre-production')) {
-    serverUrl = FEAAS_SERVER_URL_BETA;
-  }
-  return `${serverUrl}/styles/${id}/${revision}.css`;
+  return `${sitecoreEdgeUrl}/v1/files/components/styles/${id}.css?sitecoreContextId=${sitecoreEdgeContextId}`;
 };
 
 /**


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Use Edge Platform file proxy for FEaaS stylesheets. This replaces both the CDN URL (https://github.com/Sitecore/jss/pull/1645) and staged/published (https://github.com/Sitecore/jss/pull/1644) determination we used previously. These are now determined by the Edge Platform environment and Context ID (Preview vs Live), respectively.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
