### PR TITLE
 [sitecore-jss-react] Fix the pattern of detecting dynamic placeholder using double digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715) [#1716](https://github.com/Sitecore/jss/pull/1716))
 * `[sitecore-jss-nextjs]` Fix redirects middleware for working with absolute url where is using site language context ([#1727](https://github.com/Sitecore/jss/pull/1727)) ([#1737](https://github.com/Sitecore/jss/pull/1737))
 * `[sitecore-jss]` Retry policy to handle transient network errors. Users can pass `retryStrategy` to configure custom retry config to the services. They can customize the error codes and the number of retries. It consist of two functions shouldRetry and getDelay. To determine the back-off time, we employ an exponential strategy with a default factor of 2.([#1731](https://github.com/Sitecore/jss/pull/1731)) ([#1733](https://github.com/Sitecore/jss/pull/1733)) ([#1738](https://github.com/Sitecore/jss/pull/1738))
+* `[sitecore-jss-react]` Fix the pattern of detecting dynamic placeholder when user tried to add a new dynamic placeholder with double digit. ([#1745](https://github.com/Sitecore/jss/pull/1745))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -2,34 +2,35 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable react/prop-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { stub } from 'sinon';
-import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
 import { ComponentRendering, RouteData } from '@sitecore-jss/sitecore-jss/layout';
-import { ComponentFactory } from './sharedTypes';
-import { Placeholder } from './Placeholder';
-import { SitecoreContext } from './SitecoreContext';
-import { ComponentProps } from './PlaceholderCommon';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { stub } from 'sinon';
+import { convertedData as eeData, emptyPlaceholderData } from '../test-data/ee-data';
 import {
+  byocWrapperData,
+  feaasWrapperData,
   convertedDevData as nonEeDevData,
   convertedLayoutServiceData as nonEeLsData,
   sxaRenderingColumnSplitterVariant,
-  sxaRenderingVariantData,
   sxaRenderingVariantDataWithCommonContainerName as sxaRenderingCommonContainerName,
+  sxaRenderingVariantData,
+  sxaRenderingVariantDoubleDigitDynamicPlaceholder as sxaRenderingDoubleDigitContainerName,
   sxaRenderingVariantDataWithoutCommonContainerName as sxaRenderingWithoutContainerName,
-  byocWrapperData,
-  feaasWrapperData,
 } from '../test-data/non-ee-data';
-import { convertedData as eeData, emptyPlaceholderData } from '../test-data/ee-data';
 import * as SxaRichText from '../test-data/sxa-rich-text';
-import { MissingComponent, MissingComponentProps } from './MissingComponent';
-import { HiddenRendering } from './HiddenRendering';
 import * as BYOCComponent from './BYOCComponent';
 import * as BYOCWrapper from './BYOCWrapper';
 import * as FEAASComponent from './FEaaSComponent';
 import * as FEAASWrapper from './FEaaSWrapper';
+import { HiddenRendering } from './HiddenRendering';
+import { MissingComponent, MissingComponentProps } from './MissingComponent';
+import { Placeholder } from './Placeholder';
+import { ComponentProps } from './PlaceholderCommon';
+import { SitecoreContext } from './SitecoreContext';
+import { ComponentFactory } from './sharedTypes';
 
 const componentFactory: ComponentFactory = (componentName: string) => {
   const components = new Map<string, React.FC>();
@@ -338,6 +339,22 @@ describe('<Placeholder />', () => {
 
       expect(renderedComponent.find('.rendering-variant').length).to.equal(0);
       expect(renderedComponent.find('.title').length).to.equal(0);
+    });
+
+    it('should render with dynamic-1-{*} type dynamic placeholder', () => {
+      const component = sxaRenderingDoubleDigitContainerName.sitecore.route as RouteData;
+      const phKey = 'dynamic-1-{*}';
+
+      const renderedComponent = mount(
+        <Placeholder name={phKey} rendering={component} componentFactory={componentFactory} />
+      );
+
+      expect(renderedComponent.find('.rendering-variant').length).to.equal(1);
+      expect(renderedComponent.find('.rendering-variant').prop('className')).to.equal(
+        'rendering-variant col-9|col-sm-10|col-md-12|col-lg-6|col-xl-7|col-xxl-8 test-css-class-x'
+      );
+      expect(renderedComponent.find('.title').length).to.equal(1);
+      expect(renderedComponent.find('.title').text()).to.equal('Rich Text Rendering Variant');
     });
 
     it('should render another rendering variant', () => {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -16,12 +16,6 @@ import { FEaaSWrapper, FEAAS_WRAPPER_RENDERING_NAME } from './FEaaSWrapper';
 import { BYOCComponent, BYOC_COMPONENT_RENDERING_NAME } from './BYOCComponent';
 import { BYOCWrapper, BYOC_WRAPPER_RENDERING_NAME } from './BYOCWrapper';
 
-/**
- * These patterns need for right rendering Dynamic placeholders.
- * Must be distinguished Splitter components and another placeholders(containers)
- */
-const EXCLUDE_PLACEHOLDERS_RENDER = [new RegExp(/(\d{1})-\{\*\}/i)];
-
 type ErrorComponentProps = {
   [prop: string]: unknown;
 };
@@ -131,11 +125,12 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     from backend side we get common name of placeholder is called 'nameOfContainer-{*}' where '{*}' marker for replacing **/
     if (rendering?.placeholders) {
       Object.keys(rendering.placeholders).forEach((placeholder) => {
-        if (
-          placeholder.indexOf('{*}') !== -1 &&
-          !EXCLUDE_PLACEHOLDERS_RENDER.some((pattern) => name.search(pattern) !== -1) &&
-          name.replace(/[^a-zA-Z]*/gi, '') === placeholder.replace(/[^a-zA-Z]*/gi, '')
-        ) {
+        const patternPlaceholder =
+          placeholder.indexOf('{*}') !== -1
+            ? new RegExp(`^${placeholder.replace(/\{\*\}+/i, '\\d+')}$`)
+            : null;
+
+        if (patternPlaceholder && patternPlaceholder.test(name)) {
           rendering.placeholders[name] = rendering.placeholders[placeholder];
           delete rendering.placeholders[placeholder];
         }

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -20,10 +20,7 @@ import { BYOCWrapper, BYOC_WRAPPER_RENDERING_NAME } from './BYOCWrapper';
  * These patterns need for right rendering Dynamic placeholders.
  * Must be distinguished Splitter components and another placeholders(containers)
  */
-const EXCLUDE_PLACEHOLDERS_RENDER = [
-  new RegExp(/column-(\d{1})-\{\*\}/i),
-  new RegExp(/row-(\d{1})-\{\*\}/i),
-];
+const EXCLUDE_PLACEHOLDERS_RENDER = [new RegExp(/(\d{1})-\{\*\}/i)];
 
 type ErrorComponentProps = {
   [prop: string]: unknown;

--- a/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
@@ -292,6 +292,45 @@ export const sxaRenderingVariantDataWithCommonContainerName = {
   },
 };
 
+export const sxaRenderingVariantDoubleDigitDynamicPlaceholder = {
+  sitecore: {
+    context: {
+      pageEditing: false,
+    },
+    route: {
+      name: 'Home',
+      displayName: 'Home',
+      fields: {
+        key: {
+          value: 'This is a some sample &lt;p&gt;field data&lt;/p&gt; o&#39;boy! &quot;wow&quot;',
+        },
+      },
+      placeholders: {
+        'dynamic-1-{*}': [
+          {
+            uid: 'c4d5d43b-5aa8-4e03-8f16-9428f3e02d5c',
+            componentName: 'RichText',
+            dataSource: '/sitecore/content/SxaSample/SxaSampleSite/Home/Data/RichText',
+            params: {
+              GridParameters: 'col-9|col-sm-10|col-md-12|col-lg-6|col-xl-7|col-xxl-8',
+              FieldNames: 'WithTitle',
+              Styles: 'test-css-class-x',
+            },
+            fields: {
+              Text: {
+                value: 'Test RichText',
+              },
+              Title: {
+                value: 'Rich Text Rendering Variant',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
 export const sxaRenderingVariantDataWithoutCommonContainerName = {
   sitecore: {
     context: {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
The bug appeared when user add a new dynamic placeholder for example: accordion-1-{*} and it didn't work.
The pattern of detecting has been changed to universal pattern. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
