### PR TITLE
[sitecore-jss] Bugfix to prevent error: Cannot use ‘in’ operator to search for ‘editable’ in ''

### DIFF
--- a/packages/sitecore-jss/src/layout/content-styles.ts
+++ b/packages/sitecore-jss/src/layout/content-styles.ts
@@ -61,7 +61,7 @@ export const traversePlaceholder = (
 
 export const traverseField = (field: Field | Item | Item[] | undefined, config: Config) => {
   if (!field || config.loadStyles) return;
-
+  if (typeof field === 'string' && field) return;
   if ('editable' in field && field.editable) {
     config.loadStyles = CLASS_REGEXP.test(field.editable);
   } else if ('value' in field && typeof field.value === 'string') {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When working with page templates, designs, and instances within our DXP, it's essential to ensure smooth functionality and error-free operation. One recurring issue that has been identified is the error message "Cannot use the 'in' operator to search for 'editable' in [SOME-GUIDS]." This error occurs in a specific sequence of actions, including creating page templates, designs, instances, and overriding designs in the content editor.

The steps to reproduce the issue are straightforward: first, a page template is created, followed by the design of the page. Then, an instance of the page is generated, and its design is overridden from the dropdown in the content editor. Lastly, a page is selected from a multilist, which has had its design overridden. It's at this point that the error message appears.

Upon further investigation, it has been observed that the structure of Partial Designs does not align with the expected format. Instead of the {value, editable} structure, the Partial Designs exhibit a different format, which could potentially lead to the encountered error.

This approach delegates the decision to exclude "Page Designs" from traverseField to you, the expert in charge. By evaluating the impact and relevance of excluding this element, you can determine whether it aligns with jss requirements and objectives. This decision-making process ensures that we implement solutions that not only resolve the immediate issue but also uphold the integrity and functionality of Sitecore.

## Testing Details
To reproduce the issue "Cannot use the 'in' operator to search for 'editable' in [SOME PARTIAL DESIGNS IDs]," follow these steps:

- Create a Page Template.
- Create a Page Design.
-  Create an Instance of a page.
- Override the Page Design from the Dropdown in the Content Editor.
- From a multilist, select the page which has the Page Design overwritten.

Upon completing these steps, you may encounter the error message. This issue could be due to the structure of Partial Designs, which should ideally follow the {`value`, `editable`} structure instead of the provided structure: 
```json
{
  "fields": {
    "PartialDesigns": "[SOME PARTIAL DESIGNS IDs]""
  }
}
```

The solution is to validate if field is type of string then were are on this scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
