### PR TITLE
[React][nextjs] Do not apply ErrorBoundaries to empty placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss-react]`Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786) [#1790](https://github.com/Sitecore/jss/pull/1790))
+* `[sitecore-jss-react]`Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786) [#1790](https://github.com/Sitecore/jss/pull/1790) [#1793](https://github.com/Sitecore/jss/pull/1793))
 
 ## 22.0.0
 

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
@@ -5,7 +5,6 @@ import { spy } from 'sinon';
 import ErrorBoundary from './ErrorBoundary';
 import { SitecoreContextReactContext } from '../components/SitecoreContext';
 import { ComponentRendering } from '@sitecore-jss/sitecore-jss/layout';
-import { afterEach } from 'node:test';
 
 describe('ErrorBoundary', () => {
   describe('when in page editing mode', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -484,7 +484,7 @@ describe('<Placeholder />', () => {
 
   it('should render empty placeholder with no extra markup', () => {
     const phKey = 'mainEmpty';
-    
+
     const renderedComponent = mount(
       <Placeholder
         name={phKey}
@@ -493,16 +493,18 @@ describe('<Placeholder />', () => {
       />
     );
     const emptyPlaceholder = renderedComponent.find('.sc-jss-empty-placeholder');
-    //TODO: change this as needed when merging "simplify editing" feature changes into dev
-    expect(emptyPlaceholder.html()).to.equal([
-      '<div class="sc-jss-empty-placeholder">',
-      '<code type="text/sitecore" chrometype="placeholder" kind="open" id="main" class="scpm" data-selectable="true" phkey="main" key="main">',
-      '{}',
-      '</code>',
-      '<code type="text/sitecore" id="scEnclosingTag_" chrometype="placeholder" kind="close" hintname="main" class="scpm">',
-      '</code>',
-      '</div>'
-    ].join(''));
+    // TODO: change this as needed when merging "simplify editing" feature changes into dev
+    expect(emptyPlaceholder.html()).to.equal(
+      [
+        '<div class="sc-jss-empty-placeholder">',
+        '<code type="text/sitecore" chrometype="placeholder" kind="open" id="main" class="scpm" data-selectable="true" phkey="main" key="main">',
+        '{}',
+        '</code>',
+        '<code type="text/sitecore" id="scEnclosingTag_" chrometype="placeholder" kind="close" hintname="main" class="scpm">',
+        '</code>',
+        '</div>',
+      ].join('')
+    );
   });
 
   it('should render null for unknown placeholder', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -493,6 +493,7 @@ describe('<Placeholder />', () => {
       />
     );
     const emptyPlaceholder = renderedComponent.find('.sc-jss-empty-placeholder');
+    //TODO: change this as needed when merging "simplify editing" feature changes into dev
     expect(emptyPlaceholder.html()).to.equal([
       '<div class="sc-jss-empty-placeholder">',
       '<code type="text/sitecore" chrometype="placeholder" kind="open" id="main" class="scpm" data-selectable="true" phkey="main" key="main">',

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -157,7 +157,7 @@ describe('<Placeholder />', () => {
       it('when null passed to render function', () => {
         it('should render empty placeholder', () => {
           const component = dataSet.data.sitecore.route as RouteData;
-          const phKey = 'main';
+          const phKey = 'mainEmpty';
 
           const renderedComponent = mount(
             <SitecoreContext componentFactory={componentFactory}>
@@ -204,7 +204,7 @@ describe('<Placeholder />', () => {
 
       it('should render output based on the renderEmpty function in case of empty placeholder', () => {
         const route = emptyPlaceholderData.sitecore.route as RouteData;
-        const phKey = 'main';
+        const phKey = 'mainEmpty';
 
         const renderedComponent = mount(
           <SitecoreContext componentFactory={componentFactory}>
@@ -470,7 +470,7 @@ describe('<Placeholder />', () => {
   });
 
   it('should render empty placeholder', () => {
-    const phKey = 'main';
+    const phKey = 'mainEmpty';
 
     const renderedComponent = mount(
       <Placeholder
@@ -480,6 +480,28 @@ describe('<Placeholder />', () => {
       />
     );
     expect(renderedComponent.find('.sc-jss-empty-placeholder').length).to.equal(1);
+  });
+
+  it('should render empty placeholder with no extra markup', () => {
+    const phKey = 'mainEmpty';
+    
+    const renderedComponent = mount(
+      <Placeholder
+        name={phKey}
+        rendering={emptyPlaceholderData.sitecore.route}
+        componentFactory={componentFactory}
+      />
+    );
+    const emptyPlaceholder = renderedComponent.find('.sc-jss-empty-placeholder');
+    expect(emptyPlaceholder.html()).to.equal([
+      '<div class="sc-jss-empty-placeholder">',
+      '<code type="text/sitecore" chrometype="placeholder" kind="open" id="main" class="scpm" data-selectable="true" phkey="main" key="main">',
+      '{}',
+      '</code>',
+      '<code type="text/sitecore" id="scEnclosingTag_" chrometype="placeholder" kind="close" hintname="main" class="scpm">',
+      '</code>',
+      '</div>'
+    ].join(''));
   });
 
   it('should render null for unknown placeholder', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -90,11 +90,11 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
       this.props.name
     );
 
-    const components = this.getComponentsForRenderingData(placeholderData);
-
     this.isEmpty = placeholderData.every((rendering: ComponentRendering | HtmlElementRendering) =>
       isRawRendering(rendering)
     );
+
+    const components = this.getComponentsForRenderingData(placeholderData, this.isEmpty);
 
     if (this.props.renderEmpty && this.isEmpty) {
       const rendered = this.props.renderEmpty(components);

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -182,7 +182,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     );
   }
 
-  getComponentsForRenderingData(placeholderData: (ComponentRendering | HtmlElementRendering)[], isEmpty?: boolean) {
+  getComponentsForRenderingData(
+    placeholderData: (ComponentRendering | HtmlElementRendering)[],
+    isEmpty?: boolean
+  ) {
     const {
       name,
       fields: placeholderFields,
@@ -263,24 +266,25 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         );
       })
       .filter((element) => element);
-      if (isEmpty)
-        return transformedComponents;
-      
-      return transformedComponents.map((element, id) => {
-        // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
-        const type = element.props.type === 'text/sitecore' ? element.props.type : '';
-        return (
-          <ErrorBoundary
-            key={element.type + '-' + id}
-            customErrorComponent={this.props.errorComponent}
-            rendering={element.props.rendering as ComponentRendering}
-            componentLoadingMessage={this.props.componentLoadingMessage}
-            type={type}
-          >
-            {element}
-          </ErrorBoundary>
-        );
-      });
+    if (isEmpty) {
+      return transformedComponents;
+    }
+
+    return transformedComponents.map((element, id) => {
+      // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
+      const type = element.props.type === 'text/sitecore' ? element.props.type : '';
+      return (
+        <ErrorBoundary
+          key={element.type + '-' + id}
+          customErrorComponent={this.props.errorComponent}
+          rendering={element.props.rendering as ComponentRendering}
+          componentLoadingMessage={this.props.componentLoadingMessage}
+          type={type}
+        >
+          {element}
+        </ErrorBoundary>
+      );
+    });
   }
 
   getComponentForRendering(renderingDefinition: ComponentRendering): ComponentType | null {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -266,6 +266,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         );
       })
       .filter((element) => element);
+
     if (isEmpty) {
       return transformedComponents;
     }

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -182,7 +182,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     );
   }
 
-  getComponentsForRenderingData(placeholderData: (ComponentRendering | HtmlElementRendering)[]) {
+  getComponentsForRenderingData(placeholderData: (ComponentRendering | HtmlElementRendering)[], isEmpty?: boolean) {
     const {
       name,
       fields: placeholderFields,
@@ -192,7 +192,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       ...placeholderProps
     } = this.props;
 
-    return placeholderData
+    const transformedComponents = placeholderData
       .map((rendering: ComponentRendering | HtmlElementRendering, index: number) => {
         const key = (rendering as ComponentRendering).uid
           ? (rendering as ComponentRendering).uid
@@ -262,8 +262,11 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           this.props.modifyComponentProps ? this.props.modifyComponentProps(finalProps) : finalProps
         );
       })
-      .filter((element) => element)
-      .map((element, id) => {
+      .filter((element) => element);
+      if (isEmpty)
+        return transformedComponents;
+      
+      return transformedComponents.map((element, id) => {
         // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
         const type = element.props.type === 'text/sitecore' ? element.props.type : '';
         return (

--- a/packages/sitecore-jss-react/src/test-data/ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/ee-data.ts
@@ -532,7 +532,7 @@ export const emptyPlaceholderData = {
             name: 'code',
             type: 'text/sitecore',
             contents:
-              '{"commands":[{"click":"chrome:placeholder:addControl","header":"Add to here","icon":"/temp/iconcache/office/16x16/add.png","disabledIcon":"/temp/add_disabled16x16.png","isDivider":false,"tooltip":"Add a new rendering to the \'{0}\' placeholder.","type":""},{"click":"chrome:placeholder:editSettings","header":"","icon":"/temp/iconcache/office/16x16/window_gear.png","disabledIcon":"/temp/window_gear_disabled16x16.png","isDivider":false,"tooltip":"Edit the placeholder settings.","type":""}],"contextItemUri":"sitecore://master/{9BCF4A17-2EC7-4160-9504-5ABD096B46AE}?lang=en&ver=1","custom":{"allowedRenderings":[],"editable":"true"},"displayName":"main","expandedDisplayName":null}',
+              '{"commands":[],"contextItemUri":"sitecore://master/{9BCF4A17-2EC7-4160-9504-5ABD096B46AE}?lang=en&ver=1","custom":{"allowedRenderings":[],"editable":"true"},"displayName":"main","expandedDisplayName":null}',
             attributes: {
               type: 'text/sitecore',
               chrometype: 'placeholder',
@@ -568,6 +568,36 @@ export const emptyPlaceholderData = {
               kind: 'close',
               hintkey: 'HomeRendering',
               class: 'scpm',
+            },
+          },
+          {
+            name: 'code',
+            type: 'text/sitecore',
+            contents: '',
+            attributes: {
+              type: 'text/sitecore',
+              id: 'scEnclosingTag_',
+              chrometype: 'placeholder',
+              kind: 'close',
+              hintname: 'main',
+              class: 'scpm',
+            },
+          },
+        ],
+        mainEmpty: [
+          {
+            name: 'code',
+            type: 'text/sitecore',
+            contents:
+              '{}',
+            attributes: {
+              type: 'text/sitecore',
+              chrometype: 'placeholder',
+              kind: 'open',
+              id: 'main',
+              key: 'main',
+              class: 'scpm',
+              'data-selectable': 'true',
             },
           },
           {

--- a/packages/sitecore-jss-react/src/test-data/ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/ee-data.ts
@@ -588,8 +588,7 @@ export const emptyPlaceholderData = {
           {
             name: 'code',
             type: 'text/sitecore',
-            contents:
-              '{}',
+            contents: '{}',
             attributes: {
               type: 'text/sitecore',
               chrometype: 'placeholder',


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes extra markup being generated for empty placeholders, which broke adding components in Experience Editor.
This also does a couple other things:
- Add 'empty placeholder' mock data without 'rendering' code blocks. Empty placeholders would not render them.
- Shorten the code blocks content for empty placeholder data, making it easier to maintain and read
- make all the 'empty placeholder' unit tests use the 'empty placeholder' mock data

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
