### PR TITLE
[sitecore-jss-angular] Fixed missing ngModuleRef in lazy loaded components

### DIFF
--- a/packages/sitecore-jss-angular/src/components/placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/placeholder.component.ts
@@ -296,6 +296,7 @@ export class PlaceholderComponent implements OnInit, OnChanges, DoCheck, OnDestr
     // work-around for https://github.com/angular/angular/issues/12215
     const createdComponentRef = this.view.createComponent(rendering.componentImplementation, {
       index: index,
+      ngModuleRef: rendering.componentModuleRef,
     });
     if (this.parentStyleAttribute) {
       this.renderer.setAttribute(

--- a/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
+++ b/packages/sitecore-jss-angular/src/jss-component-factory.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Injector, Type, createNgModule } from '@angular/core';
+import { createNgModule, Inject, Injectable, Injector, NgModuleRef, Type } from '@angular/core';
 import { ComponentRendering, HtmlElementRendering } from '@sitecore-jss/sitecore-jss/layout';
 import {
   ComponentNameAndModule,
@@ -17,6 +17,7 @@ export interface ComponentFactoryResult {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   componentImplementation?: Type<any>;
   componentDefinition: ComponentRendering | HtmlElementRendering;
+  componentModuleRef?: NgModuleRef<unknown>;
   canActivate?:
     | JssCanActivate
     | Type<JssCanActivate>
@@ -86,6 +87,7 @@ export class JssComponentFactoryService {
         return {
           componentDefinition: component,
           componentImplementation: componentType,
+          componentModuleRef: moduleRef,
           canActivate: lazyComponent.canActivate,
           resolve: lazyComponent.resolve,
         };


### PR DESCRIPTION
Components declared in a lazy loaded Module are no longer able to inject Providers from that Module, they get a NullPointer exception from Angular Injection. 

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
When the `PlaceholderComponent` creates the Rendering Components, it is missing the `ngModuleRef` (as describen in the [Angular documentation for createComponent](https://angular.io/api/core/ViewContainerRef#createcomponent)). Without the ModuleRef the Component falls back to the App Module injector, which does not have the providers defined in the lazy loaded Module.
This change adds back the `ngModuleRef` when a Rendering Component is being created by the PlaceholderComponent, therefore using the right injector. It used to work in older versions of sitecore-jss-angular and broke with the following commit 4959479e3f5897c2dbcf3fccc6a32ad1e7262a7f. In the older version the `componentFactory` already included the `ngModuleRef`, but it's missing in the new `componentImplementation`.

## Testing Details
I built my forked repo locally, integrated it into our project and manually tested it successfully (NullPointer exceptions were no longer thrown for lazy loaded components). Unfortunately I don't have the time or capacity to add new Unit Test's.
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
