### PR TITLE
[sitecore-jss] Optimize initial Retry delay time

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 package.json
+changelog.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 package.json
-changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,7 +617,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss]` Retry policy to handle transient network errors. Users can pass `retryStrategy` to configure custom retry config to the services. They can customize the error codes and the number of retries. It consist of two functions shouldRetry and getDelay. ([#1731](https://github.com/Sitecore/jss/pull/1731))
+* `[sitecore-jss]` Retry policy to handle transient network errors. Users can pass `retryStrategy` to configure custom retry config to the services. They can customize the error codes and the number of retries. It consist of two functions shouldRetry and getDelay. To determine the back-off time, we employ an exponential strategy with a default factor of 2.([#1731](https://github.com/Sitecore/jss/pull/1731)) ([#1733](https://github.com/Sitecore/jss/pull/1733))
 
 ## 20.2.3
 

--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -407,7 +407,7 @@ describe('GraphQLRequestClient', () => {
     });
   });
 
-  describe.only('DefaultRetryStrategy class', () => {
+  describe.only('DefaultRetryStrategy', () => {
     const mockClientError = new ClientError(
       {
         data: undefined,
@@ -422,7 +422,7 @@ describe('GraphQLRequestClient', () => {
 
     const retryStrategy = new DefaultRetryStrategy([429, 503]);
 
-    it('should return false from shouldRetry method when conditions are not met', () => {
+    it('should return true from shouldRetry when conditions are met', () => {
       mockClientError.response.status = 503;
 
       const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 3);

--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -419,34 +419,34 @@ describe('GraphQLRequestClient', () => {
         query: 'query',
       }
     );
-
-    const retryStrategy = new DefaultRetryStrategy({ statusCodes: [429, 503] });
-
-    it('should return true from shouldRetry when conditions are met', () => {
-      mockClientError.response.status = 503;
+    it('should return true from shouldRetry and use default values from constructor', () => {
+      const retryStrategy = new DefaultRetryStrategy();
 
       const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 3);
       expect(shouldRetry).to.equal(true);
     });
 
     it('should return false when attempt exceeds retries', () => {
+      const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
       mockClientError.response.status = 503;
 
       const shouldRetry = retryStrategy.shouldRetry(mockClientError, 2, 1);
       expect(shouldRetry).to.equal(false);
     });
 
-    it('should return delay using exponential backoff when Retry-After header is not present', () => {
-      const delay = retryStrategy.getDelay(mockClientError, 3);
-      const expectedDelay = Math.pow(retryStrategy['factor'], 3 - 1) * 1000;
-      expect(delay).to.equal(expectedDelay);
-    });
-
     it('should return false when retries is 0', () => {
+      const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
       mockClientError.response.status = 503;
 
       const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 0);
       expect(shouldRetry).to.equal(false);
+    });
+
+    it('should return delay using exponential backoff when Retry-After header is not present', () => {
+      const retryStrategy = new DefaultRetryStrategy();
+      const delay = retryStrategy.getDelay(mockClientError, 3);
+      const expectedDelay = Math.pow(retryStrategy['factor'], 3 - 1) * 1000;
+      expect(delay).to.equal(expectedDelay);
     });
 
     it('should use custom exponential factor', () => {

--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -407,7 +407,7 @@ describe('GraphQLRequestClient', () => {
     });
   });
 
-  describe.only('DefaultRetryStrategy', () => {
+  describe('DefaultRetryStrategy', () => {
     const mockClientError = new ClientError(
       {
         data: undefined,

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -96,7 +96,7 @@ export class DefaultRetryStrategy implements RetryStrategy {
    * @param {number[]} options.statusCodes HTTP status codes to trigger retries on
    * @param {number} options.factor Factor by which the delay increases with each retry attempt
    */
-  constructor(options: { statusCodes?: number[]; factor?: number }) {
+  constructor(options: { statusCodes?: number[]; factor?: number } = {}) {
     this.statusCodes = options.statusCodes || [429];
     this.factor = options.factor || 2;
   }

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -113,7 +113,7 @@ export class DefaultRetryStrategy implements RetryStrategy {
     const rawHeaders = error.response?.headers;
     const delaySeconds = rawHeaders?.get('Retry-After')
       ? Number.parseInt(rawHeaders?.get('Retry-After'), 10)
-      : Math.pow(this.factor, attempt);
+      : Math.pow(this.factor, attempt - 1);
 
     return delaySeconds * 1000;
   }

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -92,12 +92,13 @@ export class DefaultRetryStrategy implements RetryStrategy {
   private factor: number;
 
   /**
-   * @param {number[]} statusCodes HTTP status codes to trigger retries on
-   * @param {number} factor Factor by which the delay increases with each retry attempt
+   * @param {Object} options Configurable options for retry mechanism.
+   * @param {number[]} options.statusCodes HTTP status codes to trigger retries on
+   * @param {number} options.factor Factor by which the delay increases with each retry attempt
    */
-  constructor(statusCodes?: number[], factor?: number) {
-    this.statusCodes = statusCodes || [429];
-    this.factor = factor || 2;
+  constructor(options: { statusCodes?: number[]; factor?: number }) {
+    this.statusCodes = options.statusCodes || [429];
+    this.factor = options.factor || 2;
   }
 
   shouldRetry(error: ClientError, attempt: number, retries: number): boolean {
@@ -152,7 +153,7 @@ export class GraphQLRequestClient implements GraphQLClient {
     this.retries = clientConfig.retries || 0;
     this.retryStrategy =
       clientConfig.retryStrategy ||
-      new DefaultRetryStrategy([429, 502, 503, 504, 520, 521, 522, 523, 524]);
+      new DefaultRetryStrategy({ statusCodes: [429, 502, 503, 504, 520, 521, 522, 523, 524] });
     this.client = new Client(endpoint, {
       headers: this.headers,
       fetch: clientConfig.fetch,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
At present, the initial retry delay evaluated to 2 seconds, which becomes relatively high for subsequent retries when assessed in an exponential manner. We aim to initiate the first retry after a 1-second wait instead.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
