### PR TITLE
[sitecore-jss] Use ['Retry-After'] header value without rounding off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Our versioning strategy is as follows:
     * Handle additional string error codes like ECONNRESET, ETIMEDOUT, EPROTO. Can configure more using DefaultRetryStrategy.
     * Retries has now been enabled by default with a default value of 3. It can be disabled by configuring it to 0.
     * [Retry-After] header now falls back to the default delay time when it comes out to be empty.
-    ([#1755](https://github.com/Sitecore/jss/pull/1755)) ([#1759](https://github.com/Sitecore/jss/pull/1759))
+    ([#1755](https://github.com/Sitecore/jss/pull/1755)) ([#1759](https://github.com/Sitecore/jss/pull/1759)) ([#1763](https://github.com/Sitecore/jss/pull/1763))
 
 ### 🐛 Bug Fixes
 

--- a/packages/sitecore-jss/src/graphql-request-client.test.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.test.ts
@@ -605,6 +605,19 @@ describe('GraphQLRequestClient', () => {
         expect(delay).to.equal(expectedDelay);
       });
 
+      it('should return delay using the value from Retry-After header without rounding off', () => {
+        const retryStrategy = new DefaultRetryStrategy();
+        const mockError = {
+          response: {
+            status: 429,
+            headers: new Map([['Retry-After', '1.5']]),
+          },
+        };
+        const delay = retryStrategy.getDelay(mockError, 3);
+        const expectedDelay = 1.5 * 1000;
+        expect(delay).to.equal(expectedDelay);
+      });
+
       it('should use custom exponential factor', () => {
         const customFactor = 3;
         const retryStrategy = new DefaultRetryStrategy({

--- a/packages/sitecore-jss/src/graphql-request-client.ts
+++ b/packages/sitecore-jss/src/graphql-request-client.ts
@@ -132,7 +132,7 @@ export class DefaultRetryStrategy implements RetryStrategy {
       retryAfterHeader !== undefined &&
       retryAfterHeader.trim() !== ''
     ) {
-      const delaySeconds = Number.parseInt(retryAfterHeader, 10);
+      const delaySeconds = Number.parseFloat(retryAfterHeader);
       return delaySeconds * 1000;
     } else {
       return Math.pow(this.factor, attempt - 1) * 1000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
