### PR TITLE
[sitecore-jss-nextjs] Placeholder applies the modifyComponentProps prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-proxy]` Setting "followRedirects" to "true" breaks HEAD requests ([#1630](https://github.com/Sitecore/jss/pull/1630))
 * `[templates/nextjs-sxa]` Fix shown horizontal scrollbar in EE mode. ([#1625](https://github.com/Sitecore/jss/pull/1625)), ([#1626](https://github.com/Sitecore/jss/pull/1626))
 * `[sitecore-jss-nextjs]` Fix issue when redirects works each every other times. ([#1629](https://github.com/Sitecore/jss/pull/1629))
+* `[sitecore-jss-nextjs]` Next.js placeholder applies the modifyComponentProps prop. ([#1668](https://github.com/Sitecore/jss/pull/1668))
 * `[templates/nextjs]` Fix custom headers. Now in cors-header plugin extends custom headers from next.config.js file. ([#1637](https://github.com/Sitecore/jss/pull/1637))
 * `[sitecore-jss-react]` Fix PlaceholderCommon with using two and more dynamic placeholders. ([#1641](https://github.com/Sitecore/jss/pull/1641))
 * `[templates/nextjs-multisite]` Fix site info fetch errors (now skipped) on XM Cloud rendering/editing host builds. ([#1649](https://github.com/Sitecore/jss/pull/1649)), ([#1653](https://github.com/Sitecore/jss/pull/1653))

--- a/packages/sitecore-jss-nextjs/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Placeholder.tsx
@@ -4,21 +4,29 @@ import {
   PlaceholderComponentProps,
 } from '@sitecore-jss/sitecore-jss-react';
 import { ComponentPropsReactContext } from './ComponentPropsContext';
+import { ComponentProps } from '@sitecore-jss/sitecore-jss-react/types/components/PlaceholderCommon';
 
 export const Placeholder = (props: PlaceholderComponentProps) => {
   const componentPropsContext = useContext(ComponentPropsReactContext);
+
+  function getContextProps(initialProps: ComponentProps) {
+    if (!initialProps.rendering.uid) return initialProps;
+
+    const data = componentPropsContext[initialProps.rendering.uid] as {
+      [key: string]: unknown;
+    };
+
+    return data;
+  }
 
   return (
     <ReactPlaceholder
       {...props}
       modifyComponentProps={(initialProps) => {
-        if (!initialProps.rendering.uid) return initialProps;
-
-        const data = componentPropsContext[initialProps.rendering.uid] as {
-          [key: string]: unknown;
-        };
-
-        return { ...initialProps, ...data };
+        const finalProps = props.modifyComponentProps
+          ? props.modifyComponentProps(initialProps)
+          : initialProps;
+        return { ...finalProps, ...getContextProps(initialProps) };
       }}
     />
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Placeholder component in the "nextjs package" does not apply the `modifyComponentProps` when given. Instead, the component adds its own implementation of `modifyComponentProps` that it provides to the Placeholder component from the "react package". The component needs to also apply the `modifyComponentProps` property as well.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

I tried to add a unit test but I lack knowledge of how Enzyme works. When I attempt to call `mount` on the Placeholder component it fails with the message `Cannot read properties of null (reading 'useContext')`. All other tests seem to have no problems though.

So far I tested this solution by modifying the module files inside the node_modules folder of my particular project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
