### PR TITLE
[Next.js] [BYOC] Component Builder integration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Our versioning strategy is as follows:
 * `[nextjs/template]` `[sitecore-jss-nextjs]` On-demand ISR [#1674](https://github.com/Sitecore/jss/pull/1674))
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Load the content styles for the RichText component ([#1670](https://github.com/Sitecore/jss/pull/1670))([#1683](https://github.com/Sitecore/jss/pull/1683)) ([#1684](https://github.com/Sitecore/jss/pull/1684)) ([#1693](https://github.com/Sitecore/jss/pull/1693))
 * `[templates/react]` `[sitecore-jss-react]` Replace package 'deep-equal' with 'fast-deep-equal'. No functionality change only performance improvement ([#1719](https://github.com/Sitecore/jss/pull/1719)) ([#1665](https://github.com/Sitecore/jss/pull/1665))
-* `[templates/nextjs-xmcloud]` `[sitecore-jss]` `[sitecore-jss-nextjs]` `[sitecore-jss-react]` Add support for loading appropriate stylesheets whenever a theme is applied to BYOC and SXA components by introducing new function getComponentLibraryStylesheetLinks, which replaces getFEAASLibraryStylesheetLinks (which has been marked as deprecated) ([#1722](https://github.com/Sitecore/jss/pull/1722)) 
+* `[templates/nextjs-xmcloud]` `[sitecore-jss]` `[sitecore-jss-nextjs]` `[sitecore-jss-react]` Add support for loading appropriate stylesheets whenever a theme is applied to BYOC and SXA components by introducing new function getComponentLibraryStylesheetLinks, which replaces getFEAASLibraryStylesheetLinks (which has been marked as deprecated) ([#1722](https://github.com/Sitecore/jss/pull/1722))
+* `[sitecore-jss-nextjs]` `[templates/nextjs]` [BYOC] Component Builder integration endpoint ([#1729](https://github.com/Sitecore/jss/pull/1729))
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
@@ -3,6 +3,15 @@
  */
 const feaasPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
+    async rewrites() {
+      return [
+        ...await nextConfig.rewrites(),
+        {
+          source: '/feaas-render',
+          destination: '/api/editing/feaas/render',
+        },
+      ];
+    },
     webpack: (config, options) => {
       if (options.isServer) {
         // Force use of CommonJS on the server for FEAAS SDK since JSS also uses CommonJS entrypoint to FEAAS SDK.

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
@@ -3,9 +3,10 @@
  */
 const feaasPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
-    // Enable FEAAS Nextjs Image integration
+    // Enable FEAAS Nextjs Image integration by enabling the remotePatterns option.
     images: {
       remotePatterns: [
+        ...(nextConfig.images?.remotePatterns || []),
         {
           protocol: 'https',
           hostname: '**',

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
@@ -3,6 +3,19 @@
  */
 const feaasPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
+    // Enable FEAAS Nextjs Image integration
+    images: {
+      remotePatterns: [
+        {
+          protocol: 'https',
+          hostname: '**',
+        },
+        {
+          protocol: 'http',
+          hostname: '**',
+        },
+      ],
+    },
     webpack: (config, options) => {
       if (options.isServer) {
         // Force use of CommonJS on the server for FEAAS SDK since JSS also uses CommonJS entrypoint to FEAAS SDK.

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/next-config/plugins/feaas.js
@@ -3,20 +3,6 @@
  */
 const feaasPlugin = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
-    // Enable FEAAS Nextjs Image integration by enabling the remotePatterns option.
-    images: {
-      remotePatterns: [
-        ...(nextConfig.images?.remotePatterns || []),
-        {
-          protocol: 'https',
-          hostname: '**',
-        },
-        {
-          protocol: 'http',
-          hostname: '**',
-        },
-      ],
-    },
     webpack: (config, options) => {
       if (options.isServer) {
         // Force use of CommonJS on the server for FEAAS SDK since JSS also uses CommonJS entrypoint to FEAAS SDK.

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/middleware.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/middleware.ts
@@ -1,0 +1,21 @@
+import type { NextRequest, NextFetchEvent } from 'next/server';
+import middleware from 'lib/middleware';
+
+// eslint-disable-next-line
+export default async function (req: NextRequest, ev: NextFetchEvent) {
+  return middleware(req, ev);
+}
+
+export const config = {
+  /*
+   * Match all paths except for:
+   * 1. /api routes
+   * 2. /_next (Next.js internals)
+   * 3. /sitecore/api (Sitecore API routes)
+   * 4. /- (Sitecore media)
+   * 5. /healthz (Health check)
+   * 6. /feaas-render (FEaaS render)
+   * 7. all root files inside /public
+   */
+  matcher: ['/', '/((?!api/|_next/|feaas-render|healthz|sitecore/api/|-/|favicon.ico|sc_logo.svg).*)'],
+};

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/api/editing/feaas/render.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/api/editing/feaas/render.ts
@@ -4,23 +4,11 @@ import { FEAASRenderMiddleware } from '@sitecore-jss/sitecore-jss-nextjs/editing
  * This Next.js API route is used to handle GET requests from Sitecore Component Builder.
  *
  * The `FEAASRenderMiddleware` will:
- *  1. Enable Next.js Preview Mode
- *  2. Invoke the /feaas/render page request, passing along the Preview Mode cookies.
- *  3. Return the rendered page HTML to the Sitecore Component Builder:
+ *  1. Enable Next.js Preview Mode.
+ *  2. Redirect the request to the /feaas/render page.
  *  - If "feaasSrc" query parameter is provided, the page will render a FEAAS component.
- *  - The page provides all the registered FEAAS components
+ *  - The page provides all the registered FEAAS components.
  */
-
-// Bump body size limit (1mb by default) and disable response limit for Sitecore editor payloads
-// See https://nextjs.org/docs/api-routes/request-helpers#custom-config
-export const config = {
-  api: {
-    bodyParser: {
-      sizeLimit: '2mb',
-    },
-    responseLimit: false,
-  },
-};
 
 // Wire up the FEAASRenderMiddleware handler
 const handler = new FEAASRenderMiddleware().getHandler();

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/api/editing/feaas/render.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/api/editing/feaas/render.ts
@@ -1,0 +1,28 @@
+import { FEAASRenderMiddleware } from '@sitecore-jss/sitecore-jss-nextjs/editing';
+
+/**
+ * This Next.js API route is used to handle GET requests from Sitecore Component Builder.
+ *
+ * The `FEAASRenderMiddleware` will:
+ *  1. Enable Next.js Preview Mode
+ *  2. Invoke the /feaas/render page request, passing along the Preview Mode cookies.
+ *  3. Return the rendered page HTML to the Sitecore Component Builder:
+ *  - If "feaasSrc" query parameter is provided, the page will render a FEAAS component.
+ *  - The page provides all the registered FEAAS components
+ */
+
+// Bump body size limit (1mb by default) and disable response limit for Sitecore editor payloads
+// See https://nextjs.org/docs/api-routes/request-helpers#custom-config
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '2mb',
+    },
+    responseLimit: false,
+  },
+};
+
+// Wire up the FEAASRenderMiddleware handler
+const handler = new FEAASRenderMiddleware().getHandler();
+
+export default handler;

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/feaas/render.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/feaas/render.tsx
@@ -24,6 +24,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     props: {
       feaasSrc: context.query.feaasSrc || null,
     },
+    // Don't show the page if it's not requested by the api route using the preview mode
+    notFound: !context.preview,
   };
 };
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/feaas/render.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/pages/feaas/render.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps } from 'next';
+import BYOC from 'src/byoc';
+import * as FEAAS from '@sitecore-feaas/clientside/react';
+
+/**
+ * The FEAASRender page is responsible for:
+ * - Rendering the FEAAS component if the "feaasSrc" is provided.
+ * - Rendering all the registered components.
+ * - The page is rendered only if it's requested by the api route (/api/editing/feaas/render) using the preview mode.
+ */
+const FEAASRender = ({ feaasSrc }: { feaasSrc: string }): JSX.Element => {
+  return (
+    <>
+      {/** Render the component if the "feaasSrc" is provided  */}
+      {feaasSrc && <FEAAS.Component src={feaasSrc} />}
+      {/** Render all the registered components  */}
+      <BYOC />
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      feaasSrc: context.query.feaasSrc || null,
+    },
+  };
+};
+
+export default FEAASRender;

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -1,24 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { STATIC_PROPS_ID, SERVER_PROPS_ID } from 'next/constants';
-import { AxiosDataFetcher, debug } from '@sitecore-jss/sitecore-jss';
+import { debug } from '@sitecore-jss/sitecore-jss';
 import { EDITING_COMPONENT_ID, RenderingType } from '@sitecore-jss/sitecore-jss/layout';
 import { parse } from 'node-html-parser';
 import { EditingData } from './editing-data';
 import { EditingDataService, editingDataService } from './editing-data-service';
-import {
-  QUERY_PARAM_EDITING_SECRET,
-  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
-  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
-} from './constants';
+import { QUERY_PARAM_EDITING_SECRET } from './constants';
 import { getJssEditingSecret } from '../utils/utils';
+import { RenderMiddlewareBase, RenderMiddlewareBaseConfig } from './render-middleware';
 
-export interface EditingRenderMiddlewareConfig {
-  /**
-   * The `AxiosDataFetcher` instance to use for API requests.
-   * @default new AxiosDataFetcher()
-   * @see AxiosDataFetcher
-   */
-  dataFetcher?: AxiosDataFetcher;
+export type EditingRenderMiddlewareConfig = RenderMiddlewareBaseConfig & {
   /**
    * The `EditingDataService` instance to use.
    * This would typically only be necessary if you've got a custom `EditingDataService` instance (e.g. using a custom API route).
@@ -38,34 +29,23 @@ export interface EditingRenderMiddlewareConfig {
    * @see resolveServerUrl
    */
   resolvePageUrl?: (serverUrl: string, itemPath: string) => string;
-  /**
-   * Function used to determine the root server URL. This is used for the route/page and subsequent data API requests.
-   * By default, the host header is used, with https protocol on Vercel (due to serverless function architecture) and http protocol elsewhere.
-   * @param {NextApiRequest} req The current request.
-   * @default `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
-   * @see resolvePageUrl
-   */
-  resolveServerUrl?: (req: NextApiRequest) => string;
-}
+};
 
 /**
  * Middleware / handler for use in the editing render Next.js API route (e.g. '/api/editing/render')
  * which is required for Sitecore editing support.
  */
-export class EditingRenderMiddleware {
+export class EditingRenderMiddleware extends RenderMiddlewareBase {
   private editingDataService: EditingDataService;
-  private dataFetcher: AxiosDataFetcher;
   private resolvePageUrl: (serverUrl: string, itemPath: string) => string;
-  private resolveServerUrl: (req: NextApiRequest) => string;
 
   /**
    * @param {EditingRenderMiddlewareConfig} [config] Editing render middleware config
    */
   constructor(config?: EditingRenderMiddlewareConfig) {
+    super(config);
     this.editingDataService = config?.editingDataService ?? editingDataService;
-    this.dataFetcher = config?.dataFetcher ?? new AxiosDataFetcher({ debugger: debug.editing });
     this.resolvePageUrl = config?.resolvePageUrl ?? this.defaultResolvePageUrl;
-    this.resolveServerUrl = config?.resolveServerUrl ?? this.defaultResolveServerUrl;
   }
 
   /**
@@ -75,28 +55,6 @@ export class EditingRenderMiddleware {
   public getHandler(): (req: NextApiRequest, res: NextApiResponse) => Promise<void> {
     return this.handler;
   }
-
-  /**
-   * Gets query parameters that should be passed along to subsequent requests
-   * @param {Object} query Object of query parameters from incoming URL
-   * @returns Object of approved query parameters
-   */
-  protected getQueryParamsForPropagation = (
-    query: Partial<{ [key: string]: string | string[] }>
-  ): { [key: string]: string } => {
-    const params: { [key: string]: string } = {};
-    if (query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE]) {
-      params[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = query[
-        QUERY_PARAM_PROTECTION_BYPASS_SITECORE
-      ] as string;
-    }
-    if (query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL]) {
-      params[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = query[
-        QUERY_PARAM_PROTECTION_BYPASS_VERCEL
-      ] as string;
-    }
-    return params;
-  };
 
   private handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     const { method, query, body, headers } = req;
@@ -239,20 +197,6 @@ export class EditingRenderMiddleware {
    */
   private defaultResolvePageUrl = (serverUrl: string, itemPath: string) => {
     return `${serverUrl}${itemPath}`;
-  };
-
-  /**
-   * Default server URL resolution.
-   * Note we use https protocol on Vercel due to serverless function architecture.
-   * In all other scenarios, including localhost (with or without a proxy e.g. ngrok)
-   * and within a nodejs container, http protocol should be used.
-   *
-   * For information about the VERCEL environment variable, see
-   * https://vercel.com/docs/environment-variables#system-environment-variables
-   * @param {NextApiRequest} req
-   */
-  private defaultResolveServerUrl = (req: NextApiRequest) => {
-    return `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
   };
 }
 

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -1,0 +1,383 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect, use } from 'chai';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
+import {
+  QUERY_PARAM_EDITING_SECRET,
+  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
+  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+} from './constants';
+import { FEAASRenderMiddleware } from './feaas-render-middleware';
+import { spy, match } from 'sinon';
+import sinonChai from 'sinon-chai';
+
+use(sinonChai);
+
+const mockNextJsPreviewCookies = [
+  '__prerender_bypass:1122334455',
+  '__next_preview_data:6677889900',
+];
+
+type Query = {
+  [key: string]: string;
+};
+
+const mockRequest = (query?: Query, method?: string, host?: string) => {
+  return {
+    body: {},
+    method: method ?? 'GET',
+    query: query ?? {},
+    headers: { host: host ?? 'localhost:3000' },
+  } as NextApiRequest;
+};
+
+const mockResponse = () => {
+  const res = {} as NextApiResponse;
+  res.status = spy(() => {
+    return res;
+  });
+  res.json = spy(() => {
+    return res;
+  });
+  res.send = spy(() => {
+    return res;
+  });
+  res.end = spy(() => {
+    return res;
+  });
+  res.getHeader = spy((name: string) => {
+    return name === 'Set-Cookie' ? mockNextJsPreviewCookies : undefined;
+  });
+  res.setHeader = spy();
+  res.setPreviewData = spy(() => {
+    return res;
+  });
+  return res;
+};
+
+const mockFetcher = (html?: string) => {
+  const fetcher = {} as AxiosDataFetcher;
+  fetcher.get = spy<any>(() => {
+    return Promise.resolve({ data: html ?? '' });
+  });
+  return fetcher;
+};
+
+describe('FEAASRenderMiddleware', () => {
+  const secret = 'secret1234';
+
+  beforeEach(() => {
+    process.env.JSS_EDITING_SECRET = secret;
+  });
+
+  after(() => {
+    delete process.env.JSS_EDITING_SECRET;
+  });
+
+  it('should handle request', async () => {
+    const html = '<html key="test1"><body key="test2">Something amazing</body></html>';
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+
+    const fetcher = mockFetcher(html);
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({});
+    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
+    expect(fetcher.get).to.have.been.calledOnce;
+    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
+      match('http://localhost:3000/feaas/render?timestamp'),
+      {
+        headers: {
+          Cookie: mockNextJsPreviewCookies.join(';'),
+        },
+      }
+    );
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith(
+      '<html key="test1"><body key="test2">Something amazing</body></html>'
+    );
+  });
+
+  it('should handle request when feaasSrc query parameter is present', async () => {
+    const html = '<html key="test1"><body key="test2">Something amazing</body></html>';
+    const query = {
+      feaasSrc: 'https://feaas.blob.core.windows.net/components/xxx/xyz/responsive/staged',
+    } as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+
+    const fetcher = mockFetcher(html);
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({});
+    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
+    expect(fetcher.get).to.have.been.calledOnce;
+    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
+      match(
+        'http://localhost:3000/feaas/render?feaasSrc=https%3A%2F%2Ffeaas.blob.core.windows.net%2Fcomponents%2Fxxx%2Fxyz%2Fresponsive%2Fstaged&timestamp'
+      ),
+      {
+        headers: {
+          Cookie: mockNextJsPreviewCookies.join(';'),
+        },
+      }
+    );
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith(
+      '<html key="test1"><body key="test2">Something amazing</body></html>'
+    );
+  });
+
+  it('should throw error for page render request', async () => {
+    const html = '<html phkey="test1"><body phkey="test2">Error occured</body></html>';
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const previewData = {};
+
+    const fetcher = {} as AxiosDataFetcher;
+    fetcher.get = spy<any>(() => {
+      return Promise.reject({ response: { data: html, status: 500 } });
+    });
+
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith(previewData);
+    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
+    expect(fetcher.get).to.have.been.calledOnce;
+    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
+      match('http://localhost:3000/feaas/render?timestamp'),
+      {
+        headers: {
+          Cookie: mockNextJsPreviewCookies.join(';'),
+        },
+      }
+    );
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should respondWith 405 for unsupported method', async () => {
+    const fetcher = mockFetcher();
+    const req = mockRequest({}, 'POST');
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setHeader).to.have.been.calledWithExactly('Allow', 'GET');
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(405);
+    expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should respond with 401 for missing secret', async () => {
+    const fetcher = mockFetcher();
+    const query = {} as Query;
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(401);
+    expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should respond with 401 for invalid secret', async () => {
+    const fetcher = mockFetcher();
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = 'nope';
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(401);
+    expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should use host header with http for serverUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(query, undefined, 'testhostheader.com');
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(fetcher.get).to.have.been.calledWithMatch('http://testhostheader.com');
+  });
+
+  it('should use https for serverUrl on Vercel', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(query, undefined, 'vercel.com');
+    const res = mockResponse();
+    process.env.VERCEL = '1';
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(fetcher.get).to.have.been.calledWithMatch('https://vercel.com');
+
+    delete process.env.VERCEL;
+  });
+
+  it('should use custom resolveServerUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const serverUrl = 'https://test.com';
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+      resolveServerUrl: () => {
+        return serverUrl;
+      },
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(fetcher.get).to.have.been.calledWithMatch(serverUrl);
+  });
+
+  it('should use custom resolvePageUrl', async () => {
+    const html = '<html><body>Something amazing</body></html>';
+    const fetcher = mockFetcher(html);
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const serverUrl = 'https://test.com';
+    const expectedPageUrl = `${serverUrl}/some/path/feaas/render`;
+    const resolvePageUrl = spy((serverUrl: string) => {
+      return `${serverUrl}/some/path/feaas/render`;
+    });
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+      resolvePageUrl: resolvePageUrl,
+      resolveServerUrl: () => {
+        return serverUrl;
+      },
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(resolvePageUrl).to.have.been.calledOnce;
+    expect(resolvePageUrl).to.have.been.calledWith(serverUrl);
+    expect(fetcher.get).to.have.been.calledOnce;
+    expect(fetcher.get).to.have.been.calledWithMatch(expectedPageUrl);
+  });
+
+  it('should respondWith 500 if rendered html empty', async () => {
+    const fetcher = mockFetcher('');
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should pass along protection bypass query parameters', async () => {
+    const html = '<html phkey="test1"><body phkey="test2">Something amazing</body></html>';
+    const query = {} as Query;
+    const bypassTokenSitecore = 'token1234Sitecore';
+    const bypassTokenVercel = 'token1234Vercel';
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = bypassTokenSitecore;
+    query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = bypassTokenVercel;
+    const previewData = {};
+
+    const fetcher = mockFetcher(html);
+    const req = mockRequest(query);
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware({
+      dataFetcher: fetcher,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith(previewData);
+    expect(fetcher.get).to.have.been.calledOnce;
+    expect(fetcher.get, 'pass along protection bypass query params').to.have.been.calledWithMatch(
+      `http://localhost:3000/feaas/render?${QUERY_PARAM_PROTECTION_BYPASS_SITECORE}=${bypassTokenSitecore}&${QUERY_PARAM_PROTECTION_BYPASS_VERCEL}=${bypassTokenVercel}&timestamp`
+    );
+  });
+});

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -1,23 +1,18 @@
+/* eslint-disable quotes */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, use } from 'chai';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import {
   QUERY_PARAM_EDITING_SECRET,
   QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
   QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
 } from './constants';
 import { FEAASRenderMiddleware } from './feaas-render-middleware';
-import { spy, match } from 'sinon';
+import { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 
 use(sinonChai);
-
-const mockNextJsPreviewCookies = [
-  '__prerender_bypass:1122334455',
-  '__next_preview_data:6677889900',
-];
 
 type Query = {
   [key: string]: string;
@@ -37,31 +32,23 @@ const mockResponse = () => {
   res.status = spy(() => {
     return res;
   });
-  res.json = spy(() => {
-    return res;
-  });
   res.send = spy(() => {
     return res;
   });
   res.end = spy(() => {
     return res;
   });
-  res.getHeader = spy((name: string) => {
-    return name === 'Set-Cookie' ? mockNextJsPreviewCookies : undefined;
-  });
-  res.setHeader = spy();
   res.setPreviewData = spy(() => {
     return res;
   });
-  return res;
-};
-
-const mockFetcher = (html?: string) => {
-  const fetcher = {} as AxiosDataFetcher;
-  fetcher.get = spy<any>(() => {
-    return Promise.resolve({ data: html ?? '' });
+  res.setHeader = spy(() => {
+    return res;
   });
-  return fetcher;
+  res.redirect = spy(() => {
+    return res;
+  });
+
+  return res;
 };
 
 describe('FEAASRenderMiddleware', () => {
@@ -76,124 +63,71 @@ describe('FEAASRenderMiddleware', () => {
   });
 
   it('should handle request', async () => {
-    const html = '<html key="test1"><body key="test2">Something amazing</body></html>';
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
 
-    const fetcher = mockFetcher(html);
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({});
-    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
-    expect(fetcher.get).to.have.been.calledOnce;
-    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
-      match('http://localhost:3000/feaas/render?timestamp'),
-      {
-        headers: {
-          Cookie: mockNextJsPreviewCookies.join(';'),
-        },
-      }
-    );
-    expect(res.status).to.have.been.calledOnce;
-    expect(res.status).to.have.been.calledWith(200);
-    expect(res.send).to.have.been.calledOnce;
-    expect(res.send).to.have.been.calledWith(
-      '<html key="test1"><body key="test2">Something amazing</body></html>'
-    );
+    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith('/feaas/render');
   });
 
   it('should handle request when feaasSrc query parameter is present', async () => {
-    const html = '<html key="test1"><body key="test2">Something amazing</body></html>';
     const query = {
       feaasSrc: 'https://feaas.blob.core.windows.net/components/xxx/xyz/responsive/staged',
     } as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
 
-    const fetcher = mockFetcher(html);
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({});
-    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
-    expect(fetcher.get).to.have.been.calledOnce;
-    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
-      match(
-        'http://localhost:3000/feaas/render?feaasSrc=https%3A%2F%2Ffeaas.blob.core.windows.net%2Fcomponents%2Fxxx%2Fxyz%2Fresponsive%2Fstaged&timestamp'
-      ),
-      {
-        headers: {
-          Cookie: mockNextJsPreviewCookies.join(';'),
-        },
-      }
-    );
-    expect(res.status).to.have.been.calledOnce;
-    expect(res.status).to.have.been.calledWith(200);
-    expect(res.send).to.have.been.calledOnce;
-    expect(res.send).to.have.been.calledWith(
-      '<html key="test1"><body key="test2">Something amazing</body></html>'
+    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith(
+      '/feaas/render?feaasSrc=https%3A%2F%2Ffeaas.blob.core.windows.net%2Fcomponents%2Fxxx%2Fxyz%2Fresponsive%2Fstaged'
     );
   });
 
-  it('should throw error for page render request', async () => {
-    const html = '<html phkey="test1"><body phkey="test2">Error occured</body></html>';
+  it('should throw error', async () => {
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const previewData = {};
-
-    const fetcher = {} as AxiosDataFetcher;
-    fetcher.get = spy<any>(() => {
-      return Promise.reject({ response: { data: html, status: 500 } });
-    });
 
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
+    res.setPreviewData = spy(() => {
+      throw new Error('Test Error');
     });
+
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
-    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith(previewData);
-    expect(res.getHeader, 'get preview cookies').to.have.been.calledWith('Set-Cookie');
-    expect(fetcher.get).to.have.been.calledOnce;
-    expect(fetcher.get, 'pass along preview cookies').to.have.been.calledWith(
-      match('http://localhost:3000/feaas/render?timestamp'),
-      {
-        headers: {
-          Cookie: mockNextJsPreviewCookies.join(';'),
-        },
-      }
-    );
+    expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith({});
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(500);
-    expect(res.json).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<html><body>Error: Test Error</body></html>');
   });
 
   it('should respondWith 405 for unsupported method', async () => {
-    const fetcher = mockFetcher();
     const req = mockRequest({}, 'POST');
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
@@ -201,160 +135,65 @@ describe('FEAASRenderMiddleware', () => {
     expect(res.setHeader).to.have.been.calledWithExactly('Allow', 'GET');
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(405);
-    expect(res.json).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith(
+      "<html><body>Invalid request method 'POST'</body></html>"
+    );
   });
 
   it('should respond with 401 for missing secret', async () => {
-    const fetcher = mockFetcher();
     const query = {} as Query;
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(401);
-    expect(res.json).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<html><body>Missing or invalid secret</body></html>');
   });
 
   it('should respond with 401 for invalid secret', async () => {
-    const fetcher = mockFetcher();
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = 'nope';
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(401);
-    expect(res.json).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith('<html><body>Missing or invalid secret</body></html>');
   });
 
-  it('should use host header with http for serverUrl', async () => {
-    const html = '<html><body>Something amazing</body></html>';
-    const fetcher = mockFetcher(html);
-    const query = {} as Query;
-    query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(query, undefined, 'testhostheader.com');
-    const res = mockResponse();
-
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
-    const handler = middleware.getHandler();
-
-    await handler(req, res);
-
-    expect(fetcher.get).to.have.been.calledWithMatch('http://testhostheader.com');
-  });
-
-  it('should use https for serverUrl on Vercel', async () => {
-    const html = '<html><body>Something amazing</body></html>';
-    const fetcher = mockFetcher(html);
-    const query = {} as Query;
-    query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(query, undefined, 'vercel.com');
-    const res = mockResponse();
-    process.env.VERCEL = '1';
-
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
-    const handler = middleware.getHandler();
-
-    await handler(req, res);
-
-    expect(fetcher.get).to.have.been.calledWithMatch('https://vercel.com');
-
-    delete process.env.VERCEL;
-  });
-
-  it('should use custom resolveServerUrl', async () => {
-    const html = '<html><body>Something amazing</body></html>';
-    const fetcher = mockFetcher(html);
+  it('should use custom pageUrl', async () => {
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const serverUrl = 'https://test.com';
+    const pageUrl = '/some/path/feaas/render';
 
     const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-      resolveServerUrl: () => {
-        return serverUrl;
-      },
+      pageUrl,
     });
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
-    expect(fetcher.get).to.have.been.calledWithMatch(serverUrl);
-  });
-
-  it('should use custom resolvePageUrl', async () => {
-    const html = '<html><body>Something amazing</body></html>';
-    const fetcher = mockFetcher(html);
-    const query = {} as Query;
-    query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(query);
-    const res = mockResponse();
-
-    const serverUrl = 'https://test.com';
-    const expectedPageUrl = `${serverUrl}/some/path/feaas/render`;
-    const resolvePageUrl = spy((serverUrl: string) => {
-      return `${serverUrl}/some/path/feaas/render`;
-    });
-
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-      resolvePageUrl: resolvePageUrl,
-      resolveServerUrl: () => {
-        return serverUrl;
-      },
-    });
-    const handler = middleware.getHandler();
-
-    await handler(req, res);
-
-    expect(resolvePageUrl).to.have.been.calledOnce;
-    expect(resolvePageUrl).to.have.been.calledWith(serverUrl);
-    expect(fetcher.get).to.have.been.calledOnce;
-    expect(fetcher.get).to.have.been.calledWithMatch(expectedPageUrl);
-  });
-
-  it('should respondWith 500 if rendered html empty', async () => {
-    const fetcher = mockFetcher('');
-    const query = {} as Query;
-    query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(query);
-    const res = mockResponse();
-
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
-    const handler = middleware.getHandler();
-
-    await handler(req, res);
-
-    expect(res.status).to.have.been.calledOnce;
-    expect(res.status).to.have.been.calledWith(500);
-    expect(res.json).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith(pageUrl);
   });
 
   it('should pass along protection bypass query parameters', async () => {
-    const html = '<html phkey="test1"><body phkey="test2">Something amazing</body></html>';
     const query = {} as Query;
     const bypassTokenSitecore = 'token1234Sitecore';
     const bypassTokenVercel = 'token1234Vercel';
@@ -363,21 +202,18 @@ describe('FEAASRenderMiddleware', () => {
     query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = bypassTokenVercel;
     const previewData = {};
 
-    const fetcher = mockFetcher(html);
     const req = mockRequest(query);
     const res = mockResponse();
 
-    const middleware = new FEAASRenderMiddleware({
-      dataFetcher: fetcher,
-    });
+    const middleware = new FEAASRenderMiddleware();
     const handler = middleware.getHandler();
 
     await handler(req, res);
 
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith(previewData);
-    expect(fetcher.get).to.have.been.calledOnce;
-    expect(fetcher.get, 'pass along protection bypass query params').to.have.been.calledWithMatch(
-      `http://localhost:3000/feaas/render?${QUERY_PARAM_PROTECTION_BYPASS_SITECORE}=${bypassTokenSitecore}&${QUERY_PARAM_PROTECTION_BYPASS_VERCEL}=${bypassTokenVercel}&timestamp`
+    expect(res.redirect).to.have.been.calledOnce;
+    expect(res.redirect).to.have.been.calledWith(
+      '/feaas/render?x-sitecore-protection-bypass=token1234Sitecore&x-vercel-protection-bypass=token1234Vercel'
     );
   });
 });

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -35,9 +35,6 @@ const mockResponse = () => {
   res.send = spy(() => {
     return res;
   });
-  res.end = spy(() => {
-    return res;
-  });
   res.setPreviewData = spy(() => {
     return res;
   });

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
@@ -11,6 +11,7 @@ export interface FEAASRenderMiddlewareConfig {
   /**
    * Defines FEAAS page route to render.
    * This may be necessary for certain custom Next.js routing configurations.
+   * @default /feaas/render
    */
   pageUrl?: string;
 }

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
@@ -1,0 +1,152 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { debug } from '@sitecore-jss/sitecore-jss';
+import { QUERY_PARAM_EDITING_SECRET } from './constants';
+import { getJssEditingSecret } from '../utils/utils';
+import { RenderMiddlewareBase, RenderMiddlewareBaseConfig } from './render-middleware';
+
+/**
+ * Configuration for `FEAASRenderMiddleware`.
+ */
+export type FEAASRenderMiddlewareConfig = RenderMiddlewareBaseConfig & {
+  /**
+   * Function used to determine FEAAS page URL to render.
+   * This may be necessary for certain custom Next.js routing configurations.
+   * @param {string} serverUrl The root server URL e.g. 'http://localhost:3000'
+   * @returns {string} The URL to render
+   * @default `${serverUrl}/feaas/render`
+   * @see resolveServerUrl
+   */
+  resolvePageUrl?: (serverUrl: string) => string;
+};
+
+/**
+ * Middleware / handler for use in the feaas render Next.js API route (e.g. '/api/editing/feaas/render')
+ * which is required for Sitecore editing support.
+ */
+export class FEAASRenderMiddleware extends RenderMiddlewareBase {
+  private resolvePageUrl: (serverUrl: string) => string;
+
+  /**
+   * @param {EditingRenderMiddlewareConfig} [config] Editing render middleware config
+   */
+  constructor(protected config?: FEAASRenderMiddlewareConfig) {
+    super(config);
+
+    this.resolvePageUrl = config?.resolvePageUrl ?? this.defaultResolvePageUrl;
+  }
+
+  /**
+   * Gets the Next.js API route handler
+   * @returns route handler
+   */
+  public getHandler(): (req: NextApiRequest, res: NextApiResponse) => Promise<void> {
+    return this.handler;
+  }
+
+  private handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+    const { method, query, body, headers } = req;
+
+    const startTimestamp = Date.now();
+
+    debug.editing('feaas render middleware start: %o', {
+      method,
+      query,
+      headers,
+      body,
+    });
+
+    if (method !== 'GET') {
+      debug.editing('invalid method - sent %s expected GET', method);
+      res.setHeader('Allow', 'GET');
+      return res.status(405).json({
+        html: `<html><body>Invalid request method '${method}'</body></html>`,
+      });
+    }
+
+    // Validate secret
+    const secret = query[QUERY_PARAM_EDITING_SECRET];
+    if (secret !== getJssEditingSecret()) {
+      debug.editing(
+        'invalid editing secret - sent "%s" expected "%s"',
+        secret,
+        getJssEditingSecret()
+      );
+      return res.status(401).json({
+        html: '<html><body>Missing or invalid secret</body></html>',
+      });
+    }
+
+    try {
+      // Resolve server URL
+      const serverUrl = this.resolveServerUrl(req);
+
+      // Get query string parameters to propagate on subsequent requests (e.g. for deployment protection bypass)
+      const params = this.getQueryParamsForPropagation(query);
+
+      // Enable Next.js Preview Mode
+      res.setPreviewData({});
+
+      // Grab the Next.js preview cookies to send on to the render request
+      const cookies = res.getHeader('Set-Cookie') as string[];
+
+      // Make actual render request for page route, passing on preview cookies as well as any approved query string parameters.
+      // Note timestamp effectively disables caching the request in Axios (no amount of cache headers seemed to do it)
+      const requestUrl = new URL(this.resolvePageUrl(serverUrl));
+
+      for (const key in params) {
+        if ({}.hasOwnProperty.call(params, key)) {
+          requestUrl.searchParams.append(key, params[key]);
+        }
+      }
+
+      // Pass "feaasSrc" in case a FEAASComponent is being requested
+      if (query.feaasSrc) {
+        requestUrl.searchParams.append('feaasSrc', query.feaasSrc as string);
+      }
+
+      requestUrl.searchParams.append('timestamp', Date.now().toString());
+
+      debug.editing('fetching page route for %s', requestUrl.toString());
+
+      const pageRes = await this.dataFetcher.get<string>(requestUrl.toString(), {
+        headers: {
+          Cookie: cookies.join(';'),
+        },
+      });
+
+      const html = pageRes.data;
+
+      if (!html || html.length === 0) {
+        throw new Error('Failed to render html');
+      }
+
+      // Return expected JSON result
+      debug.editing('feaas render middleware end in %dms: %o', Date.now() - startTimestamp, {
+        status: 200,
+        html,
+      });
+      res.status(200).send(html);
+    } catch (err) {
+      const error = err as Record<string, unknown>;
+
+      if (error.response || error.request) {
+        // Axios error, which could mean the server or page URL isn't quite right, so provide a more helpful hint
+        console.info(
+          // eslint-disable-next-line quotes
+          "Hint: for non-standard server or Next.js route configurations, you may need to override the 'resolveServerUrl' or 'resolvePageUrl' available on the 'FEAASRenderMiddleware' config."
+        );
+      }
+      res.status(500).json({
+        html: `<html><body>${error}</body></html>`,
+      });
+    }
+  };
+
+  /**
+   * Default FEAAS page URL resolution.
+   * @param {string} serverUrl The root server URL e.g. 'http://localhost:3000'
+   */
+  private defaultResolvePageUrl = (serverUrl: string) => {
+    return `${serverUrl}/feaas/render`;
+  };
+}

--- a/packages/sitecore-jss-nextjs/src/editing/index.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/index.ts
@@ -15,3 +15,4 @@ export {
   editingDataService,
 } from './editing-data-service';
 export { VercelEditingDataCache } from './vercel-editing-data-cache';
+export { FEAASRenderMiddleware, FEAASRenderMiddlewareConfig } from './feaas-render-middleware';

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable dot-notation */
+import chai, { use } from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiString from 'chai-string';
+import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
+import { RenderMiddlewareBase } from './render-middleware';
+import { NextApiRequest } from 'next';
+import {
+  QUERY_PARAM_EDITING_SECRET,
+  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
+  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+} from './constants';
+
+use(sinonChai);
+const expect = chai.use(chaiString).expect;
+
+type Query = {
+  [key: string]: string;
+};
+
+describe('RenderMiddlewareBase', () => {
+  class SampleMiddleware extends RenderMiddlewareBase {}
+
+  const mockFetcher = () => ({} as AxiosDataFetcher);
+
+  describe('defaultResolveServerUrl', () => {
+    it('should use https protocol on Vercel', async () => {
+      process.env.VERCEL = '1';
+
+      const middleware = new SampleMiddleware();
+
+      const url = middleware['defaultResolveServerUrl']({
+        headers: { host: 'localhost' },
+      } as NextApiRequest);
+
+      expect(url).to.equal('https://localhost');
+
+      delete process.env.VERCEL;
+    });
+
+    it('should use http protocol', async () => {
+      const middleware = new SampleMiddleware();
+
+      const url = middleware['defaultResolveServerUrl']({
+        headers: { host: 'localhost' },
+      } as NextApiRequest);
+
+      expect(url).to.equal('http://localhost');
+    });
+  });
+
+  it('should use custom resolveServerUrl', async () => {
+    const serverUrl = 'https://test.com';
+
+    const middleware = new SampleMiddleware({
+      resolveServerUrl: () => serverUrl,
+    });
+
+    expect(middleware['resolveServerUrl']({} as NextApiRequest)).to.equal(serverUrl);
+  });
+
+  it('should use custom dataFetcher', () => {
+    const dataFetcher = mockFetcher();
+
+    const middleware = new SampleMiddleware({
+      dataFetcher,
+    });
+
+    expect(middleware['dataFetcher']).to.equal(dataFetcher);
+  });
+
+  describe('getQueryParamsForPropagation', () => {
+    it('should construct query params for protection bypass', () => {
+      const middleware = new SampleMiddleware();
+
+      const secret = 'secret1234';
+      const query = {} as Query;
+      const bypassTokenSitecore = 'token1234Sitecore';
+      const bypassTokenVercel = 'token1234Vercel';
+      query[QUERY_PARAM_EDITING_SECRET] = secret;
+      query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = bypassTokenSitecore;
+      query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = bypassTokenVercel;
+
+      expect(middleware['getQueryParamsForPropagation'](query)).to.deep.equal({
+        [QUERY_PARAM_PROTECTION_BYPASS_SITECORE]: bypassTokenSitecore,
+        [QUERY_PARAM_PROTECTION_BYPASS_VERCEL]: bypassTokenVercel,
+      });
+    });
+  });
+});

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
@@ -2,9 +2,7 @@
 import chai, { use } from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiString from 'chai-string';
-import { AxiosDataFetcher } from '@sitecore-jss/sitecore-jss';
 import { RenderMiddlewareBase } from './render-middleware';
-import { NextApiRequest } from 'next';
 import {
   QUERY_PARAM_EDITING_SECRET,
   QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
@@ -20,54 +18,6 @@ type Query = {
 
 describe('RenderMiddlewareBase', () => {
   class SampleMiddleware extends RenderMiddlewareBase {}
-
-  const mockFetcher = () => ({} as AxiosDataFetcher);
-
-  describe('defaultResolveServerUrl', () => {
-    it('should use https protocol on Vercel', async () => {
-      process.env.VERCEL = '1';
-
-      const middleware = new SampleMiddleware();
-
-      const url = middleware['defaultResolveServerUrl']({
-        headers: { host: 'localhost' },
-      } as NextApiRequest);
-
-      expect(url).to.equal('https://localhost');
-
-      delete process.env.VERCEL;
-    });
-
-    it('should use http protocol', async () => {
-      const middleware = new SampleMiddleware();
-
-      const url = middleware['defaultResolveServerUrl']({
-        headers: { host: 'localhost' },
-      } as NextApiRequest);
-
-      expect(url).to.equal('http://localhost');
-    });
-  });
-
-  it('should use custom resolveServerUrl', async () => {
-    const serverUrl = 'https://test.com';
-
-    const middleware = new SampleMiddleware({
-      resolveServerUrl: () => serverUrl,
-    });
-
-    expect(middleware['resolveServerUrl']({} as NextApiRequest)).to.equal(serverUrl);
-  });
-
-  it('should use custom dataFetcher', () => {
-    const dataFetcher = mockFetcher();
-
-    const middleware = new SampleMiddleware({
-      dataFetcher,
-    });
-
-    expect(middleware['dataFetcher']).to.equal(dataFetcher);
-  });
 
   describe('getQueryParamsForPropagation', () => {
     it('should construct query params for protection bypass', () => {

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable dot-notation */
-import chai, { use } from 'chai';
-import sinonChai from 'sinon-chai';
+import chai from 'chai';
 import chaiString from 'chai-string';
 import { RenderMiddlewareBase } from './render-middleware';
 import {
@@ -9,7 +8,6 @@ import {
   QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
 } from './constants';
 
-use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
 type Query = {

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
@@ -1,0 +1,75 @@
+import { AxiosDataFetcher, debug } from '@sitecore-jss/sitecore-jss';
+import { NextApiRequest } from 'next';
+import {
+  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
+  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+} from './constants';
+
+/**
+ * Configuration for `RenderMiddlewareBase`.
+ */
+export type RenderMiddlewareBaseConfig = {
+  /**
+   * The `AxiosDataFetcher` instance to use for API requests.
+   * @default new AxiosDataFetcher()
+   * @see AxiosDataFetcher
+   */
+  dataFetcher?: AxiosDataFetcher;
+  /**
+   * Function used to determine the root server URL. This is used for the route/page and subsequent data API requests.
+   * By default, the host header is used, with https protocol on Vercel (due to serverless function architecture) and http protocol elsewhere.
+   * @param {NextApiRequest} req The current request.
+   * @default `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
+   * @see resolvePageUrl
+   */
+  resolveServerUrl?: (req: NextApiRequest) => string;
+};
+
+/**
+ * Base class for middleware that handles pages and components rendering in Sitecore Editors.
+ */
+export abstract class RenderMiddlewareBase {
+  protected dataFetcher: AxiosDataFetcher;
+  protected resolveServerUrl: (req: NextApiRequest) => string;
+
+  constructor(protected config?: RenderMiddlewareBaseConfig) {
+    this.dataFetcher = config?.dataFetcher ?? new AxiosDataFetcher({ debugger: debug.editing });
+    this.resolveServerUrl = config?.resolveServerUrl ?? this.defaultResolveServerUrl;
+  }
+
+  /**
+   * Gets query parameters that should be passed along to subsequent requests
+   * @param {Object} query Object of query parameters from incoming URL
+   * @returns Object of approved query parameters
+   */
+  protected getQueryParamsForPropagation = (
+    query: Partial<{ [key: string]: string | string[] }>
+  ): { [key: string]: string } => {
+    const params: { [key: string]: string } = {};
+    if (query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE]) {
+      params[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = query[
+        QUERY_PARAM_PROTECTION_BYPASS_SITECORE
+      ] as string;
+    }
+    if (query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL]) {
+      params[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = query[
+        QUERY_PARAM_PROTECTION_BYPASS_VERCEL
+      ] as string;
+    }
+    return params;
+  };
+
+  /**
+   * Default server URL resolution.
+   * Note we use https protocol on Vercel due to serverless function architecture.
+   * In all other scenarios, including localhost (with or without a proxy e.g. ngrok)
+   * and within a nodejs container, http protocol should be used.
+   *
+   * For information about the VERCEL environment variable, see
+   * https://vercel.com/docs/environment-variables#system-environment-variables
+   * @param {NextApiRequest} req
+   */
+  private defaultResolveServerUrl = (req: NextApiRequest) => {
+    return `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
+  };
+}

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
@@ -1,44 +1,14 @@
-import { AxiosDataFetcher, debug } from '@sitecore-jss/sitecore-jss';
-import { NextApiRequest } from 'next';
 import {
   QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
   QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
 } from './constants';
 
 /**
- * Configuration for `RenderMiddlewareBase`.
- */
-export type RenderMiddlewareBaseConfig = {
-  /**
-   * The `AxiosDataFetcher` instance to use for API requests.
-   * @default new AxiosDataFetcher()
-   * @see AxiosDataFetcher
-   */
-  dataFetcher?: AxiosDataFetcher;
-  /**
-   * Function used to determine the root server URL. This is used for the route/page and subsequent data API requests.
-   * By default, the host header is used, with https protocol on Vercel (due to serverless function architecture) and http protocol elsewhere.
-   * @param {NextApiRequest} req The current request.
-   * @default `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
-   * @see resolvePageUrl
-   */
-  resolveServerUrl?: (req: NextApiRequest) => string;
-};
-
-/**
  * Base class for middleware that handles pages and components rendering in Sitecore Editors.
  */
 export abstract class RenderMiddlewareBase {
-  protected dataFetcher: AxiosDataFetcher;
-  protected resolveServerUrl: (req: NextApiRequest) => string;
-
-  constructor(protected config?: RenderMiddlewareBaseConfig) {
-    this.dataFetcher = config?.dataFetcher ?? new AxiosDataFetcher({ debugger: debug.editing });
-    this.resolveServerUrl = config?.resolveServerUrl ?? this.defaultResolveServerUrl;
-  }
-
   /**
-   * Gets query parameters that should be passed along to subsequent requests
+   * Gets query parameters that should be passed along to subsequent requests (e.g. for deployment protection bypass)
    * @param {Object} query Object of query parameters from incoming URL
    * @returns Object of approved query parameters
    */
@@ -57,19 +27,5 @@ export abstract class RenderMiddlewareBase {
       ] as string;
     }
     return params;
-  };
-
-  /**
-   * Default server URL resolution.
-   * Note we use https protocol on Vercel due to serverless function architecture.
-   * In all other scenarios, including localhost (with or without a proxy e.g. ngrok)
-   * and within a nodejs container, http protocol should be used.
-   *
-   * For information about the VERCEL environment variable, see
-   * https://vercel.com/docs/environment-variables#system-environment-variables
-   * @param {NextApiRequest} req
-   */
-  private defaultResolveServerUrl = (req: NextApiRequest) => {
-    return `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
Added a new endpoint to enable Component Builder to work with BYOC components registered in a JSS application

- The `FEAASRenderMiddleware` ( _/api/editing/feaas/render_) will

  1) Enable Next.js Preview Mode.
  2) Redirect to the /feaas/render page.

> NOTE: Handles Vercel protection bypass, custom server url etc.

If "src" query parameter is provided, the page will render a FEAAS component.
The page provides all the registered FEAAS components

- The `FEAASRender` (_/feaas/render_) page is responsible for

  1) Rendering the FEAAS component if the "feaasSrc" is provided.
  2) Rendering all the registered components.
  3) The page is rendered only if it's requested by the api route (/api/editing/feaas/render) using the preview mode.

- Introduced a common `RenderMiddleware`

<!--
- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
