### PR TITLE
[templates/nextjs] [templates/nextjs-styleguide] Update deprecated GraphQLRequestClient import statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Load the content styles for the RichText component ([#1670](https://github.com/Sitecore/jss/pull/1670))([#1683](https://github.com/Sitecore/jss/pull/1683)) ([#1684](https://github.com/Sitecore/jss/pull/1684)) ([#1693](https://github.com/Sitecore/jss/pull/1693))
 * `[templates/react]` `[sitecore-jss-react]` Replace package 'deep-equal' with 'fast-deep-equal'. No functionality change only performance improvement ([#1719](https://github.com/Sitecore/jss/pull/1719)) ([#1665](https://github.com/Sitecore/jss/pull/1665))
 * `[templates/nextjs-xmcloud]` `[sitecore-jss]` `[sitecore-jss-nextjs]` `[sitecore-jss-react]` Add support for loading appropriate stylesheets whenever a theme is applied to BYOC and SXA components by introducing new function getComponentLibraryStylesheetLinks, which replaces getFEAASLibraryStylesheetLinks (which has been marked as deprecated) ([#1722](https://github.com/Sitecore/jss/pull/1722)) 
+* `[templates/nextjs]` `[templates/nextjs-styleguide]` Modify all GraphQLRequestClient import statements so that it gets imported from the /graphql submodule ([#1728](https://github.com/Sitecore/jss/pull/1728)) 
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/graphql/GraphQL-ConnectedDemo.dynamic.tsx
@@ -5,9 +5,9 @@ import {
   GetServerSideComponentProps,
   GetStaticComponentProps,
   constants,
-  GraphQLRequestClient,
   withDatasourceCheck,
 } from '@sitecore-jss/sitecore-jss-nextjs';
+import { GraphQLRequestClient } from '@sitecore-jss/sitecore-jss-nextjs/graphql';
 import {
   resetEditorChromes
 } from '@sitecore-jss/sitecore-jss-nextjs/utils';

--- a/packages/create-sitecore-jss/src/templates/nextjs/scripts/fetch-graphql-introspection-data.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs/scripts/fetch-graphql-introspection-data.ts
@@ -1,4 +1,4 @@
-import { GraphQLRequestClient } from '@sitecore-jss/sitecore-jss-nextjs';
+import { GraphQLRequestClient } from '@sitecore-jss/sitecore-jss-nextjs/graphql';
 import fs from 'fs';
 import { getIntrospectionQuery } from 'graphql';
 
@@ -26,11 +26,11 @@ const client = new GraphQLRequestClient(jssConfig.graphQLEndpoint, {
 
 client
   .request(getIntrospectionQuery())
-  .then((result) => {
+  .then(result => {
     fs.writeFile(
       './src/temp/GraphQLIntrospectionResult.json',
       JSON.stringify(result, null, 2),
-      (err) => {
+      err => {
         if (err) {
           console.error('Error writing GraphQLIntrospectionResult file', err);
           return;
@@ -40,7 +40,7 @@ client
       }
     );
   })
-  .catch((e) => {
+  .catch(e => {
     console.error(e);
     process.exit(1);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Modify all `GraphQLRequestClient` import statements so that it gets imported from the `/graphql` submodule

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
