### PR TITLE
[Chore] Replaced deprecated "npm bin" by "npm exec"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Load the content styles for the RichText component [#1670](https://github.com/Sitecore/jss/pull/1670)
 
+### 🧹 Chores
+
+* Upgrade to Node.js 20.x ([#1679](https://github.com/Sitecore/jss/pull/1679))
+
 ### 🐛 Bug Fixes
 
 * `[templates/node-headless-ssr-proxy]` `[node-headless-ssr-proxy]` Add sc_site qs parameter to Layout Service requests by default ([#1660](https://github.com/Sitecore/jss/pull/1660))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ variables:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '16.x'
+    versionSpec: '20.x'
 - script: |
     yarn cache clean --all && yarn install --immutable
   displayName: 'yarn install - initial'

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "3.22.1",
   "packages": ["packages/*", "samples/*"],
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-sitecore-jss/package.json
+++ b/packages/create-sitecore-jss/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run clean && tsc && ts-node ./scripts/build-templates.ts",
     "clean": "del-cli dist types",
-    "lint": "eslint --no-eslintrc -c .eslintrc ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "watch": "ts-node ./scripts/watch-templates.ts",
     "test": "mocha --require ts-node/register \"./src/**/*.test.ts\"",
     "coverage": "nyc npm test"

--- a/packages/create-sitecore-jss/package.json
+++ b/packages/create-sitecore-jss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sitecore-jss",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "Sitecore JSS initializer",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/sitecore-jss-angular-schematics/package.json
+++ b/packages/sitecore-jss-angular-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-angular-schematics",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "Scaffolding schematics for Sitecore JSS Angular apps",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/sitecore-jss-angular/package.json
+++ b/packages/sitecore-jss-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-angular",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "",
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
@@ -60,7 +60,7 @@
     "rxjs": "~7.8.1"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21"
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22"
   },
   "main": "dist/esm2020/sitecore-jss-sitecore-jss-angular.mjs",
   "module": "dist/esm2020/sitecore-jss-sitecore-jss-angular.js",

--- a/packages/sitecore-jss-angular/package.json
+++ b/packages/sitecore-jss-angular/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "ng test",
     "test:watch": "ng test --no-single-run --browsers Chrome",
     "coverage": "ng test --code-coverage",

--- a/packages/sitecore-jss-angular/src/test.ts
+++ b/packages/sitecore-jss-angular/src/test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 import 'zone.js';
 import 'zone.js/testing';

--- a/packages/sitecore-jss-cli/package.json
+++ b/packages/sitecore-jss-cli/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "watch": "npm run build -- --watch",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "prepublishOnly": "npm run build",
     "jss": "node ./dist/cjs/bin/jss.js",
     "test": "mocha --require ts-node/register/transpile-only \"./src/**/*.test.ts\"",

--- a/packages/sitecore-jss-cli/package.json
+++ b/packages/sitecore-jss-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-cli",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "Sitecore JSS command-line",
   "main": "dist/cjs/cli.js",
   "module": "dist/esm/cli.js",
@@ -33,7 +33,7 @@
     "url": "https://github.com/sitecore/jss/issues"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss-dev-tools": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss-dev-tools": "21.7.0-canary.22",
     "chalk": "^4.1.2",
     "cross-spawn": "^7.0.3",
     "dotenv": "^16.0.3",

--- a/packages/sitecore-jss-dev-tools/package.json
+++ b/packages/sitecore-jss-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-dev-tools",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "Utilities to assist in the development and deployment of Sitecore JSS apps.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -33,7 +33,7 @@
     "url": "https://github.com/sitecore/jss/issues"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22",
     "axios": "^1.3.2",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",

--- a/packages/sitecore-jss-dev-tools/package.json
+++ b/packages/sitecore-jss-dev-tools/package.json
@@ -9,7 +9,7 @@
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "watch": "npm run build -- --watch",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register -r tsconfig-paths/register  \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-dev-tools/src/templating/react/generate-component-builder.ts
+++ b/packages/sitecore-jss-dev-tools/src/templating/react/generate-component-builder.ts
@@ -36,9 +36,10 @@ export function generateComponentBuilder({
 
 /**
  * Watch for changes to component builder sources
- * @param {string} componentRootPath root path to components
- * @param {PackageDefinition[]} packages packages to include in component builder
- * @param {ComponentFile[]} components components to include in component builder
+ * @param {object} config configuration for component builder watcher
+ * @param {string} config.componentRootPath root path to components
+ * @param {PackageDefinition[]} config.packages packages to include in component builder
+ * @param {ComponentFile[]} config.components components to include in component builder
  */
 export function watchComponentBuilder({
   componentRootPath,

--- a/packages/sitecore-jss-forms/package.json
+++ b/packages/sitecore-jss-forms/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-forms/package.json
+++ b/packages/sitecore-jss-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-forms",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -44,7 +44,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21"
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22"
   },
   "description": "",
   "types": "types/index.d.ts",

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.tsx ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.tsx\" \"./src/**/*.ts\"",
     "test": "mocha --require ./test/setup.js \"./src/**/*.test.ts\" \"./src/**/*.test.tsx\" --exit",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-nextjs",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -73,9 +73,9 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21",
-    "@sitecore-jss/sitecore-jss-dev-tools": "21.7.0-canary.21",
-    "@sitecore-jss/sitecore-jss-react": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22",
+    "@sitecore-jss/sitecore-jss-dev-tools": "21.7.0-canary.22",
+    "@sitecore-jss/sitecore-jss-react": "21.7.0-canary.22",
     "@vercel/kv": "^0.2.1",
     "node-html-parser": "^6.1.4",
     "prop-types": "^15.8.1",

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -78,7 +78,7 @@ export class EditingRenderMiddleware {
 
   /**
    * Gets query parameters that should be passed along to subsequent requests
-   * @param query Object of query parameters from incoming URL
+   * @param {Object} query Object of query parameters from incoming URL
    * @returns Object of approved query parameters
    */
   protected getQueryParamsForPropagation = (

--- a/packages/sitecore-jss-proxy/package.json
+++ b/packages/sitecore-jss-proxy/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-proxy/package.json
+++ b/packages/sitecore-jss-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-proxy",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "Proxy middleware for express.js server.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sitecore-jss-react-forms/package.json
+++ b/packages/sitecore-jss-react-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react-forms",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -55,7 +55,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss-forms": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss-forms": "21.7.0-canary.22",
     "prop-types": "^15.8.1"
   },
   "description": "",

--- a/packages/sitecore-jss-react-forms/package.json
+++ b/packages/sitecore-jss-react-forms/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.tsx ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.tsx\" \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register/transpile-only --require ./src/tests/shim.ts ./src/tests/jsdom-setup.ts ./src/tests/enzyme-setup.ts \"./src/**/*.test.tsx\" --exit",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-react-native/package.json
+++ b/packages/sitecore-jss-react-native/package.json
@@ -8,7 +8,7 @@
     "clean": "del-cli dist types",
     "typecheck": "tsc",
     "fixcrlf": "eslint --rule 'linebreak-style: [\"error\", \"unix\"]' --ext .ts --no-eslintrc --fix ./dist",
-    "lint": "eslint ./src/**/*.tsx ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.tsx\" \"./src/**/*.ts\"",
     "test": "jest",
     "prepublishOnly": "npm test && npm run build",
     "coverage": "jest --config ./jest.config.coverage.js",

--- a/packages/sitecore-jss-react-native/package.json
+++ b/packages/sitecore-jss-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react-native",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "url": "https://github.com/sitecore/jss/issues"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22",
     "prop-types": "^15.7.2",
     "react-native-htmlview": "^0.15.0",
     "react-native-svg": "^5.3.0",

--- a/packages/sitecore-jss-react/package.json
+++ b/packages/sitecore-jss-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -63,7 +63,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22",
     "deep-equal": "^2.1.0",
     "prop-types": "^15.8.1",
     "style-attr": "^1.3.0"

--- a/packages/sitecore-jss-react/package.json
+++ b/packages/sitecore-jss-react/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.tsx ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.tsx\" \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register/transpile-only --require ./src/tests/shim.ts ./src/tests/jsdom-setup.ts ./src/tests/enzyme-setup.ts \"./src/**/*.test.ts\" \"./src/**/*.test.tsx\" --exit",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-rendering-host/package.json
+++ b/packages/sitecore-jss-rendering-host/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register/transpile-only \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss-rendering-host/package.json
+++ b/packages/sitecore-jss-rendering-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-rendering-host",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/sitecore-jss-vue/package.json
+++ b/packages/sitecore-jss-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-vue",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "description": "A library for building Sitecore JSS apps using Vue.js",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -51,7 +51,7 @@
     "vue": "^3.2.45"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "21.7.0-canary.21",
+    "@sitecore-jss/sitecore-jss": "21.7.0-canary.22",
     "@vue/compiler-sfc": "^3.0.11"
   },
   "types": "./types/index.d.ts",

--- a/packages/sitecore-jss-vue/package.json
+++ b/packages/sitecore-jss-vue/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "jest",
     "prepublishOnly": "npm run build",
     "coverage": "jest --config ./jest.config.coverage.js",

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc -p tsconfig.json && tsc -p tsconfig-esm.json",
     "clean": "del-cli dist types",
-    "lint": "eslint ./src/**/*.ts",
+    "lint": "eslint \"./src/**/*.ts\"",
     "test": "mocha --require ts-node/register \"./src/**/*.test.ts\"",
     "prepublishOnly": "npm run build",
     "coverage": "nyc npm test",

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss",
-  "version": "21.7.0-canary.21",
+  "version": "21.7.0-canary.22",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6500,7 +6500,7 @@ __metadata:
     "@angular/platform-browser": ~15.2.9
     "@angular/platform-browser-dynamic": ~15.2.9
     "@angular/router": ~15.2.9
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/jasmine": ^3.4.1
     "@types/node": ^14.14.35
     codelyzer: ^6.0.1
@@ -6531,7 +6531,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-cli@workspace:packages/sitecore-jss-cli"
   dependencies:
-    "@sitecore-jss/sitecore-jss-dev-tools": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.7.0-canary.22
     "@types/chai": ^4.2.4
     "@types/cross-spawn": ^6.0.2
     "@types/mocha": ^10.0.1
@@ -6563,11 +6563,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-dev-tools@21.7.0-canary.21, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
+"@sitecore-jss/sitecore-jss-dev-tools@21.7.0-canary.22, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/chai": ^4.3.4
     "@types/chokidar": ^2.1.3
     "@types/del": ^4.0.0
@@ -6619,11 +6619,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-forms@21.7.0-canary.21, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
+"@sitecore-jss/sitecore-jss-forms@21.7.0-canary.22, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/lodash.unescape": ^4.0.7
@@ -6647,9 +6647,9 @@ __metadata:
   resolution: "@sitecore-jss/sitecore-jss-nextjs@workspace:packages/sitecore-jss-nextjs"
   dependencies:
     "@sitecore-cloudsdk/personalize": ^0.1.1
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
-    "@sitecore-jss/sitecore-jss-dev-tools": 21.7.0-canary.21
-    "@sitecore-jss/sitecore-jss-react": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
+    "@sitecore-jss/sitecore-jss-dev-tools": 21.7.0-canary.22
+    "@sitecore-jss/sitecore-jss-react": 21.7.0-canary.22
     "@types/chai": ^4.3.4
     "@types/chai-as-promised": ^7.1.5
     "@types/chai-string": ^1.4.2
@@ -6723,7 +6723,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react-forms@workspace:packages/sitecore-jss-react-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss-forms": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss-forms": 21.7.0-canary.22
     "@types/chai": ^4.3.4
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
@@ -6763,7 +6763,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": ^7.5.2
     "@babel/preset-env": ^7.6.2
     "@babel/preset-typescript": ^7.6.0
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/jest": ^24.0.18
     "@types/prop-types": ^15.7.3
     "@types/react": ^16.9.5
@@ -6793,12 +6793,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-react@21.7.0-canary.21, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
+"@sitecore-jss/sitecore-jss-react@21.7.0-canary.22, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react"
   dependencies:
     "@sitecore-feaas/clientside": ^0.5.0
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/deep-equal": ^1.0.1
@@ -6872,7 +6872,7 @@ __metadata:
   resolution: "@sitecore-jss/sitecore-jss-vue@workspace:packages/sitecore-jss-vue"
   dependencies:
     "@babel/core": ^7.20.12
-    "@sitecore-jss/sitecore-jss": 21.7.0-canary.21
+    "@sitecore-jss/sitecore-jss": 21.7.0-canary.22
     "@types/jest": ^29.2.6
     "@types/node": ^18.11.18
     "@vue/compiler-dom": ^3.2.45
@@ -6896,7 +6896,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss@21.7.0-canary.21, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
+"@sitecore-jss/sitecore-jss@21.7.0-canary.22, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss"
   dependencies:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
* **_npm bin_** doesn't exist in npm 10, so **_npm exec_** should be used instead
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
