### PR TITLE
[chore][sitecore-jss] Set single root for retry unit tests

### DIFF
--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -120,6 +120,7 @@ describe('GraphQLRequestClient', () => {
       );
     }
   });
+
   it('should throw error when request is aborted with default timeout value', async () => {
     nock('http://jssnextweb')
       .post('/graphql')
@@ -134,96 +135,6 @@ describe('GraphQLRequestClient', () => {
     await graphQLClient.request('test').catch((error) => {
       expect(error.name).to.equal('AbortError');
     });
-  });
-
-  it('should use retry and throw error when retries specified', async function() {
-    this.timeout(8000);
-    nock('http://jssnextweb')
-      .post('/graphql')
-      .reply(429)
-      .post('/graphql')
-      .reply(429)
-      .post('/graphql')
-      .reply(429);
-
-    const graphQLClient = new GraphQLRequestClient(endpoint, {
-      retries: 2,
-    });
-    spy.on(graphQLClient['client'], 'request');
-    await graphQLClient.request('test').catch((error) => {
-      expect(error).to.not.be.undefined;
-      expect(graphQLClient['client'].request).to.be.called.exactly(3);
-      spy.restore(graphQLClient);
-    });
-  });
-
-  it('should use retry and resolve if one of the requests resolves', async function() {
-    this.timeout(8000);
-    nock('http://jssnextweb')
-      .post('/graphql')
-      .reply(429)
-      .post('/graphql')
-      .reply(429)
-      .post('/graphql')
-      .reply(200, {
-        data: {
-          result: 'Hello world...',
-        },
-      });
-    const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 2 });
-    spy.on(graphQLClient['client'], 'request');
-
-    const data = await graphQLClient.request('test');
-
-    expect(data).to.not.be.null;
-    expect(graphQLClient['client'].request).to.be.called.exactly(3);
-    spy.restore(graphQLClient);
-  });
-
-  it('should use [retry-after] header value when response is 429', async function() {
-    this.timeout(7000);
-    nock('http://jssnextweb')
-      .post('/graphql')
-      .reply(429, {}, { 'Retry-After': '2' });
-    const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 1 });
-    spy.on(graphQLClient, 'debug');
-
-    await graphQLClient.request('test').catch(() => {
-      expect(graphQLClient['debug']).to.have.been.called.with(
-        'Error: %d. Retrying in %dms (attempt %d).',
-        429,
-        2000,
-        1
-      );
-      spy.restore(graphQLClient);
-    });
-  });
-
-  it('should throw error when request is aborted value after retry', async function() {
-    this.timeout(3000);
-    nock('http://jssnextweb')
-      .post('/graphql')
-      .reply(429)
-      .post('/graphql')
-      .delay(100)
-      .reply(200, {
-        data: {
-          result: 'Hello world...',
-        },
-      });
-
-    const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 1, timeout: 50 });
-    spy.on(graphQLClient['client'], 'request');
-    try {
-      await graphQLClient.request('test');
-      // If the request does not throw an error, fail the test
-      expect.fail('Expected request to throw an error');
-    } catch (error) {
-      expect(graphQLClient['client'].request).to.be.called.exactly(2);
-      expect(error.name).to.equal('AbortError');
-    } finally {
-      spy.restore(graphQLClient);
-    }
   });
 
   it('should throw error upon request timeout using provided timeout value', async () => {
@@ -257,115 +168,10 @@ describe('GraphQLRequestClient', () => {
     });
   });
 
-  describe('Retrayable status codes', () => {
-    const retryableStatusCodeThrowError = async (statusCode: number) => {
-      nock('http://jssnextweb')
-        .post('/graphql')
-        .reply(statusCode)
-        .post('/graphql')
-        .reply(statusCode)
-        .post('/graphql')
-        .reply(statusCode);
-
-      const graphQLClient = new GraphQLRequestClient(endpoint, {
-        retries: 2,
-      });
-
-      spy.on(graphQLClient['client'], 'request');
-
-      try {
-        await graphQLClient.request('test');
-      } catch (error) {
-        expect(error).to.not.be.undefined;
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(3);
-        spy.restore(graphQLClient);
-      }
-    };
-
-    // Test cases for each retryable status code
-    for (const statusCode of [429, 502, 503, 504, 520, 521, 522, 523, 524]) {
-      it(`should retry and throw error for ${statusCode} when retries specified`, async function() {
-        this.timeout(8000);
-        await retryableStatusCodeThrowError(statusCode);
-      });
-    }
-
-    const retryableStatusCodeResolve = async (statusCode: number) => {
-      nock('http://jssnextweb')
-        .post('/graphql')
-        .reply(statusCode)
-        .post('/graphql')
-        .reply(statusCode)
-        .post('/graphql')
-        .reply(200, {
-          data: {
-            result: 'Hello world...',
-          },
-        });
-
-      const graphQLClient = new GraphQLRequestClient(endpoint, {
-        retries: 3,
-      });
-
-      spy.on(graphQLClient['client'], 'request');
-
-      const data = await graphQLClient.request('test');
-
-      try {
-        await graphQLClient.request('test');
-        expect(data).to.not.be.null;
-      } catch (error) {
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(4);
-        spy.restore(graphQLClient);
-      }
-    };
-
-    // Test cases for each retryable status code
-    for (const statusCode of [429, 502, 503, 504, 520, 521, 522, 523, 524]) {
-      it(`should retry and resolve for ${statusCode} if one of the request resolves`, async function() {
-        this.timeout(16000);
-        await retryableStatusCodeResolve(statusCode);
-      });
-    }
-
-    it('should retry based on custom retryStrategy', async function() {
+  describe('Working with retryer', () => {
+    it('should use retry and throw error when retries specified', async function() {
       this.timeout(8000);
-
       nock('http://jssnextweb')
-        .post('/graphql')
-        .reply(502, {
-          data: {
-            result: 'Hello world...',
-          },
-        });
-
-      const customRetryStrategy = {
-        shouldRetry: (_: any, attempt: number) => attempt <= 3,
-        getDelay: () => 1000,
-      };
-
-      const graphQLClient = new GraphQLRequestClient(endpoint, {
-        retries: 4,
-        retryStrategy: customRetryStrategy,
-      });
-
-      spy.on(graphQLClient['client'], 'request');
-
-      try {
-        await graphQLClient.request('test');
-      } catch (error) {
-        expect(error).to.not.be.undefined;
-        expect(graphQLClient['client'].request).to.be.called.exactly(4);
-        spy.restore(graphQLClient);
-      }
-    });
-
-    it('should delay before retrying based on exponential backoff', async function() {
-      this.timeout(32000);
-
-      nock('http://jssnextweb')
-        .post('/graphql')
-        .reply(429)
         .post('/graphql')
         .reply(429)
         .post('/graphql')
@@ -374,88 +180,288 @@ describe('GraphQLRequestClient', () => {
         .reply(429);
 
       const graphQLClient = new GraphQLRequestClient(endpoint, {
-        retries: 4,
+        retries: 2,
       });
+      spy.on(graphQLClient['client'], 'request');
+      await graphQLClient.request('test').catch((error) => {
+        expect(error).to.not.be.undefined;
+        expect(graphQLClient['client'].request).to.be.called.exactly(3);
+        spy.restore(graphQLClient);
+      });
+    });
 
+    it('should use retry and resolve if one of the requests resolves', async function() {
+      this.timeout(8000);
+      nock('http://jssnextweb')
+        .post('/graphql')
+        .reply(429)
+        .post('/graphql')
+        .reply(429)
+        .post('/graphql')
+        .reply(200, {
+          data: {
+            result: 'Hello world...',
+          },
+        });
+      const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 2 });
       spy.on(graphQLClient['client'], 'request');
 
+      const data = await graphQLClient.request('test');
+
+      expect(data).to.not.be.null;
+      expect(graphQLClient['client'].request).to.be.called.exactly(3);
+      spy.restore(graphQLClient);
+    });
+
+    it('should use [retry-after] header value when response is 429', async function() {
+      this.timeout(7000);
+      nock('http://jssnextweb')
+        .post('/graphql')
+        .reply(429, {}, { 'Retry-After': '2' });
+      const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 1 });
+      spy.on(graphQLClient, 'debug');
+
+      await graphQLClient.request('test').catch(() => {
+        expect(graphQLClient['debug']).to.have.been.called.with(
+          'Error: %d. Retrying in %dms (attempt %d).',
+          429,
+          2000,
+          1
+        );
+        spy.restore(graphQLClient);
+      });
+    });
+
+    it('should throw error when request is aborted value after retry', async function() {
+      this.timeout(3000);
+      nock('http://jssnextweb')
+        .post('/graphql')
+        .reply(429)
+        .post('/graphql')
+        .delay(100)
+        .reply(200, {
+          data: {
+            result: 'Hello world...',
+          },
+        });
+
+      const graphQLClient = new GraphQLRequestClient(endpoint, { retries: 1, timeout: 50 });
+      spy.on(graphQLClient['client'], 'request');
       try {
         await graphQLClient.request('test');
-
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(1);
-
-        const clock = sinon.useFakeTimers();
-        clock.tick(1000);
-
-        await graphQLClient.request('test');
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(2);
-
-        clock.tick(2000);
-
-        await graphQLClient.request('test');
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(3);
-
-        clock.tick(4000);
-
-        await graphQLClient.request('test');
-        expect(graphQLClient['client'].request).to.have.been.called.exactly(4);
-
-        clock.restore();
+        // If the request does not throw an error, fail the test
+        expect.fail('Expected request to throw an error');
       } catch (error) {
-        console.log('error');
+        expect(graphQLClient['client'].request).to.be.called.exactly(2);
+        expect(error.name).to.equal('AbortError');
+      } finally {
+        spy.restore(graphQLClient);
       }
     });
-  });
 
-  describe('DefaultRetryStrategy', () => {
-    const mockClientError = new ClientError(
-      {
-        data: undefined,
-        errors: [{ message: 'GaphqlError' }],
-        extensions: undefined,
-        status: 429,
-      },
-      {
-        query: 'query',
+    describe('Retrayable status codes', () => {
+      const retryableStatusCodeThrowError = async (statusCode: number) => {
+        nock('http://jssnextweb')
+          .post('/graphql')
+          .reply(statusCode)
+          .post('/graphql')
+          .reply(statusCode)
+          .post('/graphql')
+          .reply(statusCode);
+
+        const graphQLClient = new GraphQLRequestClient(endpoint, {
+          retries: 2,
+        });
+
+        spy.on(graphQLClient['client'], 'request');
+
+        try {
+          await graphQLClient.request('test');
+        } catch (error) {
+          expect(error).to.not.be.undefined;
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(3);
+          spy.restore(graphQLClient);
+        }
+      };
+
+      // Test cases for each retryable status code
+      for (const statusCode of [429, 502, 503, 504, 520, 521, 522, 523, 524]) {
+        it(`should retry and throw error for ${statusCode} when retries specified`, async function() {
+          this.timeout(8000);
+          await retryableStatusCodeThrowError(statusCode);
+        });
       }
-    );
-    it('should return true from shouldRetry and use default values from constructor', () => {
-      const retryStrategy = new DefaultRetryStrategy();
 
-      const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 3);
-      expect(shouldRetry).to.equal(true);
+      const retryableStatusCodeResolve = async (statusCode: number) => {
+        nock('http://jssnextweb')
+          .post('/graphql')
+          .reply(statusCode)
+          .post('/graphql')
+          .reply(statusCode)
+          .post('/graphql')
+          .reply(200, {
+            data: {
+              result: 'Hello world...',
+            },
+          });
+
+        const graphQLClient = new GraphQLRequestClient(endpoint, {
+          retries: 3,
+        });
+
+        spy.on(graphQLClient['client'], 'request');
+
+        const data = await graphQLClient.request('test');
+
+        try {
+          await graphQLClient.request('test');
+          expect(data).to.not.be.null;
+        } catch (error) {
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(4);
+          spy.restore(graphQLClient);
+        }
+      };
+
+      // Test cases for each retryable status code
+      for (const statusCode of [429, 502, 503, 504, 520, 521, 522, 523, 524]) {
+        it(`should retry and resolve for ${statusCode} if one of the request resolves`, async function() {
+          this.timeout(16000);
+          await retryableStatusCodeResolve(statusCode);
+        });
+      }
+
+      it('should retry based on custom retryStrategy', async function() {
+        this.timeout(8000);
+
+        nock('http://jssnextweb')
+          .post('/graphql')
+          .reply(502, {
+            data: {
+              result: 'Hello world...',
+            },
+          });
+
+        const customRetryStrategy = {
+          shouldRetry: (_: any, attempt: number) => attempt <= 3,
+          getDelay: () => 1000,
+        };
+
+        const graphQLClient = new GraphQLRequestClient(endpoint, {
+          retries: 4,
+          retryStrategy: customRetryStrategy,
+        });
+
+        spy.on(graphQLClient['client'], 'request');
+
+        try {
+          await graphQLClient.request('test');
+        } catch (error) {
+          expect(error).to.not.be.undefined;
+          expect(graphQLClient['client'].request).to.be.called.exactly(4);
+          spy.restore(graphQLClient);
+        }
+      });
+
+      it('should delay before retrying based on exponential backoff', async function() {
+        this.timeout(32000);
+
+        nock('http://jssnextweb')
+          .post('/graphql')
+          .reply(429)
+          .post('/graphql')
+          .reply(429)
+          .post('/graphql')
+          .reply(429)
+          .post('/graphql')
+          .reply(429);
+
+        const graphQLClient = new GraphQLRequestClient(endpoint, {
+          retries: 4,
+        });
+
+        spy.on(graphQLClient['client'], 'request');
+
+        try {
+          await graphQLClient.request('test');
+
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(1);
+
+          const clock = sinon.useFakeTimers();
+          clock.tick(1000);
+
+          await graphQLClient.request('test');
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(2);
+
+          clock.tick(2000);
+
+          await graphQLClient.request('test');
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(3);
+
+          clock.tick(4000);
+
+          await graphQLClient.request('test');
+          expect(graphQLClient['client'].request).to.have.been.called.exactly(4);
+
+          clock.restore();
+        } catch (error) {
+          console.log('error');
+        }
+      });
     });
 
-    it('should return false when attempt exceeds retries', () => {
-      const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
-      mockClientError.response.status = 503;
+    describe('DefaultRetryStrategy', () => {
+      const mockClientError = new ClientError(
+        {
+          data: undefined,
+          errors: [{ message: 'GaphqlError' }],
+          extensions: undefined,
+          status: 429,
+        },
+        {
+          query: 'query',
+        }
+      );
+      it('should return true from shouldRetry and use default values from constructor', () => {
+        const retryStrategy = new DefaultRetryStrategy();
 
-      const shouldRetry = retryStrategy.shouldRetry(mockClientError, 2, 1);
-      expect(shouldRetry).to.equal(false);
-    });
+        const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 3);
+        expect(shouldRetry).to.equal(true);
+      });
 
-    it('should return false when retries is 0', () => {
-      const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
-      mockClientError.response.status = 503;
+      it('should return false when attempt exceeds retries', () => {
+        const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
+        mockClientError.response.status = 503;
 
-      const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 0);
-      expect(shouldRetry).to.equal(false);
-    });
+        const shouldRetry = retryStrategy.shouldRetry(mockClientError, 2, 1);
+        expect(shouldRetry).to.equal(false);
+      });
 
-    it('should return delay using exponential backoff when Retry-After header is not present', () => {
-      const retryStrategy = new DefaultRetryStrategy();
-      const delay = retryStrategy.getDelay(mockClientError, 3);
-      const expectedDelay = Math.pow(retryStrategy['factor'], 3 - 1) * 1000;
-      expect(delay).to.equal(expectedDelay);
-    });
+      it('should return false when retries is 0', () => {
+        const retryStrategy = new DefaultRetryStrategy({ statusCodes: [503] });
+        mockClientError.response.status = 503;
 
-    it('should use custom exponential factor', () => {
-      const customFactor = 3;
-      const retryStrategy = new DefaultRetryStrategy({ statusCodes: [429], factor: customFactor });
+        const shouldRetry = retryStrategy.shouldRetry(mockClientError, 1, 0);
+        expect(shouldRetry).to.equal(false);
+      });
 
-      const delay = retryStrategy.getDelay(mockClientError, 3);
-      const expectedDelay = Math.pow(customFactor, 3 - 1) * 1000;
-      expect(delay).to.equal(expectedDelay);
+      it('should return delay using exponential backoff when Retry-After header is not present', () => {
+        const retryStrategy = new DefaultRetryStrategy();
+        const delay = retryStrategy.getDelay(mockClientError, 3);
+        const expectedDelay = Math.pow(retryStrategy['factor'], 3 - 1) * 1000;
+        expect(delay).to.equal(expectedDelay);
+      });
+
+      it('should use custom exponential factor', () => {
+        const customFactor = 3;
+        const retryStrategy = new DefaultRetryStrategy({
+          statusCodes: [429],
+          factor: customFactor,
+        });
+
+        const delay = retryStrategy.getDelay(mockClientError, 3);
+        const expectedDelay = Math.pow(customFactor, 3 - 1) * 1000;
+        expect(delay).to.equal(expectedDelay);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description / Motivation
Retry unit tests take a long time to complete- by design. This PR is a small QoL change for devs. Putting all retry tests under the single root makes disabling them during development easier, when working on non-graphql-client logic.

## Testing Details
- [x] Unit Test still pass
- [ ] Manual Test/Other (Please elaborate)

