### PR TITLE
[sitecore-jss-nextjs][sitecore-jss] multi-origin CORS validation for next editing middlewares

### DIFF
--- a/packages/sitecore-jss-nextjs/src/editing/constants.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/constants.ts
@@ -1,3 +1,9 @@
 export const QUERY_PARAM_EDITING_SECRET = 'secret';
 export const QUERY_PARAM_PROTECTION_BYPASS_SITECORE = 'x-sitecore-protection-bypass';
 export const QUERY_PARAM_PROTECTION_BYPASS_VERCEL = 'x-vercel-protection-bypass';
+export const EDITING_ALLOWED_ORIGINS = [
+  'https://pages-dev.sitecore-staging.cloud/',
+  'https://pages-staging.sitecore-staging.cloud/',
+  'https://pages-preprod.sitecorecloud.io/',
+  'https://pages.sitecorecloud.io/',
+];

--- a/packages/sitecore-jss-nextjs/src/editing/constants.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/constants.ts
@@ -1,9 +1,4 @@
 export const QUERY_PARAM_EDITING_SECRET = 'secret';
 export const QUERY_PARAM_PROTECTION_BYPASS_SITECORE = 'x-sitecore-protection-bypass';
 export const QUERY_PARAM_PROTECTION_BYPASS_VERCEL = 'x-vercel-protection-bypass';
-export const EDITING_ALLOWED_ORIGINS = [
-  'https://pages-dev.sitecore-staging.cloud/',
-  'https://pages-staging.sitecore-staging.cloud/',
-  'https://pages-preprod.sitecorecloud.io/',
-  'https://pages.sitecorecloud.io/',
-];
+export const EDITING_ALLOWED_ORIGINS = ['https://pages*.cloud/', 'https://pages.sitecorecloud.io/'];

--- a/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.ts
@@ -1,8 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { QUERY_PARAM_EDITING_SECRET } from './constants';
+import { EDITING_ALLOWED_ORIGINS, QUERY_PARAM_EDITING_SECRET } from './constants';
 import { getJssEditingSecret } from '../utils/utils';
 import { debug } from '@sitecore-jss/sitecore-jss';
 import { Metadata } from '@sitecore-jss/sitecore-jss-dev-tools';
+import { enforceCors } from '../utils/index';
 
 export type EditingConfigMiddlewareConfig = {
   /**
@@ -35,6 +36,12 @@ export class EditingConfigMiddleware {
 
   private handler = async (_req: NextApiRequest, res: NextApiResponse): Promise<void> => {
     const secret = _req.query[QUERY_PARAM_EDITING_SECRET];
+    if (!enforceCors(_req, res, EDITING_ALLOWED_ORIGINS)) {
+      debug.editing(
+        'invalid origin host - set allowed origins in API_ALLOWED_ORIGINS env property'
+      );
+      return res.status(401).json({ message: 'Invalid origin' });
+    }
     if (secret !== getJssEditingSecret()) {
       debug.editing(
         'invalid editing secret - sent "%s" expected "%s"',

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.test.ts
@@ -15,11 +15,22 @@ type Query = {
   [key: string]: string;
 };
 
-const mockRequest = (method: string, query?: Query, body?: unknown) => {
+const allowedOrigin = 'https://allowed.com';
+
+const mockRequest = (
+  method: string,
+  query?: Query,
+  body?: unknown,
+  headers?: { [key: string]: string }
+) => {
   return {
     method,
     query: query ?? {},
     body: body ?? {},
+    headers: {
+      origin: allowedOrigin,
+      ...headers,
+    },
   } as NextApiRequest;
 };
 
@@ -34,7 +45,9 @@ const mockResponse = () => {
   res.end = spy(() => {
     return res;
   });
-  res.setHeader = spy();
+  res.setHeader = spy(() => {
+    return res;
+  });
   return res;
 };
 
@@ -59,10 +72,12 @@ describe('EditingDataMiddleware', () => {
 
   beforeEach(() => {
     process.env.JSS_EDITING_SECRET = secret;
+    process.env.API_ALLOWED_ORIGINS = allowedOrigin;
   });
 
   after(() => {
     delete process.env.JSS_EDITING_SECRET;
+    delete process.env.API_ALLOWED_ORIGINS;
   });
 
   it('should handle PUT request', async () => {
@@ -130,6 +145,21 @@ describe('EditingDataMiddleware', () => {
     expect(res.status).to.have.been.calledWith(200);
     expect(res.json).to.have.been.calledOnce;
     expect(res.json).to.have.been.calledWith(mockEditingData);
+  });
+
+  it('should stop request and return 401 when CORS match is not met', async () => {
+    const req = mockRequest('GET', {}, {}, { origin: 'https://notallowed.com' });
+    const res = mockResponse();
+    const cache = mockCache();
+    const middleware = new EditingDataMiddleware({ editingDataCache: cache });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(401);
+    expect(res.json).to.have.been.calledOnce;
+    expect(res.json).to.have.been.calledWith({ message: 'Invalid origin' });
   });
 
   it('should respond with 400 for invalid editing data', async () => {

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.ts
@@ -1,8 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { EditingDataCache, editingDataDiskCache } from './editing-data-cache';
 import { EditingData, isEditingData } from './editing-data';
-import { QUERY_PARAM_EDITING_SECRET } from './constants';
+import { EDITING_ALLOWED_ORIGINS, QUERY_PARAM_EDITING_SECRET } from './constants';
 import { getJssEditingSecret } from '../utils/utils';
+import { enforceCors } from '../utils';
+import { debug } from '@sitecore-jss/sitecore-jss';
 
 export interface EditingDataMiddlewareConfig {
   /**
@@ -51,6 +53,12 @@ export class EditingDataMiddleware {
     const secret = query[QUERY_PARAM_EDITING_SECRET];
     const key = query[this.queryParamKey];
 
+    if (!enforceCors(req, res, EDITING_ALLOWED_ORIGINS)) {
+      debug.editing(
+        'invalid origin host - set allowed origins in API_ALLOWED_ORIGINS env property'
+      );
+      return res.status(401).json({ message: 'Invalid origin' });
+    }
     // Validate secret
     if (secret !== getJssEditingSecret()) {
       res.status(401).end('Missing or invalid secret');

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -32,12 +32,23 @@ type Query = {
   [key: string]: string;
 };
 
-const mockRequest = (body?: any, query?: Query, method?: string, host?: string) => {
+const allowedOrigin = 'https://allowed.com';
+
+const mockRequest = (
+  body?: any,
+  query?: Query,
+  method?: string,
+  headers?: { [key: string]: string }
+) => {
   return {
     body: body ?? {},
     method: method ?? 'POST',
     query: query ?? {},
-    headers: { host: host ?? 'localhost:3000' },
+    headers: {
+      host: 'localhost:3000',
+      origin: allowedOrigin,
+      ...headers,
+    },
   } as NextApiRequest;
 };
 
@@ -83,12 +94,14 @@ describe('EditingRenderMiddleware', () => {
 
   beforeEach(() => {
     process.env.JSS_EDITING_SECRET = secret;
+    process.env.API_ALLOWED_ORIGINS = allowedOrigin;
     delete process.env.VERCEL;
   });
 
   after(() => {
     delete process.env.JSS_EDITING_SECRET;
     delete process.env.VERCEL;
+    delete process.env.API_ALLOWED_ORIGINS;
   });
 
   it('should handle request', async () => {
@@ -312,6 +325,27 @@ describe('EditingRenderMiddleware', () => {
     expect(res.json).to.have.been.calledOnce;
   });
 
+  it('should stop request and return 401 when CORS match is not met', async () => {
+    const req = mockRequest({}, {}, 'POST', { origin: 'https://notallowed.com' });
+    const res = mockResponse();
+    const fetcher = mockFetcher();
+    const dataService = mockDataService();
+    const middleware = new EditingRenderMiddleware({
+      dataFetcher: fetcher,
+      editingDataService: dataService,
+    });
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(401);
+    expect(res.json).to.have.been.calledOnce;
+    expect(res.json).to.have.been.calledWith({
+      html: '<html><body>Requests from origin https://notallowed.com not allowed</body></html>',
+    });
+  });
+
   it('should respond with 401 for missing secret', async () => {
     const fetcher = mockFetcher();
     const dataService = mockDataService();
@@ -381,7 +415,7 @@ describe('EditingRenderMiddleware', () => {
     const dataService = mockDataService();
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(EE_BODY, query, undefined, 'testhostheader.com');
+    const req = mockRequest(EE_BODY, query, undefined, { host: 'testhostheader.com' });
     const res = mockResponse();
 
     const middleware = new EditingRenderMiddleware({
@@ -401,7 +435,7 @@ describe('EditingRenderMiddleware', () => {
     const dataService = mockDataService();
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
-    const req = mockRequest(EE_BODY, query, undefined, 'vercel.com');
+    const req = mockRequest(EE_BODY, query, undefined, { host: 'vercel.com' });
     const res = mockResponse();
     process.env.VERCEL = '1';
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -5,9 +5,10 @@ import { EDITING_COMPONENT_ID, RenderingType } from '@sitecore-jss/sitecore-jss/
 import { parse } from 'node-html-parser';
 import { EditingData } from './editing-data';
 import { EditingDataService, editingDataService } from './editing-data-service';
-import { QUERY_PARAM_EDITING_SECRET } from './constants';
+import { EDITING_ALLOWED_ORIGINS, QUERY_PARAM_EDITING_SECRET } from './constants';
 import { getJssEditingSecret } from '../utils/utils';
 import { RenderMiddlewareBase } from './render-middleware';
+import { enforceCors } from '../utils';
 
 export interface EditingRenderMiddlewareConfig {
   /**
@@ -86,6 +87,15 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
       headers,
       body,
     });
+
+    if (!enforceCors(req, res, EDITING_ALLOWED_ORIGINS)) {
+      debug.editing(
+        'invalid origin host - set allowed origins in API_ALLOWED_ORIGINS env property'
+      );
+      return res.status(401).json({
+        html: `<html><body>Requests from origin ${req.headers?.origin} not allowed</body></html>`,
+      });
+    }
 
     if (method !== 'POST') {
       debug.editing('invalid method - sent %s expected POST', method);

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -18,12 +18,18 @@ type Query = {
   [key: string]: string;
 };
 
-const mockRequest = (query?: Query, method?: string, host?: string) => {
+const allowedOrigin = 'https://allowed.com';
+
+const mockRequest = (query?: Query, method?: string, headers?: { [key: string]: string }) => {
   return {
     body: {},
     method: method ?? 'GET',
     query: query ?? {},
-    headers: { host: host ?? 'localhost:3000' },
+    headers: {
+      host: 'localhost:3000',
+      origin: allowedOrigin,
+      ...headers,
+    },
   } as NextApiRequest;
 };
 
@@ -53,10 +59,12 @@ describe('FEAASRenderMiddleware', () => {
 
   beforeEach(() => {
     process.env.JSS_EDITING_SECRET = secret;
+    process.env.API_ALLOWED_ORIGINS = allowedOrigin;
   });
 
   after(() => {
     delete process.env.JSS_EDITING_SECRET;
+    delete process.env.API_ALLOWED_ORIGINS;
   });
 
   it('should handle request', async () => {
@@ -135,6 +143,22 @@ describe('FEAASRenderMiddleware', () => {
     expect(res.send).to.have.been.calledOnce;
     expect(res.send).to.have.been.calledWith(
       "<html><body>Invalid request method 'POST'</body></html>"
+    );
+  });
+
+  it('should stop request and return 401 when CORS match is not met', async () => {
+    const req = mockRequest({}, 'POST', { origin: 'https://notallowed.com' });
+    const res = mockResponse();
+    const middleware = new FEAASRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnce;
+    expect(res.status).to.have.been.calledWith(401);
+    expect(res.send).to.have.been.calledOnce;
+    expect(res.send).to.have.been.calledWith(
+      '<html><body>Requests from origin https://notallowed.com are not allowed</body></html>'
     );
   });
 

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
@@ -1,8 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { debug } from '@sitecore-jss/sitecore-jss';
-import { QUERY_PARAM_EDITING_SECRET } from './constants';
+import { EDITING_ALLOWED_ORIGINS, QUERY_PARAM_EDITING_SECRET } from './constants';
 import { getJssEditingSecret } from '../utils/utils';
 import { RenderMiddlewareBase } from './render-middleware';
+import { enforceCors } from '../utils';
 
 /**
  * Configuration for `FEAASRenderMiddleware`.
@@ -51,6 +52,14 @@ export class FEAASRenderMiddleware extends RenderMiddlewareBase {
       query,
       headers,
     });
+
+    if (!enforceCors(req, res, EDITING_ALLOWED_ORIGINS)) {
+      return res
+        .status(401)
+        .send(
+          `<html><body>Requests from origin ${req.headers?.origin} are not allowed</body></html>`
+        );
+    }
 
     if (method !== 'GET') {
       debug.editing('invalid method - sent %s expected GET', method);

--- a/packages/sitecore-jss-nextjs/src/utils/index.ts
+++ b/packages/sitecore-jss-nextjs/src/utils/index.ts
@@ -4,4 +4,5 @@ export {
   isEditorActive,
   resetEditorChromes,
   resolveUrl,
+  enforceCors,
 } from '@sitecore-jss/sitecore-jss/utils';

--- a/packages/sitecore-jss/src/utils/index.ts
+++ b/packages/sitecore-jss/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { default as isServer } from './is-server';
-export { resolveUrl, isAbsoluteUrl, isTimeoutError } from './utils';
+export { resolveUrl, isAbsoluteUrl, isTimeoutError, enforceCors } from './utils';
 export { tryParseEnvValue } from './env';
 export {
   ExperienceEditor,

--- a/packages/sitecore-jss/src/utils/utils.test.ts
+++ b/packages/sitecore-jss/src/utils/utils.test.ts
@@ -202,7 +202,7 @@ describe('utils', () => {
       return res;
     };
 
-    it('should return true if origin matches allowedOrigins from API_ALLOWED_ORIGINS env variable', () => {
+    it('should return true if origin is found in allowedOrigins from API_ALLOWED_ORIGINS env variable', () => {
       const req = mockRequest();
       const res = mockResponse();
       process.env.API_ALLOWED_ORIGINS = mockOrigin;
@@ -210,7 +210,7 @@ describe('utils', () => {
       delete process.env.API_ALLOWED_ORIGINS;
     });
 
-    it('should return true if origin matches allowedOrigins passed as argument', () => {
+    it('should return true if origin is found in allowedOrigins passed as argument', () => {
       const req = mockRequest('http://allowed.com');
       const res = mockResponse();
 
@@ -223,6 +223,12 @@ describe('utils', () => {
       process.env.API_ALLOWED_ORIGINS = 'https://strictallowed.com, https://alsoallowed.com';
       expect(enforceCors(req, res, ['https://paramallowed.com'])).to.be.equal(false);
       delete process.env.API_ALLOWED_ORIGINS;
+    });
+
+    it('should return true when origin matches a wildcard value from allowedOrigins', () => {
+      const req = mockRequest('https://veryallowed.com');
+      const res = mockResponse();
+      expect(enforceCors(req, res, ['https://*owed.com'])).to.be.equal(true);
     });
 
     it('should set Access-Control-Allow-Origin header for matching origin', () => {

--- a/packages/sitecore-jss/src/utils/utils.test.ts
+++ b/packages/sitecore-jss/src/utils/utils.test.ts
@@ -2,7 +2,8 @@
 import { expect, spy } from 'chai';
 import { isEditorActive, resetEditorChromes, isServer, resolveUrl } from '.';
 import { ChromeRediscoveryGlobalFunctionName } from './editing';
-import { isAbsoluteUrl, isTimeoutError } from './utils';
+import { enforceCors, isAbsoluteUrl, isTimeoutError } from './utils';
+import { IncomingMessage, OutgoingMessage } from 'http';
 
 // must make TypeScript happy with `global` variable modification
 interface CustomWindow {
@@ -179,6 +180,57 @@ describe('utils', () => {
       expect(isTimeoutError({ code: 'ETIMEDOUT' })).to.be.true;
       expect(isTimeoutError({ response: { status: 408 } })).to.be.true;
       expect(isTimeoutError({ name: 'AbortError' })).to.be.true;
+    });
+  });
+
+  describe('enforceCors', () => {
+    const mockOrigin = 'https://maybeallowed.com';
+    const mockRequest = (origin?: string) => {
+      return {
+        headers: {
+          origin: origin || mockOrigin,
+        },
+      } as IncomingMessage;
+    };
+
+    const mockResponse = () => {
+      const res = {} as OutgoingMessage;
+      res.setHeader = spy(() => {
+        return res;
+      });
+
+      return res;
+    };
+
+    it('should return true if origin matches allowedOrigins from API_ALLOWED_ORIGINS env variable', () => {
+      const req = mockRequest();
+      const res = mockResponse();
+      process.env.API_ALLOWED_ORIGINS = mockOrigin;
+      expect(enforceCors(req, res)).to.be.equal(true);
+      delete process.env.API_ALLOWED_ORIGINS;
+    });
+
+    it('should return true if origin matches allowedOrigins passed as argument', () => {
+      const req = mockRequest('http://allowed.com');
+      const res = mockResponse();
+
+      expect(enforceCors(req, res, ['http://allowed.com'])).to.be.equal(true);
+    });
+
+    it('should return false if origin matches neither allowedOrigins from API_ALLOWED_ORIGINS env variable nor argument', () => {
+      const req = mockRequest('https://notallowed.com');
+      const res = mockResponse();
+      process.env.API_ALLOWED_ORIGINS = 'https://strictallowed.com, https://alsoallowed.com';
+      expect(enforceCors(req, res, ['https://paramallowed.com'])).to.be.equal(false);
+      delete process.env.API_ALLOWED_ORIGINS;
+    });
+
+    it('should set Access-Control-Allow-Origin header for matching origin', () => {
+      const req = mockRequest();
+      const res = mockResponse();
+
+      enforceCors(req, res, [mockOrigin]);
+      expect(res.setHeader).to.have.been.called.with('Access-Control-Allow-Origin', mockOrigin);
     });
   });
 });

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -77,6 +77,10 @@ export const isTimeoutError = (error: unknown) => {
   );
 };
 
+const convertToRegex = (pattern: string) => {
+  return pattern.replace('.', '\\.').replace(/\*/g, '.*');
+};
+
 export const enforceCors = (
   req: IncomingMessage,
   res: OutgoingMessage,
@@ -87,7 +91,14 @@ export const enforceCors = (
     : [];
   allowedOrigins = defaultAllowedOrigins.concat(allowedOrigins || []);
   const origin = req.headers.origin;
-  if (origin && allowedOrigins.includes(origin)) {
+  if (
+    origin &&
+    allowedOrigins.some(
+      (allowedOrigin) =>
+        origin === allowedOrigin ||
+        new RegExp('^' + convertToRegex(allowedOrigin) + '$').test(origin)
+    )
+  ) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH');
     return true;

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -2,6 +2,7 @@ import isServer from './is-server';
 import { ParsedUrlQueryInput } from 'querystring';
 import { AxiosError } from 'axios';
 import { ResponseError } from '../data-fetcher';
+import { IncomingMessage, OutgoingMessage } from 'http';
 
 /**
  * note: encodeURIComponent is available via browser (window) or natively in node.js
@@ -74,4 +75,22 @@ export const isTimeoutError = (error: unknown) => {
     (error as ResponseError).response?.status === 408 ||
     (error as Error).name === 'AbortError'
   );
+};
+
+export const enforceCors = (
+  req: IncomingMessage,
+  res: OutgoingMessage,
+  allowedOrigins?: string[]
+): boolean => {
+  const defaultAllowedOrigins = process.env.API_ALLOWED_ORIGINS
+    ? process.env.API_ALLOWED_ORIGINS.replace(' ', '').split(',')
+    : [];
+  allowedOrigins = defaultAllowedOrigins.concat(allowedOrigins || []);
+  const origin = req.headers.origin;
+  if (origin && allowedOrigins.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH');
+    return true;
+  }
+  return false;
 };


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
CORS configuration through next config only allows to set a single allowed origin - or a wildcard.
JSS editing API endpoints require a more sophisticated configuration. This PR adds a function to validate incoming origin against multiple possible values, with an option to configure more allowed origins through env variable. 
It also applies this CORS validation function to editing middleware handlers:
- ensures handler stops execution when incoming request's origin does not match allowed origins list
- Sitecore Pages' hostnames are tested against by default

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
