### PR TITLE
[sitecore-jss-nextjs] Add page state into shared context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 * `[nextjs/template]` `[sitecore-jss-nextjs]` On-demand ISR [#1674](https://github.com/Sitecore/jss/pull/1672))
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Load the content styles for the RichText component ([#1670](https://github.com/Sitecore/jss/pull/1670))([#1683](https://github.com/Sitecore/jss/pull/1683)) ([#1684](https://github.com/Sitecore/jss/pull/1684)) ([#1693](https://github.com/Sitecore/jss/pull/1693))
+* `[sitecore-jss-nextjs]` `[templates/nextjs-xmcloud]` Page state (preview, edit, normal) is available through shared context. This allows access to the state for integrations such as CloudSDK and FEAAS. ([#1703](https://github.com/Sitecore/jss/pull/1703))
 
 ### 🧹 Chores
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/Bootstrap.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/Bootstrap.tsx
@@ -12,7 +12,10 @@ const Bootstrap = (props: SitecorePageProps): JSX.Element | null => {
    * This function is the entry point for setting up the application's context and any SDKs that are required for its proper functioning.
    * It prepares the resources needed to interact with various services and features within the application.
    */
-  context.init({ siteName: props.site?.name || config.sitecoreSiteName });
+  context.init({
+    siteName: props.site?.name || config.sitecoreSiteName,
+    pageState: props.layoutData?.sitecore?.context?.pageState,
+  });
 
   return null;
 };

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -4,7 +4,6 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { Context } from './';
 import { LayoutServicePageState } from '@sitecore-jss/sitecore-jss-react';
-import { PageStateType } from './context';
 
 describe('Context', () => {
   const sdks = {
@@ -143,10 +142,10 @@ describe('Context', () => {
     it('should initialize the context with a different page mode', () => {
       const context = new Context<typeof sdks>(props);
 
-      context.init({ pageState: PageStateType.Edit });
+      context.init({ pageState: LayoutServicePageState.Edit });
 
       expect(context.isInitialized).to.be.true;
-      expect(context.pageState).to.equal(PageStateType.Edit);
+      expect(context.pageState).to.equal(LayoutServicePageState.Edit);
     });
 
     it('should not initialize the context if it is already initialized', () => {

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -3,6 +3,8 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { Context } from './';
+import { LayoutServicePageState } from '@sitecore-jss/sitecore-jss-react';
+import { PageStateType } from './context';
 
 describe('Context', () => {
   const sdks = {
@@ -97,6 +99,15 @@ describe('Context', () => {
       });
     });
 
+    it('should use normal pageMode when context is initialized with empty props', () => {
+      const context = new Context<typeof sdks>(props);
+
+      context.init();
+
+      expect(context.isInitialized).to.be.true;
+      expect(context.pageState).to.equal(LayoutServicePageState.Normal);
+    });
+
     it('should initialize the context with a different site name', (done) => {
       const context = new Context<typeof sdks>(props);
 
@@ -127,6 +138,15 @@ describe('Context', () => {
 
         done();
       });
+    });
+
+    it('should initialize the context with a different page mode', () => {
+      const context = new Context<typeof sdks>(props);
+
+      context.init({ pageState: PageStateType.Edit });
+
+      expect(context.isInitialized).to.be.true;
+      expect(context.pageState).to.equal(PageStateType.Edit);
     });
 
     it('should not initialize the context if it is already initialized', () => {

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -1,4 +1,14 @@
 /**
+ * Page state enum
+ * Duplicates LayoutServicePageState to simplify future context migration into CloudSDK
+ */
+export enum PageStateType {
+  Preview = 'preview',
+  Edit = 'edit',
+  Normal = 'normal',
+}
+
+/**
  * Software Development Kit (SDK) instance
  */
 export type SDK<SDKType = unknown> = {
@@ -25,6 +35,10 @@ export interface ContextInitProps {
    * Your Sitecore site name
    */
   siteName?: string;
+  /**
+   * Sitecore page state (normal, preview, edit)
+   */
+  pageState?: PageStateType;
 }
 
 /**
@@ -75,6 +89,10 @@ export class Context<SDKModules extends SDKModulesType> {
    */
   public siteName: string;
   /**
+   * Sitecore page state (normal, preview, edit)
+   */
+  public pageState: PageStateType;
+  /**
    * Software Development Kits (SDKs) to be initialized
    */
   public readonly sdks: { [module in keyof SDKModules]?: SDKModules[module]['sdk'] } = {};
@@ -87,6 +105,7 @@ export class Context<SDKModules extends SDKModulesType> {
     this.sitecoreEdgeUrl = props.sitecoreEdgeUrl;
     this.sitecoreEdgeContextId = props.sitecoreEdgeContextId;
     this.siteName = props.siteName;
+    this.pageState = PageStateType.Normal;
   }
 
   public init(props: ContextInitProps = {}) {
@@ -97,6 +116,10 @@ export class Context<SDKModules extends SDKModulesType> {
 
     if (props.siteName) {
       this.siteName = props.siteName;
+    }
+
+    if (props.pageState) {
+      this.pageState = props.pageState;
     }
 
     // iterate over the SDKs and initialize them

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -1,12 +1,4 @@
-/**
- * Page state enum
- * Duplicates LayoutServicePageState to simplify future context migration into CloudSDK
- */
-export enum PageStateType {
-  Preview = 'preview',
-  Edit = 'edit',
-  Normal = 'normal',
-}
+import { LayoutServicePageState } from '@sitecore-jss/sitecore-jss-react';
 
 /**
  * Software Development Kit (SDK) instance
@@ -38,7 +30,7 @@ export interface ContextInitProps {
   /**
    * Sitecore page state (normal, preview, edit)
    */
-  pageState?: PageStateType;
+  pageState?: LayoutServicePageState;
 }
 
 /**
@@ -91,7 +83,7 @@ export class Context<SDKModules extends SDKModulesType> {
   /**
    * Sitecore page state (normal, preview, edit)
    */
-  public pageState: PageStateType;
+  public pageState: LayoutServicePageState;
   /**
    * Software Development Kits (SDKs) to be initialized
    */
@@ -105,7 +97,7 @@ export class Context<SDKModules extends SDKModulesType> {
     this.sitecoreEdgeUrl = props.sitecoreEdgeUrl;
     this.sitecoreEdgeContextId = props.sitecoreEdgeContextId;
     this.siteName = props.siteName;
-    this.pageState = PageStateType.Normal;
+    this.pageState = LayoutServicePageState.Normal;
   }
 
   public init(props: ContextInitProps = {}) {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
Extends shared context with pageState property. This allows BYOC components and CloudSDK functionality to adjust behavior based on the current state (editing, preview, normal).

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
