### PR TITLE
[Personalize] Remove unused component experiences from layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715) [#1716](https://github.com/Sitecore/jss/pull/1716))
 * `[sitecore-jss-nextjs]` Fix redirects middleware for working with absolute url where is using site language context ([#1727](https://github.com/Sitecore/jss/pull/1727)) ([#1737](https://github.com/Sitecore/jss/pull/1737))
 * `[sitecore-jss]` Enable the Layout and dictionary service to use custom `retryStrategy`. ([#1749](https://github.com/Sitecore/jss/pull/1749))
+* `[sitecore-jss]` Any unused personalized component variants are deleted before sending layout data to the client, thus are completely hidden from the customer. ([#1752](https://github.com/Sitecore/jss/pull/1752))
 
 ### 🛠 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs] [templates/nextjs-xmcloud]` SDK initialization rejections are now correctly handled. Errors should no longer occur after getSDK() promises resolve when they shouldn't (for example, getting Events SDK in development environment) ([#1712](https://github.com/Sitecore/jss/pull/1712) [#1715](https://github.com/Sitecore/jss/pull/1715) [#1716](https://github.com/Sitecore/jss/pull/1716))
 * `[sitecore-jss-nextjs]` Fix redirects middleware for working with absolute url where is using site language context ([#1727](https://github.com/Sitecore/jss/pull/1727)) ([#1737](https://github.com/Sitecore/jss/pull/1737))
 * `[sitecore-jss]` Enable the Layout and dictionary service to use custom `retryStrategy`. ([#1749](https://github.com/Sitecore/jss/pull/1749))
-* `[sitecore-jss]` Any unused personalized component variants are deleted before sending layout data to the client, thus are completely hidden from the customer. ([#1752](https://github.com/Sitecore/jss/pull/1752))
 
 ### 🛠 Breaking Changes
 
@@ -49,6 +48,12 @@ Our versioning strategy is as follows:
 
 * Upgrade to Node.js 20.x ([#1679](https://github.com/Sitecore/jss/pull/1679))([#1681](https://github.com/Sitecore/jss/pull/1681))
 * `[nextjs/template]` Upgrade graphql-codegen packages to latest ([#1711](https://github.com/Sitecore/jss/pull/1711))
+
+## 21.6.4
+
+### 🐛 Bug Fixes
+
+* `[sitecore-jss]` Any unused personalized component variants are deleted before sending layout data to the client, thus are completely hidden from the customer. ([#1752](https://github.com/Sitecore/jss/pull/1752))
 
 ## 21.6.3
 

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
@@ -130,22 +130,28 @@ describe('layout-personalizer', () => {
   });
 
   describe('personalizeComponent', () => {
-    it('should return personalized component', () => {
+    it('should return personalized component without experiences', () => {
       const variant = 'mountain_bike_audience';
       const personalizedComponentResult = personalizeComponent(
         (component as unknown) as ComponentRenderingWithExperiences,
         variant
       );
       expect(personalizedComponentResult).to.deep.equal(componentWithExperiences);
+      expect(
+        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
+      ).to.deep.equal(undefined);
     });
 
-    it('should return default component when variant is undefined', () => {
+    it('should return default component without experiences when variant is undefined', () => {
       const variant = '_default';
       const personalizedComponentResult = personalizeComponent(
         (component as unknown) as ComponentRenderingWithExperiences,
         variant
       );
       expect(personalizedComponentResult).to.deep.equal(component);
+      expect(
+        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
+      ).to.deep.equal({});
     });
 
     it('should return null when variantVariant is hidden', () => {
@@ -164,30 +170,6 @@ describe('layout-personalizer', () => {
         variant
       );
       expect(personalizedComponentResult).to.equal(null);
-    });
-
-    it('should return personalized component without experiences', () => {
-      const variant = 'mountain_bike_audience';
-      const personalizedComponentResult = personalizeComponent(
-        (component as unknown) as ComponentRenderingWithExperiences,
-        variant
-      );
-
-      expect(
-        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
-      ).to.deep.equal({});
-    });
-
-    it('should empty experiences for default variant', () => {
-      const variant = '_default';
-      const personalizedComponentResult = personalizeComponent(
-        (component as unknown) as ComponentRenderingWithExperiences,
-        variant
-      );
-
-      expect(
-        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
-      ).to.deep.equal({});
     });
   });
 });

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
@@ -165,5 +165,29 @@ describe('layout-personalizer', () => {
       );
       expect(personalizedComponentResult).to.equal(null);
     });
+
+    it('should return personalized component without experiences', () => {
+      const variant = 'mountain_bike_audience';
+      const personalizedComponentResult = personalizeComponent(
+        (component as unknown) as ComponentRenderingWithExperiences,
+        variant
+      );
+
+      expect(
+        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
+      ).to.deep.equal({});
+    });
+
+    it('should empty experiences for default variant', () => {
+      const variant = '_default';
+      const personalizedComponentResult = personalizeComponent(
+        (component as unknown) as ComponentRenderingWithExperiences,
+        variant
+      );
+
+      expect(
+        (personalizedComponentResult as ComponentRenderingWithExperiences).experiences
+      ).to.deep.equal({});
+    });
   });
 });

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -79,8 +79,10 @@ export function personalizeComponent(
     component = variant;
   }
 
-    // remove unused experiences from layout data
+  // remove unused experiences from layout data
+  if (component.experiences) {
     component.experiences = {};
+  }
 
   if (!component.placeholders) return component;
 

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -79,6 +79,9 @@ export function personalizeComponent(
     component = variant;
   }
 
+    // remove unused experiences from layout data
+    component.experiences = {};
+
   if (!component.placeholders) return component;
 
   Object.keys(component?.placeholders).forEach((placeholder) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR makes sure that any unused personalized variants are deleted before sending layout data to the client, thus are completely hidden from the customer.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - Personalize a component in xmcloud and make sure that, when you run your app in production or in vercel, in the layout data json (can be found in the resulting html of the page) does not contain any personalize experiences of the component and personalization works properly;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
