### PR TITLE
[sitecore-jss][templates/nextjs-xmcloud] Enable site query in XMCloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Our versioning strategy is as follows:
 * `[templates/nextjs-xmcloud]` `[sitecore-jss]` `[sitecore-jss-nextjs]` `[sitecore-jss-react]` Add support for loading appropriate stylesheets whenever a theme is applied to BYOC and SXA components by introducing new function getComponentLibraryStylesheetLinks, which replaces getFEAASLibraryStylesheetLinks (which has been marked as deprecated) ([#1722](https://github.com/Sitecore/jss/pull/1722)) 
 * `[templates/nextjs-xmcloud]` `[sitecore-jss-nextjs]` Add protected endpoint which provides configuration information (the sitecore packages used by the app and all registered components) to be used to determine feature compatibility on Pages side. ([#1724](https://github.com/Sitecore/jss/pull/1724) [#1734](https://github.com/Sitecore/jss/pull/1734)) 
 * `[sitecore-jss-nextjs]` `[templates/nextjs]` [BYOC] Component Builder integration endpoint ([#1729](https://github.com/Sitecore/jss/pull/1729))
+* `[sitecore-jss]` `[templates/nextjs-xmcloud]` Enable site GraphQL query for mutlisite in XMCloud instead of default search one. Site query should take "Valid for environment" SXA site setting into account when returning site list. ([#1739](https://github.com/Sitecore/jss/pull/1739))
+  * To enable this on your existing app, modify  src\lib\graphql-client-factory\create.ts and add "xmCloud: true" to clientConfig
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs-xmcloud]` `[sitecore-jss-nextjs]` Add protected endpoint which provides configuration information (the sitecore packages used by the app and all registered components) to be used to determine feature compatibility on Pages side. ([#1724](https://github.com/Sitecore/jss/pull/1724) [#1734](https://github.com/Sitecore/jss/pull/1734)) 
 * `[sitecore-jss-nextjs]` `[templates/nextjs]` [BYOC] Component Builder integration endpoint ([#1729](https://github.com/Sitecore/jss/pull/1729))
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Enable site GraphQL query for mutlisite in XMCloud instead of default search one. Site query should take "Valid for environment" SXA site setting into account when returning site list. ([#1739](https://github.com/Sitecore/jss/pull/1739))
-  * To enable this on your existing app, modify  src\lib\graphql-client-factory\create.ts and add "xmCloud: true" to clientConfig
+  * To enable this on your existing app, modify the \scripts\config\plugins\multisite.ts file and add "xmCloud: true" to GraphQLSiteInfoService constructor call
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs-xmcloud]` `[sitecore-jss-nextjs]` Add protected endpoint which provides configuration information (the sitecore packages used by the app and all registered components) to be used to determine feature compatibility on Pages side. ([#1724](https://github.com/Sitecore/jss/pull/1724) [#1734](https://github.com/Sitecore/jss/pull/1734)) 
 * `[sitecore-jss-nextjs]` `[templates/nextjs]` [BYOC] Component Builder integration endpoint ([#1729](https://github.com/Sitecore/jss/pull/1729))
 * `[sitecore-jss]` `[templates/nextjs-xmcloud]` Enable site GraphQL query for mutlisite in XMCloud instead of default search one. Site query should take "Valid for environment" SXA site setting into account when returning site list. ([#1739](https://github.com/Sitecore/jss/pull/1739))
-  * To enable this on your existing app, modify the \scripts\config\plugins\multisite.ts file and add "xmCloud: true" to GraphQLSiteInfoService constructor call
+  * To enable this on your existing app, modify the \scripts\config\plugins\multisite.ts file and add "useSiteQuery: true" to GraphQLSiteInfoService constructor call
 
 ### 🐛 Bug Fixes
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -19,7 +19,8 @@ class MultisitePlugin implements ConfigPlugin {
       const siteInfoService = new GraphQLSiteInfoService({
         clientFactory: createGraphQLClientFactory(config),
         <% if (templates.includes("nextjs-xmcloud")) { -%>
-        xmCloud: true,
+        // enable site query for the service. Only works on XMCloud currently
+        useSiteQuery: true,
         <% } -%>
       });
       sites = await siteInfoService.fetchSiteInfo();

--- a/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-multisite/scripts/config/plugins/multisite.ts
@@ -18,6 +18,9 @@ class MultisitePlugin implements ConfigPlugin {
     try {
       const siteInfoService = new GraphQLSiteInfoService({
         clientFactory: createGraphQLClientFactory(config),
+        <% if (templates.includes("nextjs-xmcloud")) { -%>
+        xmCloud: true,
+        <% } -%>
       });
       sites = await siteInfoService.fetchSiteInfo();
     } catch (error) {

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/graphql-client-factory/create.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/graphql-client-factory/create.ts
@@ -16,13 +16,11 @@ export const createGraphQLClientFactory = (config: JssConfig) => {
   if (config.sitecoreEdgeContextId) {
     clientConfig = {
       endpoint: getEdgeProxyContentUrl(config.sitecoreEdgeContextId, config.sitecoreEdgeUrl),
-      xmCloud: true,
     };
   } else if (config.graphQLEndpoint && config.sitecoreApiKey) {
     clientConfig = {
       endpoint: config.graphQLEndpoint,
       apiKey: config.sitecoreApiKey,
-      xmCloud: true,
     };
   } else {
     throw new Error(

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/graphql-client-factory/create.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/lib/graphql-client-factory/create.ts
@@ -16,11 +16,13 @@ export const createGraphQLClientFactory = (config: JssConfig) => {
   if (config.sitecoreEdgeContextId) {
     clientConfig = {
       endpoint: getEdgeProxyContentUrl(config.sitecoreEdgeContextId, config.sitecoreEdgeUrl),
+      xmCloud: true,
     };
   } else if (config.graphQLEndpoint && config.sitecoreApiKey) {
     clientConfig = {
       endpoint: config.graphQLEndpoint,
       apiKey: config.sitecoreApiKey,
+      xmCloud: true,
     };
   } else {
     throw new Error(

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -80,7 +80,11 @@ export type GraphQLRequestClientFactory = (
 /**
  * Configuration type for @type GraphQLRequestClientFactory
  */
-export type GraphQLRequestClientFactoryConfig = { endpoint: string; apiKey?: string };
+export type GraphQLRequestClientFactoryConfig = {
+  endpoint: string;
+  apiKey?: string;
+  xmCloud?: boolean;
+};
 
 /**
  * Represents a default retry strategy for handling retry attempts in case of specific HTTP status codes.

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -83,7 +83,6 @@ export type GraphQLRequestClientFactory = (
 export type GraphQLRequestClientFactoryConfig = {
   endpoint: string;
   apiKey?: string;
-  xmCloud?: boolean;
 };
 
 /**

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
@@ -317,8 +317,8 @@ describe('GraphQLSiteInfoService', () => {
       },
     };
 
-    const getXmCLoudSiteInfoService = (initProps: { [key: string]: unknown }) => {
-      return new GraphQLSiteInfoService({ xmCloud: true, ...initProps });
+    const getSiteQuerySiteInfoService = (initProps: { [key: string]: unknown }) => {
+      return new GraphQLSiteInfoService({ useSiteQuery: true, ...initProps });
     };
 
     it('should return correct result', async () => {
@@ -333,7 +333,7 @@ describe('GraphQLSiteInfoService', () => {
           ],
         })
       );
-      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const service = getSiteQuerySiteInfoService({ apiKey: apiKey, endpoint: endpoint });
       const result = await service.fetchSiteInfo();
       expect(result).to.be.deep.equal([
         {
@@ -365,7 +365,7 @@ describe('GraphQLSiteInfoService', () => {
         endpoint,
         apiKey,
       });
-      const service = getXmCLoudSiteInfoService({ clientFactory });
+      const service = getSiteQuerySiteInfoService({ clientFactory });
       const result = await service.fetchSiteInfo();
       expect(result).to.be.deep.equal([
         {
@@ -385,7 +385,7 @@ describe('GraphQLSiteInfoService', () => {
       nock(endpoint)
         .post('/')
         .reply(200, emptyResponse);
-      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const service = getSiteQuerySiteInfoService({ apiKey: apiKey, endpoint: endpoint });
       const result = await service.fetchSiteInfo();
       expect(result).to.deep.equal([]);
     });
@@ -402,7 +402,7 @@ describe('GraphQLSiteInfoService', () => {
           ],
         })
       );
-      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const service = getSiteQuerySiteInfoService({ apiKey: apiKey, endpoint: endpoint });
       const result = await service.fetchSiteInfo();
       expect(result).to.be.deep.equal([
         {

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.test.ts
@@ -3,7 +3,11 @@
 import { expect, spy, use } from 'chai';
 import spies from 'chai-spies';
 import nock from 'nock';
-import { GraphQLSiteInfoService, GraphQLSiteInfoResult } from './graphql-siteinfo-service';
+import {
+  GraphQLSiteInfoService,
+  GraphQLSiteInfoResult,
+  GraphQLXmCloudSiteInfoResult,
+} from './graphql-siteinfo-service';
 import { GraphQLRequestClient, PageInfo } from '../graphql';
 import debugApi from 'debug';
 import debug from '../debug';
@@ -265,5 +269,148 @@ describe('GraphQLSiteInfoService', () => {
     expect(result).to.deep.equal([]);
     expect(debug.multisite.log, 'log debug message').to.be.called.once;
     expect(nock.isDone(), 'skip request').to.be.false;
+  });
+
+  describe('Fetch with site query in XM Cloud', () => {
+    const site = ({
+      name,
+      hostName,
+      language,
+    }: {
+      name: string;
+      hostName: string;
+      language: string;
+    }): GraphQLXmCloudSiteInfoResult => ({
+      name,
+      hostName,
+      language,
+    });
+
+    const nonEmptyResponse = ({
+      count = 1,
+      sites = [],
+    }: {
+      count?: number;
+      sites?: GraphQLXmCloudSiteInfoResult[];
+    } = {}) => ({
+      data: {
+        site: {
+          siteInfoCollection: [
+            ...[...Array(count).keys()].map((n) =>
+              site({
+                name: `site ${n}`,
+                hostName: 'restricted.gov',
+                language: 'en',
+              })
+            ),
+            ...sites,
+          ],
+        },
+      },
+    });
+
+    const emptyResponse = {
+      data: {
+        site: {
+          siteInfoCollection: [],
+        },
+      },
+    };
+
+    const getXmCLoudSiteInfoService = (initProps: { [key: string]: unknown }) => {
+      return new GraphQLSiteInfoService({ xmCloud: true, ...initProps });
+    };
+
+    it('should return correct result', async () => {
+      mockSiteInfoRequest(
+        nonEmptyResponse({
+          sites: [
+            site({
+              name: 'public 0',
+              hostName: 'pr.showercurtains.org',
+              language: '',
+            }),
+          ],
+        })
+      );
+      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const result = await service.fetchSiteInfo();
+      expect(result).to.be.deep.equal([
+        {
+          name: 'site 0',
+          hostName: 'restricted.gov',
+          language: 'en',
+        },
+        {
+          name: 'public 0',
+          hostName: 'pr.showercurtains.org',
+          language: '',
+        },
+      ]);
+    });
+
+    it('should return correct result using clientFactory', async () => {
+      mockSiteInfoRequest(
+        nonEmptyResponse({
+          sites: [
+            site({
+              name: 'public 0',
+              hostName: 'pr.showercurtains.org',
+              language: '',
+            }),
+          ],
+        })
+      );
+      const clientFactory = GraphQLRequestClient.createClientFactory({
+        endpoint,
+        apiKey,
+      });
+      const service = getXmCLoudSiteInfoService({ clientFactory });
+      const result = await service.fetchSiteInfo();
+      expect(result).to.be.deep.equal([
+        {
+          name: 'site 0',
+          hostName: 'restricted.gov',
+          language: 'en',
+        },
+        {
+          name: 'public 0',
+          hostName: 'pr.showercurtains.org',
+          language: '',
+        },
+      ]);
+    });
+
+    it('should return empty array when empty result received', async () => {
+      nock(endpoint)
+        .post('/')
+        .reply(200, emptyResponse);
+      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const result = await service.fetchSiteInfo();
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should filter out default website', async () => {
+      mockSiteInfoRequest(
+        nonEmptyResponse({
+          sites: [
+            site({
+              name: 'website',
+              hostName: 'notheadless.org',
+              language: '',
+            }),
+          ],
+        })
+      );
+      const service = getXmCLoudSiteInfoService({ apiKey: apiKey, endpoint: endpoint });
+      const result = await service.fetchSiteInfo();
+      expect(result).to.be.deep.equal([
+        {
+          name: 'site 0',
+          hostName: 'restricted.gov',
+          language: 'en',
+        },
+      ]);
+    });
   });
 });

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -39,6 +39,18 @@ const defaultQuery = /* GraphQL */ `
   }
 `;
 
+const xmCloudQuery = /* GraphQL */ `
+  query {
+    site {
+      siteInfoCollection {
+        name
+        hostName: hostname
+        language
+      }
+    }
+  }
+`;
+
 export type SiteInfo = {
   /**
    * Additional user-defined properties
@@ -80,6 +92,10 @@ export type GraphQLSiteInfoServiceConfig = CacheOptions & {
    * This factory function is used to create and configure GraphQL clients for making GraphQL API requests.
    */
   clientFactory?: GraphQLRequestClientFactory;
+  /**
+   * Boolean indicating if app is running for xm cloud
+   */
+  xmCloud?: boolean;
 };
 
 type GraphQLSiteInfoResponse = {
@@ -101,12 +117,28 @@ export type GraphQLSiteInfoResult = {
   };
 };
 
+type GraphQLXmCloudSiteInfoResponse = {
+  site: {
+    siteInfoCollection: GraphQLXmCloudSiteInfoResult[];
+  };
+};
+
+export type GraphQLXmCloudSiteInfoResult = {
+  name: string;
+  hostName: string;
+  language: string;
+};
+
 export class GraphQLSiteInfoService {
   private graphQLClient: GraphQLClient;
   private cache: CacheClient<SiteInfo[]>;
 
   protected get query(): string {
     return defaultQuery;
+  }
+
+  protected get xmCloudQuery(): string {
+    return xmCloudQuery;
   }
 
   /**
@@ -128,6 +160,15 @@ export class GraphQLSiteInfoService {
       return [];
     }
 
+    const results: SiteInfo[] = this.config.xmCloud
+      ? await this.fetchWithSiteQuery()
+      : await this.fetchWithDefaultQuery();
+
+    this.cache.setCacheValue(this.getCacheKey(), results);
+    return results;
+  }
+
+  protected async fetchWithDefaultQuery(): Promise<SiteInfo[]> {
     const results: SiteInfo[] = [];
     let hasNext = true;
     let after = '';
@@ -150,8 +191,27 @@ export class GraphQLSiteInfoService {
       hasNext = response.search.pageInfo.hasNext;
       after = response.search.pageInfo.endCursor;
     }
+    return results;
+  }
 
-    this.cache.setCacheValue(this.getCacheKey(), results);
+  protected async fetchWithSiteQuery(): Promise<SiteInfo[]> {
+    const results: SiteInfo[] = [];
+
+    const response = await this.graphQLClient.request<GraphQLXmCloudSiteInfoResponse>(
+      this.xmCloudQuery
+    );
+    const result = response?.site?.siteInfoCollection?.reduce<SiteInfo[]>((result, current) => {
+      // filter out built in website
+      current.name !== 'website' &&
+        result.push({
+          name: current.name,
+          hostName: current.hostName,
+          language: current.language,
+        });
+      return result;
+    }, []);
+
+    results.push(...result);
     return results;
   }
 

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -195,8 +195,6 @@ export class GraphQLSiteInfoService {
   }
 
   protected async fetchWithSiteQuery(): Promise<SiteInfo[]> {
-    const results: SiteInfo[] = [];
-
     const response = await this.graphQLClient.request<GraphQLXmCloudSiteInfoResponse>(
       this.xmCloudQuery
     );
@@ -211,8 +209,7 @@ export class GraphQLSiteInfoService {
       return result;
     }, []);
 
-    results.push(...result);
-    return results;
+    return result;
   }
 
   /**

--- a/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-siteinfo-service.ts
@@ -39,7 +39,7 @@ const defaultQuery = /* GraphQL */ `
   }
 `;
 
-const xmCloudQuery = /* GraphQL */ `
+const siteQuery = /* GraphQL */ `
   query {
     site {
       siteInfoCollection {
@@ -93,9 +93,9 @@ export type GraphQLSiteInfoServiceConfig = CacheOptions & {
    */
   clientFactory?: GraphQLRequestClientFactory;
   /**
-   * Boolean indicating if app is running for xm cloud
+   * Boolean indicating if service will use site GQL query instead of search
    */
-  xmCloud?: boolean;
+  useSiteQuery?: boolean;
 };
 
 type GraphQLSiteInfoResponse = {
@@ -137,8 +137,11 @@ export class GraphQLSiteInfoService {
     return defaultQuery;
   }
 
-  protected get xmCloudQuery(): string {
-    return xmCloudQuery;
+  /**
+   * site query is available on XM Cloud and XP 10.4+
+   */
+  protected get siteQuery(): string {
+    return siteQuery;
   }
 
   /**
@@ -160,7 +163,7 @@ export class GraphQLSiteInfoService {
       return [];
     }
 
-    const results: SiteInfo[] = this.config.xmCloud
+    const results: SiteInfo[] = this.config.useSiteQuery
       ? await this.fetchWithSiteQuery()
       : await this.fetchWithDefaultQuery();
 
@@ -196,7 +199,7 @@ export class GraphQLSiteInfoService {
 
   protected async fetchWithSiteQuery(): Promise<SiteInfo[]> {
     const response = await this.graphQLClient.request<GraphQLXmCloudSiteInfoResponse>(
-      this.xmCloudQuery
+      this.siteQuery
     );
     const result = response?.site?.siteInfoCollection?.reduce<SiteInfo[]>((result, current) => {
       // filter out built in website


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
SiteInfoGraphQLService now accepts a boolean xmCloud parameter. The parameter enables using site query - and it will be enabled by default when xmcloud addon is used via clientConfig.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
