### PR TITLE
[sitecore-jss-nextjs] Rework promises in context implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Our versioning strategy is as follows:
 * `[templates/node-headless-ssr-proxy]` `[node-headless-ssr-proxy]` Add sc_site qs parameter to Layout Service requests by default ([#1660](https://github.com/Sitecore/jss/pull/1660))
 * `[templates/nextjs-sxa]` Fixed Image component when there is using Banner variant which set property background-image when image is empty. ([#1689](https://github.com/Sitecore/jss/pull/1689)) ([#1692](https://github.com/Sitecore/jss/pull/1692))
 * `[templates/nextjs-sxa]` Fix feature `show Grid column` in Experience Editor. ([#1704](https://github.com/Sitecore/jss/pull/1704))
+* `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715) [#1716](https://github.com/Sitecore/jss/pull/1716))
 
 ### 🧹 Chores
 
@@ -32,7 +33,7 @@ Our versioning strategy is as follows:
 ### 🎉 New Features & Improvements
 
 * `[templates/react]` `[templates/angular]` `[templates/vue]` `[templates/node-headless-ssr-proxy]` `[templates/node-headless-ssr-experience-edge]` ([#1647](https://github.com/Sitecore/jss/pull/1647)) ([#1672](https://github.com/Sitecore/jss/pull/1672)) Switch from using JSS_APP_NAME to SITECORE_SITE_NAME - environment and config variables in React, Vue, Angular templates as well as ssr node proxy apps templates have been renamed. 
-* `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` ([#1640](https://github.com/Sitecore/jss/pull/1640)) ([#1662](https://github.com/Sitecore/jss/pull/1662))([#1661](https://github.com/Sitecore/jss/pull/1661)) ([#1672](https://github.com/Sitecore/jss/pull/1672)) ([#1675](https://github.com/Sitecore/jss/pull/1675)) ([#1710](https://github.com/Sitecore/jss/pull/1710)) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715)) Sitecore Edge Platform and Context support:
+* `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` ([#1640](https://github.com/Sitecore/jss/pull/1640)) ([#1662](https://github.com/Sitecore/jss/pull/1662))([#1661](https://github.com/Sitecore/jss/pull/1661)) ([#1672](https://github.com/Sitecore/jss/pull/1672)) ([#1675](https://github.com/Sitecore/jss/pull/1675)) ([#1710](https://github.com/Sitecore/jss/pull/1710)) Sitecore Edge Platform and Context support:
   * Introducing the _clientFactory_ property. This property can be utilized by GraphQL-based services, the previously used _endpoint_ and _apiKey_ properties are deprecated. The _clientFactory_ serves as the central hub for executing GraphQL requests within the application.
   * New SITECORE_EDGE_CONTEXT_ID environment variable has been added.
   * The JSS_APP_NAME environment variable has been updated and is now referred to as SITECORE_SITE_NAME.

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -177,7 +177,7 @@ describe('Context', () => {
       try {
         context.init();
       } catch (e) {
-        throw 'Should not throw';
+        done(e);
       } finally {
         done();
       }
@@ -190,7 +190,7 @@ describe('Context', () => {
       context
         .getSDK('Error')
         .then(() => {
-          throw new Error('should not resolve');
+          done('should not resolve');
         })
         .catch((e) => {
           expect(e).to.be.equal('Cannot init Error');

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -177,10 +177,10 @@ describe('Context', () => {
       try {
         context.init();
       } catch (e) {
-        throw('Should not throw');
+        throw 'Should not throw';
       } finally {
         done();
-      }      
+      }
     });
 
     it('should reject when getting SDK that rejected initialization', (done) => {

--- a/packages/sitecore-jss-nextjs/src/context/context.test.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.test.ts
@@ -171,15 +171,16 @@ describe('Context', () => {
       expect(context.siteName).to.equal('website-1');
     });
 
-    it('should catch and log when SDK initialization rejects', () => {
-      const consoleSpy = sinon.spy(console, 'log');
+    it('should not fail context init when an SDK init throws', (done) => {
       const localProps = { ...props, sdks: errorSdk };
       const context = new Context<typeof errorSdk>(localProps);
-      context.init();
-      expect(
-        consoleSpy.calledWith('Initialization for SDK Error skipped. Reason: \n Cannot init Error')
-      );
-      consoleSpy.restore();
+      try {
+        context.init();
+      } catch (e) {
+        throw('Should not throw');
+      } finally {
+        done();
+      }      
     });
 
     it('should reject when getting SDK that rejected initialization', (done) => {

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -134,8 +134,7 @@ export class Context<SDKModules extends SDKModulesType> {
     } else {
       return this.sdkPromises[name]!.then((result) => {
         return (
-          (this.sdkErrors[name] && Promise.reject(this.sdkErrors[name])) ||
-          Promise.resolve(result)
+          (this.sdkErrors[name] && Promise.reject(this.sdkErrors[name])) || Promise.resolve(result)
         );
       });
     }

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -93,7 +93,7 @@ export class Context<SDKModules extends SDKModulesType> {
    */
   protected sdkPromises: { [module in keyof SDKModules]?: Promise<SDKModules[module]['sdk']> } = {};
 
-  protected failedSdks: { [module in keyof SDKModules]?: string } = {};
+  protected sdkErrors: { [module in keyof SDKModules]?: string } = {};
 
   constructor(protected props: ContextConfig<SDKModules>) {
     this.sitecoreEdgeUrl = props.sitecoreEdgeUrl;
@@ -134,7 +134,7 @@ export class Context<SDKModules extends SDKModulesType> {
     } else {
       return this.sdkPromises[name]!.then((result) => {
         return (
-          (this.failedSdks[name] && Promise.reject(this.failedSdks[name])) ||
+          (this.sdkErrors[name] && Promise.reject(this.sdkErrors[name])) ||
           Promise.resolve(result)
         );
       });
@@ -157,7 +157,7 @@ export class Context<SDKModules extends SDKModulesType> {
         })
         .catch((e) => {
           // if init rejects, we mark SDK as failed - so getSDK cal would reject with a reason
-          this.failedSdks[name] = e;
+          this.sdkErrors[name] = e;
           resolve(undefined);
         });
     });

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -155,7 +155,7 @@ export class Context<SDKModules extends SDKModulesType> {
           resolve(this.sdks[name]);
         })
         .catch((e) => {
-          // if init rejects, we mark SDK as failed - so getSDK cal would reject with a reason
+          // if init rejects, we mark SDK as failed - so getSDK call would reject with a reason
           this.sdkErrors[name] = e;
           resolve(undefined);
         });

--- a/packages/sitecore-jss-nextjs/src/context/context.ts
+++ b/packages/sitecore-jss-nextjs/src/context/context.ts
@@ -93,6 +93,8 @@ export class Context<SDKModules extends SDKModulesType> {
    */
   protected sdkPromises: { [module in keyof SDKModules]?: Promise<SDKModules[module]['sdk']> } = {};
 
+  protected failedSdks: { [module in keyof SDKModules]?: string } = {};
+
   constructor(protected props: ContextConfig<SDKModules>) {
     this.sitecoreEdgeUrl = props.sitecoreEdgeUrl;
     this.sitecoreEdgeContextId = props.sitecoreEdgeContextId;
@@ -127,7 +129,16 @@ export class Context<SDKModules extends SDKModulesType> {
    * @returns initialized SDK
    */
   public getSDK = <T extends keyof SDKModules>(name: T): Promise<SDKModules[T]['sdk']> => {
-    return this.sdkPromises[name] || Promise.reject(`Unknown SDK '${String(name)}'`);
+    if (!this.sdkPromises[name]) {
+      return Promise.reject(`Unknown SDK '${String(name)}'`);
+    } else {
+      return this.sdkPromises[name]!.then((result) => {
+        return (
+          (this.failedSdks[name] && Promise.reject(this.failedSdks[name])) ||
+          Promise.resolve(result)
+        );
+      });
+    }
   };
 
   /**
@@ -137,7 +148,7 @@ export class Context<SDKModules extends SDKModulesType> {
    * @returns {void}
    */
   protected initSDK<T extends keyof SDKModules>(name: T): void {
-    this.sdkPromises[name] = new Promise((resolve, reject) => {
+    this.sdkPromises[name] = new Promise((resolve) => {
       this.props.sdks[name]
         .init(this)
         .then(() => {
@@ -145,8 +156,9 @@ export class Context<SDKModules extends SDKModulesType> {
           resolve(this.sdks[name]);
         })
         .catch((e) => {
-          // if init rejects, getSDK will reject too now
-          reject(e);
+          // if init rejects, we mark SDK as failed - so getSDK cal would reject with a reason
+          this.failedSdks[name] = e;
+          resolve(undefined);
         });
     });
   }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Follow up to context changes.
- Ensure SDK init methods can throw without halting context init
- Ensure getSDK method can properly resolve and reject
- Ensure relevant message is passed when getSDK rejects

## Testing Details
- [x] Unit Test Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
