### PR TITLE
[sitecore-jss-react] ErrorBoundary nested components fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss-react]`Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786) [#1790](https://github.com/Sitecore/jss/pull/1790) [#1793](https://github.com/Sitecore/jss/pull/1793) [#1794](https://github.com/Sitecore/jss/pull/1794))
+* `[sitecore-jss-react]`Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786) [#1790](https://github.com/Sitecore/jss/pull/1790) [#1793](https://github.com/Sitecore/jss/pull/1793) [#1794](https://github.com/Sitecore/jss/pull/1794) [#1799](https://github.com/Sitecore/jss/pull/1799))
 
 ## 22.0.0
 

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
@@ -32,7 +32,7 @@ describe('ErrorBoundary', () => {
 
       const rendered = mount(
         <SitecoreContextReactContext.Provider value={testComponentProps}>
-          <ErrorBoundary rendering={rendering} customErrorComponent={CustomErrorComponent}>
+          <ErrorBoundary rendering={rendering} errorComponent={CustomErrorComponent}>
             <TestErrorComponent />
           </ErrorBoundary>
         </SitecoreContextReactContext.Provider>
@@ -148,7 +148,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = mount(
-        <ErrorBoundary customErrorComponent={CustomErrorComponent}>
+        <ErrorBoundary errorComponent={CustomErrorComponent}>
           <TestErrorComponent />
         </ErrorBoundary>
       );
@@ -254,7 +254,7 @@ describe('ErrorBoundary', () => {
       };
 
       const rendered = mount(
-        <ErrorBoundary customErrorComponent={CustomErrorComponent}>
+        <ErrorBoundary errorComponent={CustomErrorComponent}>
           <TestErrorComponent />
         </ErrorBoundary>
       );

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { ComponentRendering, LayoutServicePageState } from '@sitecore-jss/siteco
 import { withSitecoreContext } from '../enhancers/withSitecoreContext';
 import { SitecoreContextValue } from './SitecoreContext';
 
-type CustomErrorComponentProps = {
+type ErrorComponentProps = {
   [prop: string]: unknown;
 };
 
@@ -11,9 +11,7 @@ export type ErrorBoundaryProps = {
   children: ReactNode;
   sitecoreContext: SitecoreContextValue;
   type: string;
-  customErrorComponent?:
-    | React.ComponentClass<CustomErrorComponentProps>
-    | React.FC<CustomErrorComponentProps>;
+  errorComponent?: React.ComponentClass<ErrorComponentProps> | React.FC<ErrorComponentProps>;
   rendering?: ComponentRendering;
   componentLoadingMessage?: string;
 };
@@ -56,8 +54,8 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
 
   render() {
     if (this.state.error) {
-      if (this.props.customErrorComponent) {
-        return <this.props.customErrorComponent error={this.state.error} />;
+      if (this.props.errorComponent) {
+        return <this.props.errorComponent error={this.state.error} />;
       } else {
         if (this.showErrorDetails()) {
           return (

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -462,7 +462,7 @@ describe('<Placeholder />', () => {
       <Placeholder name={phKey} rendering={component} componentFactory={componentFactory} />
     );
 
-    const eeChrome = renderedComponent.find({ chrometype: 'placeholder', kind: 'open', id: phKey });
+    const eeChrome = renderedComponent.find(`code#${phKey}[chrometype="placeholder"][kind="open"]`);
     expect(eeChrome.length).to.eq(1);
     const keyAttribute = eeChrome.get(0).key;
     expect(keyAttribute).to.not.be.undefined;

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -275,12 +275,14 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
       const type = element.props.type === 'text/sitecore' ? element.props.type : '';
       return (
+        // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
+        // that's why we need to expose element's props here
         <ErrorBoundary
           key={element.type + '-' + id}
-          customErrorComponent={this.props.errorComponent}
-          rendering={element.props.rendering as ComponentRendering}
+          errorComponent={this.props.errorComponent}
           componentLoadingMessage={this.props.componentLoadingMessage}
           type={type}
+          {...element.props}
         >
           {element}
         </ErrorBoundary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow up to https://github.com/Sitecore/jss/pull/1786 . It aims to fix an issue in the case where parent component is being used with withPlaceholder HOC and references its child components' props (this issue was caught in automated rendering tests for styleguide tabs component); since each child component is wrapped by ErrorBoundary, this adds additional level of nesting and changes the way parent should access its children's props; this is solved by exposing components props inside the error boundary. 
This PR also: 
- renames ErrorBoundary's customErrorComponent prop;
- updates failing Placeholder unit test to not select ErrorBoundary and check only html elements;

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
