### PR TITLE
[templates/nextjs] Add default image remotePatterns config for whitelisting remote image hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715) [#1716](https://github.com/Sitecore/jss/pull/1716))
 * `[sitecore-jss-nextjs]` Remove custom loader function i.e. `sitecoreLoader` to enable NextImage to use built-in image optimization from vercel. ([#1726](https://github.com/Sitecore/jss/pull/1726))
 * `[sitecore-jss-nextjs]` Fix redirects middleware for working with absolute url where is using site language context ([#1727](https://github.com/Sitecore/jss/pull/1727))
+* `[templates/nextjs]` Add default image remotePatterns in next.config.js for whitelisting remote image hostnames so that can be served by the Next.js Image Optimization API ([#1732](https://github.com/Sitecore/jss/pull/1732))
 
 ### 🛠 Breaking Changes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -30,6 +30,19 @@ const nextConfig = {
   // Enable React Strict Mode
   reactStrictMode: true,
 
+  // use this configuration to ensure that only images from the whitelisted domains
+  // can be served from the Next.js Image Optimization API
+  // see https://nextjs.org/docs/app/api-reference/components/image#remotepatterns
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'edge.**',
+        port: '',
+      },
+    ],
+  },
+
   async rewrites() {
     // When in connected mode we want to proxy Sitecore paths off to Sitecore
     return [

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -37,7 +37,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'edge.**',
+        hostname: 'edge*.**',
         port: '',
       },
     ],


### PR DESCRIPTION
… hostnames

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds default image remotePatterns configuration for whitelisting remove image hostnames.
Only Images from the whitelisted hostnames will be served from the Next.js Image Optimization API - see https://nextjs.org/docs/app/api-reference/components/image#remotepatterns 

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
