### PR TITLE
 [sitecore-jss-nextjs]: fixed redirects middleware when pattern use default locale in regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Our versioning strategy is as follows:
 * `[templates/node-headless-ssr-proxy]` `[node-headless-ssr-proxy]` Add sc_site qs parameter to Layout Service requests by default ([#1660](https://github.com/Sitecore/jss/pull/1660))
 * `[templates/nextjs-sxa]` Fixed Image component when there is using Banner variant which set property background-image when image is empty. ([#1689](https://github.com/Sitecore/jss/pull/1689)) ([#1692](https://github.com/Sitecore/jss/pull/1692))
 * `[sitecore-jss-react]` `[templates/nextjs-xmcloud]` Ensure FEAAS and BYOC components can correctly use item datasources ([#1694](https://github.com/Sitecore/jss/pull/1694))
+* `[sitecore-jss-nextjs]` Fix loop error in redirect middleware when the pattern of redirect has default locale. ([#1696](https://github.com/Sitecore/jss/pull/1696))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -120,7 +120,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
         }
 
         url.pathname = url.pathname
-          .replace(regexParser(existsRedirect.pattern), existsRedirect.target)
+          .replace(regexParser(existsRedirect.pattern_modify), existsRedirect.target)
           .replace(/^\/\//, '/');
       }
 
@@ -173,20 +173,22 @@ export class RedirectsMiddleware extends MiddlewareBase {
     const redirects = await this.redirectsService.fetchRedirects(siteName);
     const tragetURL = req.nextUrl.pathname;
     const targetQS = req.nextUrl.search || '';
+    const language = this.getLanguage(req);
 
     return redirects.length
       ? redirects.find((redirect: RedirectInfo) => {
-          redirect.pattern = `/^\/${redirect.pattern
+          redirect.pattern_modify = redirect.pattern.replace(RegExp(`^[^]?/${language}/`, 'gi'), '');
+          redirect.pattern = `/^\/${redirect.pattern_modify
             .replace(/^\/|\/$/g, '')
             .replace(/^\^\/|\/\$$/g, '')
             .replace(/^\^|\$$/g, '')
             .replace(/\$\/gi$/g, '')}[\/]?$/gi`;
 
           return (
-            (regexParser(redirect.pattern).test(tragetURL) ||
-              regexParser(redirect.pattern).test(`${tragetURL}${targetQS}`) ||
-              regexParser(redirect.pattern).test(`/${req.nextUrl.locale}${tragetURL}`) ||
-              regexParser(redirect.pattern).test(
+            (regexParser(redirect.pattern_modify).test(tragetURL) ||
+              regexParser(redirect.pattern_modify).test(`${tragetURL}${targetQS}`) ||
+              regexParser(redirect.pattern_modify).test(`/${req.nextUrl.locale}${tragetURL}`) ||
+              regexParser(redirect.pattern_modify).test(
                 `/${req.nextUrl.locale}${tragetURL}${targetQS}`
               )) &&
             (redirect.locale

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -177,7 +177,10 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
     return redirects.length
       ? redirects.find((redirect: RedirectInfo) => {
-          redirect.pattern_modify = redirect.pattern.replace(RegExp(`^[^]?/${language}/`, 'gi'), '');
+          redirect.pattern_modify = redirect.pattern.replace(
+            RegExp(`^[^]?/${language}/`, 'gi'),
+            ''
+          );
           redirect.pattern = `/^\/${redirect.pattern_modify
             .replace(/^\/|\/$/g, '')
             .replace(/^\^\/|\/\$$/g, '')

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -120,7 +120,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
         }
 
         url.pathname = url.pathname
-          .replace(regexParser(existsRedirect.pattern_modify), existsRedirect.target)
+          .replace(regexParser(existsRedirect.pattern), existsRedirect.target)
           .replace(/^\/\//, '/');
       }
 
@@ -174,24 +174,22 @@ export class RedirectsMiddleware extends MiddlewareBase {
     const tragetURL = req.nextUrl.pathname;
     const targetQS = req.nextUrl.search || '';
     const language = this.getLanguage(req);
+    const modifyRedirects = structuredClone(redirects);
 
-    return redirects.length
-      ? redirects.find((redirect: RedirectInfo) => {
-          redirect.pattern_modify = redirect.pattern.replace(
-            RegExp(`^[^]?/${language}/`, 'gi'),
-            ''
-          );
-          redirect.pattern = `/^\/${redirect.pattern_modify
+    return modifyRedirects.length
+      ? modifyRedirects.find((redirect: RedirectInfo) => {
+          redirect.pattern = redirect.pattern.replace(RegExp(`^[^]?/${language}/`, 'gi'), '');
+          redirect.pattern = `/^\/${redirect.pattern
             .replace(/^\/|\/$/g, '')
             .replace(/^\^\/|\/\$$/g, '')
             .replace(/^\^|\$$/g, '')
             .replace(/\$\/gi$/g, '')}[\/]?$/gi`;
 
           return (
-            (regexParser(redirect.pattern_modify).test(tragetURL) ||
-              regexParser(redirect.pattern_modify).test(`${tragetURL}${targetQS}`) ||
-              regexParser(redirect.pattern_modify).test(`/${req.nextUrl.locale}${tragetURL}`) ||
-              regexParser(redirect.pattern_modify).test(
+            (regexParser(redirect.pattern).test(tragetURL) ||
+              regexParser(redirect.pattern).test(`${tragetURL}${targetQS}`) ||
+              regexParser(redirect.pattern).test(`/${req.nextUrl.locale}${tragetURL}`) ||
+              regexParser(redirect.pattern).test(
                 `/${req.nextUrl.locale}${tragetURL}${targetQS}`
               )) &&
             (redirect.locale


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
A loop of error occured when pattern of redirect had default locale.
This fix remove default locale in pattern because req.url hasn't default locale in pathname. 
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
