### PR TITLE
Fix double registration of byoc components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-react]` `[templates/nextjs-xmcloud]` Ensure FEAAS and BYOC components can correctly use item datasources ([#1694](https://github.com/Sitecore/jss/pull/1694))
 * `[sitecore-jss-nextjs]` Fix loop error in redirect middleware when the pattern of redirect has default locale. ([#1696](https://github.com/Sitecore/jss/pull/1696))
 * `[templates/nextjs-sxa]` Fix feature `show Grid column` in Experience Editor. ([#1704](https://github.com/Sitecore/jss/pull/1704))
+* `[templates/nextjs-xmcloud]` Fix double registration of BYOC components ([#1707](https://github.com/Sitecore/jss/pull/1707))
 
 ### 🛠 Breaking Changes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
@@ -8,7 +8,14 @@ const feaasPlugin = (nextConfig = {}) => {
         // Force use of CommonJS on the server for FEAAS SDK since JSS also uses CommonJS entrypoint to FEAAS SDK.
         // This prevents issues arising due to FEAAS SDK's dual CommonJS/ES module support on the server (via conditional exports).
         // See https://nodejs.org/api/packages.html#dual-package-hazard.
-        config.externals = [{ '@sitecore-feaas/clientside/react': 'commonjs @sitecore-feaas/clientside/react' }, ...config.externals];
+        config.externals = [
+          {
+            '@sitecore-feaas/clientside/react': 'commonjs @sitecore-feaas/clientside/react',
+            '@sitecore/byoc': 'commonjs @sitecore/byoc',
+            '@sitecore/byoc/react': 'commonjs @sitecore/byoc/react',
+            ...config.externals,
+          },
+        ];
       }
 
       // Overload the Webpack config if it was already overloaded
@@ -17,7 +24,7 @@ const feaasPlugin = (nextConfig = {}) => {
       }
 
       return config;
-    }
+    },
   });
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
BYOC components doesn't render on pages because of double registration i.e one on server and another on client.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
