### PR TITLE
[sitecore-jss-nextjs] Reject SDK promise when init was rejected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fix redirects middleware when source URL contains query string. ([#1696](https://github.com/Sitecore/jss/pull/1702))
 * `[templates/nextjs-sxa]` Fix feature `show Grid column` in Experience Editor. ([#1704](https://github.com/Sitecore/jss/pull/1704))
 * `[templates/nextjs-xmcloud]` Fix double registration of BYOC components ([#1707](https://github.com/Sitecore/jss/pull/1707)) ([#1709](https://github.com/Sitecore/jss/pull/1709))
+* `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712))
 
 ### 🛠 Breaking Changes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/context/sdk/events.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/context/sdk/events.ts
@@ -6,8 +6,11 @@ const sdkModule: SDK<typeof Events> = {
   init: async (props) => {
     // Events module can't be initialized on the server side
     // We also don't want to initialize it in development mode
-    if (typeof window === 'undefined' || process.env.NODE_ENV === 'development') return;
-
+    if (typeof window === 'undefined') 
+      throw "Events SDK can't be initialized in server context";
+    if (process.env.NODE_ENV === 'development')
+      throw 'Events SDK is not initialized in development environment';
+    
     await Events.init({
       siteName: props.siteName,
       sitecoreEdgeUrl: props.sitecoreEdgeUrl,

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/context/sdk/events.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/context/sdk/events.ts
@@ -7,9 +7,9 @@ const sdkModule: SDK<typeof Events> = {
     // Events module can't be initialized on the server side
     // We also don't want to initialize it in development mode
     if (typeof window === 'undefined') 
-      throw "Events SDK can't be initialized in server context";
+      throw 'Browser Events SDK is not initialized in server context';
     if (process.env.NODE_ENV === 'development')
-      throw 'Events SDK is not initialized in development environment';
+      throw 'Browser Events SDK is not initialized in development environment';
     
     await Events.init({
       siteName: props.siteName,

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -34,10 +34,10 @@ describe('Context', () => {
       init: () => {
         return new Promise<void>((_, reject) => {
           reject('Cannot init Error');
-        });        
-      }
+        });
+      },
     },
-  }
+  };
 
   const fooInitSpy = sinon.spy(sdks.Foo, 'init');
   const barInitSpy = sinon.spy(sdks.Bar, 'init');
@@ -171,27 +171,30 @@ describe('Context', () => {
       expect(context.siteName).to.equal('website-1');
     });
 
-    
     it('should catch and log when SDK initialization rejects', () => {
       const consoleSpy = sinon.spy(console, 'log');
-      const localProps = {...props, sdks: errorSdk};
+      const localProps = { ...props, sdks: errorSdk };
       const context = new Context<typeof errorSdk>(localProps);
       context.init();
-      expect(consoleSpy.calledWith('Initialization for SDK Error skipped. Reason: \n Cannot init Error'));
+      expect(
+        consoleSpy.calledWith('Initialization for SDK Error skipped. Reason: \n Cannot init Error')
+      );
       consoleSpy.restore();
     });
 
     it('should reject when getting SDK that rejected initialization', (done) => {
-      const localProps = {...props, sdks: errorSdk};
+      const localProps = { ...props, sdks: errorSdk };
       const context = new Context<typeof errorSdk>(localProps);
       context.init();
-      context.getSDK('Error').then(()=> {
-        throw new Error('should not resolve');       
-      })
-      .catch((e) => {
-        expect(e).to.be.equal('Cannot init Error');
-        done();
-      });
+      context
+        .getSDK('Error')
+        .then(() => {
+          throw new Error('should not resolve');
+        })
+        .catch((e) => {
+          expect(e).to.be.equal('Cannot init Error');
+          done();
+        });
     });
   });
 

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -145,7 +145,7 @@ export class Context<SDKModules extends SDKModulesType> {
           resolve(this.sdks[name]);
         })
         .catch((e) => {
-          console.log(`Initialization for SDK ${name.toString()} skipped. Reason: \n ${e}`);
+          // if init rejects, getSDK will reject too now
           reject(e);
         });
     });

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -137,11 +137,13 @@ export class Context<SDKModules extends SDKModulesType> {
    * @returns {void}
    */
   protected initSDK<T extends keyof SDKModules>(name: T): void {
-    this.sdkPromises[name] = new Promise((resolve) => {
+    this.sdkPromises[name] = new Promise((resolve, reject) => {
       this.props.sdks[name].init(this).then(() => {
         this.sdks[name] = this.props.sdks[name].sdk;
-
         resolve(this.sdks[name]);
+      }).catch((e) => {
+        console.log(`Initialization for SDK ${name.toString()} skipped. Reason: \n ${e}`);
+        reject(e);
       });
     });
   }

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -138,13 +138,16 @@ export class Context<SDKModules extends SDKModulesType> {
    */
   protected initSDK<T extends keyof SDKModules>(name: T): void {
     this.sdkPromises[name] = new Promise((resolve, reject) => {
-      this.props.sdks[name].init(this).then(() => {
-        this.sdks[name] = this.props.sdks[name].sdk;
-        resolve(this.sdks[name]);
-      }).catch((e) => {
-        console.log(`Initialization for SDK ${name.toString()} skipped. Reason: \n ${e}`);
-        reject(e);
-      });
+      this.props.sdks[name]
+        .init(this)
+        .then(() => {
+          this.sdks[name] = this.props.sdks[name].sdk;
+          resolve(this.sdks[name]);
+        })
+        .catch((e) => {
+          console.log(`Initialization for SDK ${name.toString()} skipped. Reason: \n ${e}`);
+          reject(e);
+        });
     });
   }
 }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Events SDK should not initialize in dev environment or server context. This PR ensures Events SDK promise is not pending in such situations and will reject instead. Context logic has been made to handle initialization rejects.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
