### PR TITLE
[FEAAS] Nextjs Image for FEAAS

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.feaas.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.feaas.tsx
@@ -3,12 +3,18 @@ import * as FEAAS from '@sitecore-feaas/clientside/react';
 
 // Element implementations for Sitecore Component Builder can be overriden here
 
+// type to adjust HTMLAttributes to nextjs Image attributes
+type ImageProps = {
+  src: string;
+  alt: string;
+} & React.HTMLAttributes<HTMLImageElement>;
+
 // Register next Image to be used in Component Builder.
 // Nextjs image implementation will be used when img is rendered in component from Component Builder
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-FEAAS.setElementImplementation('img', (attributes: any) => {
-  delete attributes.children;
-  return <Image {...attributes} />;
+FEAAS.setElementImplementation('img', (attributes: ImageProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { children, ...imgAttributes } = attributes;
+  return <Image height={1920} width={1200} {...imgAttributes} />;
 });
 
 // eslint-disable-next-line import/no-anonymous-default-export

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.feaas.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.feaas.tsx
@@ -1,0 +1,15 @@
+import Image from 'next/image';
+import * as FEAAS from '@sitecore-feaas/clientside/react';
+
+// Element implementations for Sitecore Component Builder can be overriden here
+
+// Register next Image to be used in Component Builder.
+// Nextjs image implementation will be used when img is rendered in component from Component Builder
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+FEAAS.setElementImplementation('img', (attributes: any) => {
+  delete attributes.children;
+  return <Image {...attributes} />;
+});
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {};

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/byoc/index.ts
@@ -19,7 +19,11 @@ const ClientBundle = dynamic(() => import('./index.client'), {
 // Import your hybrid (server rendering with client hydration) components via index.hybrid.ts
 import './index.hybrid';
 
+// Import elements implementations for feaas/component builder
+import './index.feaas';
+
 // As long as component bundle is exported and rendered on page (as an empty element), client-only BYOC components are registered and become available
 // The rest of components will be regsitered in both server and client-side contexts when this module is imported into Layout
 FEAAS.enableNextClientsideComponents(dynamic, ClientBundle);
+
 export default FEAAS.ExternalComponentBundle;

--- a/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
+++ b/packages/create-sitecore-jss/src/templates/nextjs/next.config.js
@@ -2,6 +2,28 @@ const jssConfig = require('./src/temp/config');
 const plugins = require('./src/temp/next-config-plugins') || {};
 
 const publicUrl = jssConfig.publicUrl;
+// remotePatterns presets used for nextjs image optimization
+// Less secure pattern can be used in development and editing
+const remotePatternsDev = [
+  {
+    protocol: 'https',
+    hostname: '*',
+    port: '',
+  }
+];
+// More secure remotePatternsProd should be used when going live
+const remotePatternsProd = [
+  {
+    protocol: 'https',
+    hostname: 'edge*.**',
+    port: '',
+  },
+  {
+    protocol: 'https',
+    hostname: 'feaas*.blob.core.windows.net',
+    port: '',
+  },
+];
 
 /**
  * @type {import('next').NextConfig}
@@ -32,20 +54,13 @@ const nextConfig = {
 
   // use this configuration to ensure that only images from the whitelisted domains
   // can be served from the Next.js Image Optimization API
+  // uses remotePatterns presets out of the box
   // see https://nextjs.org/docs/app/api-reference/components/image#remotepatterns
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'edge*.**',
-        port: '',
-      },
-      {
-        protocol: 'https',
-        hostname: 'feaas*.blob.core.windows.net',
-        port: '',
-      },
-    ],
+    remotePatterns: 
+      process.env.NODE_ENV === 'development' || process.env.SITECORE ? 
+       remotePatternsDev : 
+       remotePatternsProd
   },
 
   async rewrites() {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
This change will ensure nextjs's implementation for Image is used when img elements are rendered withing FEAAS Components (from Component Builder). It also adds remotePatterns presets for dev and prod in nextjs.config - to allow easier management of rules for editing/dev and live deployments.

Note: setElementImplementation call might become typed on FEAAS side. Feaas version will need to be updated in that case for this PR. Do not merge it until it's done.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - editing, connected, production modes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
