### PR TITLE
[sitecore-jss-react] Use ComponentDataOverride instead of ComponentProps for BYOCComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* [sitecore-jss-react] Use ComponentDataOverride instead of ComponentProps for BYOCComponent ([#1682](https://github.com/Sitecore/jss/pull/1682))
 * `[sitecore-jss-proxy]` Setting "followRedirects" to "true" breaks HEAD requests ([#1630](https://github.com/Sitecore/jss/pull/1630))
 * `[templates/nextjs-sxa]` Fix shown horizontal scrollbar in EE mode. ([#1625](https://github.com/Sitecore/jss/pull/1625)), ([#1626](https://github.com/Sitecore/jss/pull/1626))
 * `[sitecore-jss-nextjs]` Fix issue when redirects works each every other times. ([#1629](https://github.com/Sitecore/jss/pull/1629))

--- a/packages/sitecore-jss-react/src/components/BYOCComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCComponent.test.tsx
@@ -6,11 +6,11 @@ import { BYOCComponent } from './BYOCComponent';
 import { MissingComponent, MissingComponentProps } from './MissingComponent';
 
 describe('BYOCComponent', () => {
-  it('should render with props when ComponentProps is provided', () => {
+  it('should render with props when ComponentDataOverride is provided', () => {
     const mockProps = {
       params: {
         ComponentName: 'Foo',
-        ComponentProps: JSON.stringify({ prop1: 'value1' }),
+        ComponentDataOverride: JSON.stringify({ prop1: 'value1' }),
       },
       fetchedData: {},
     };
@@ -38,7 +38,7 @@ describe('BYOCComponent', () => {
     const mockProps = {
       params: {
         ComponentName: 'Foo',
-        ComponentProps: JSON.stringify({ prop1: 'value1' }),
+        ComponentDataOverride: JSON.stringify({ prop1: 'value1' }),
       },
       fetchedData,
     };
@@ -67,7 +67,7 @@ describe('BYOCComponent', () => {
     const mockProps = {
       params: {
         ComponentName: 'Foo',
-        ComponentProps: JSON.stringify({ prop1: 'value1' }),
+        ComponentDataOverride: JSON.stringify({ prop1: 'value1' }),
       },
     };
     const Foo = () => <p id="foo-content">Test</p>;
@@ -93,7 +93,7 @@ describe('Error handling', () => {
     const props = {
       params: {
         ComponentName: 'ExampleComponent',
-        ComponentProps: 'invalid-json',
+        ComponentDataOverride: 'invalid-json',
       },
       fetchedData: {},
     };
@@ -108,7 +108,7 @@ describe('Error handling', () => {
       errorComponent: customErrorComponent,
       params: {
         ComponentName: 'ExampleComponent',
-        ComponentProps: 'invalid-json',
+        ComponentDataOverride: 'invalid-json',
       },
       fetchedData: {},
     };
@@ -122,7 +122,7 @@ describe('Error handling', () => {
     const props = {
       params: {
         ComponentName: '',
-        ComponentProps: JSON.stringify({ text: 'this is a BYOC component' }),
+        ComponentDataOverride: JSON.stringify({ text: 'this is a BYOC component' }),
       },
     };
     const wrapper = mount(<BYOCComponent {...props} />);

--- a/packages/sitecore-jss-react/src/components/BYOCComponent.tsx
+++ b/packages/sitecore-jss-react/src/components/BYOCComponent.tsx
@@ -27,7 +27,7 @@ export type BYOCComponentParams = {
   /**
    * JSON props to pass into rendered component
    */
-  ComponentProps?: string;
+  ComponentDataOverride?: string;
   /**
    * A string with classes that can be used to apply themes, via SXA functionality
    */
@@ -133,9 +133,9 @@ export class BYOCComponent extends React.Component<BYOCComponentProps> {
 
     let componentProps: { [key: string]: any } = null;
 
-    if (props.params?.ComponentProps) {
+    if (props.params?.ComponentDataOverride) {
       try {
-        componentProps = JSON.parse(props.params.ComponentProps) ?? {};
+        componentProps = JSON.parse(props.params.ComponentDataOverride) ?? {};
       } catch (e) {
         console.error(
           `Parsing props for ${componentName} component from rendering params failed. Error: ${e}`
@@ -169,8 +169,8 @@ export class BYOCComponent extends React.Component<BYOCComponentProps> {
 export async function fetchBYOCComponentServerProps(
   params: BYOCComponentParams
 ): Promise<BYOCComponentProps> {
-  const fetchDataOptions: FEAAS.DataOptions = params.ComponentProps
-    ? JSON.parse(params.ComponentProps)
+  const fetchDataOptions: FEAAS.DataOptions = params.ComponentDataOverride
+    ? JSON.parse(params.ComponentDataOverride)
     : {};
 
   const fetchedData: FEAAS.DataScopes = await FEAAS.DataSettings.fetch(fetchDataOptions || {});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
* Use **ComponentDataOverride** instead of **ComponentProps** for _BYOCComponent_
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
