### PR TITLE
[Chore] gitignore for upgrade docs in release branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 scjssconfig.json
 scjssconfig.bak
 
+UPGRADING.md
+docs/upgrades
+
 *.pfx
 *.publishsettings
 node_modules/


### PR DESCRIPTION
Add gitignore rules for upgrade documentation in release branches. This will reduce conflicts when merging changes on releases - and we mainly need upgrade guides in dev only anyway.