### PR TITLE
[Editing Integration] Render clientScripts / clientData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Change
 
-*  Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792)) ([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))
+*  Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))
   * `[sitecore-jss-react]` Introduces `PlaceholderMetadata` component which supports the hydration of chromes on Pages by rendering  the components and placeholders with required metadata.
   * `[sitecore-jss]` Chromes are hydrated based on the basis of new `editMode` property derived from LayoutData, which is defined as an enum consisting of `metadata` and `chromes`.
   * `ComponentConsumerProps` is removed. You might need to reuse _WithSitecoreContextProps_ type.
   * `[sitecore-jss-react]` `[sitecore-jss-nextjs]` Introduce FieldMetadata component and functionality to render it when metadata field property is provided in the field's layout data. In such case the field component is wrapped with metadata markup to enable chromes hydration when editing in pages. Ability to render metadata has been added to the field rendering components for react and nextjs.
+  * `[sitecore-jss-react]` Introduced `EditingScripts` component to render clientScripts / clientData in editing.
 
 ## 22.0.0
 

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -44,3 +44,17 @@
         ```
             configText += `config.${prop} = process.env.${constantCase(prop)} || '${config[prop]?.trim()}';\n`;
         ```
+
+# nextjs-xmcloud
+
+* Render a new `EditingScripts` component in your `Scripts.ts` file to support a new Editing Integration feature.
+    ```
+    import { EditingScripts } from '@sitecore-jss/sitecore-jss-nextjs';
+    ...
+    const Scripts = (): JSX.Element | null => {
+        <>
+        <EditingScripts />
+        ...
+        </>
+    );
+    ```

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/Scripts.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/src/Scripts.tsx
@@ -1,3 +1,4 @@
+import { EditingScripts } from '@sitecore-jss/sitecore-jss-nextjs';
 // The BYOC bundle imports external (BYOC) components into the app and makes sure they are ready to be used
 import BYOC from 'src/byoc';
 import CdpPageView from 'components/CdpPageView';
@@ -9,6 +10,7 @@ const Scripts = (): JSX.Element => {
       <BYOC />
       <CdpPageView />
       <FEAASScripts />
+      <EditingScripts />
     </>
   );
 };

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -169,4 +169,5 @@ export {
   WithSitecoreContextOptions,
   WithSitecoreContextProps,
   withFieldMetadata,
+  EditingScripts,
 } from '@sitecore-jss/sitecore-jss-react';

--- a/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
@@ -1,0 +1,165 @@
+/* eslint-disable no-unused-expressions */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import {
+  EditMode,
+  LayoutServiceData,
+  LayoutServicePageState,
+} from '@sitecore-jss/sitecore-jss/layout';
+import { EditingScripts } from './EditingScripts';
+import { SitecoreContext } from './SitecoreContext';
+import { ComponentFactory } from './sharedTypes';
+
+describe('<EditingScripts />', () => {
+  const mockComponentFactory: ComponentFactory = () => null;
+
+  const getLayoutData = ({
+    editMode,
+    pageState,
+    pageEditing,
+    clientData,
+    clientScripts,
+  }: {
+    editMode?: EditMode;
+    pageState: LayoutServicePageState;
+    pageEditing: boolean;
+    clientData?: Record<string, Record<string, unknown>>;
+    clientScripts?: string[];
+  }): LayoutServiceData => ({
+    sitecore: {
+      context: {
+        editMode,
+        pageState,
+        pageEditing,
+        site: {
+          name: 'JssTestWeb',
+        },
+        language: 'en',
+        clientData: clientData || {
+          foo: {
+            x: 1,
+            y: '1',
+            z: true,
+          },
+          bar: {
+            a: 2,
+            b: '2',
+            c: false,
+          },
+        },
+        clientScripts: clientScripts || [
+          'http://test.foo/script1.js',
+          'http://test.foo/script2.js',
+        ],
+      },
+      route: null,
+    },
+  });
+
+  it('should render nothing when not in editing', () => {
+    const layoutData = getLayoutData({
+      pageState: LayoutServicePageState.Normal,
+      pageEditing: false,
+    });
+
+    const component = mount(
+      <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
+        <EditingScripts />
+      </SitecoreContext>
+    );
+
+    const scripts = component.find('EditingScripts');
+
+    expect(scripts.html()).to.be.null;
+    expect(scripts.find('script')).to.have.length(0);
+  });
+
+  ['Preview', 'Edit'].forEach((pageState) => {
+    it(`should render nothing when ${pageState} and edit mode is Chromes`, () => {
+      const layoutData = getLayoutData({
+        editMode: EditMode.Chromes,
+        pageState: LayoutServicePageState[pageState],
+        pageEditing: true,
+      });
+
+      const component = mount(
+        <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
+          <EditingScripts />
+        </SitecoreContext>
+      );
+
+      const scripts = component.find('EditingScripts');
+
+      expect(scripts.html()).to.be.null;
+      expect(scripts.find('script')).to.have.length(0);
+    });
+
+    describe(`should render scripts when ${pageState} and edit mode is Metadata`, () => {
+      it('should render scripts', () => {
+        const layoutData = getLayoutData({
+          editMode: EditMode.Metadata,
+          pageState: LayoutServicePageState[pageState],
+          pageEditing: true,
+        });
+
+        const component = mount(
+          <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
+            <EditingScripts />
+          </SitecoreContext>
+        );
+
+        const scripts = component.find('EditingScripts');
+
+        expect(scripts.find('script')).to.have.length(4);
+
+        const script1 = scripts.find('script').at(0);
+        expect(script1.prop('src')).to.equal('http://test.foo/script1.js');
+
+        const script2 = scripts.find('script').at(1);
+        expect(script2.prop('src')).to.equal('http://test.foo/script2.js');
+
+        const script3 = scripts.find('script').at(2);
+        expect(script3.prop('id')).to.equal('foo');
+        expect(script3.prop('type')).to.equal('application/json');
+        expect(script3.prop('dangerouslySetInnerHTML')).to.deep.equal({
+          __html: '{"x":1,"y":"1","z":true}',
+        });
+        expect(script3.html()).to.equal(
+          '<script id="foo" type="application/json">{"x":1,"y":"1","z":true}</script>'
+        );
+
+        const script4 = scripts.find('script').at(3);
+        expect(script4.prop('id')).to.equal('bar');
+        expect(script4.prop('type')).to.equal('application/json');
+        expect(script4.prop('dangerouslySetInnerHTML')).to.deep.equal({
+          __html: '{"a":2,"b":"2","c":false}',
+        });
+        expect(script4.html()).to.equal(
+          '<script id="bar" type="application/json">{"a":2,"b":"2","c":false}</script>'
+        );
+      });
+
+      it('should render nothing when data is not provided', () => {
+        const layoutData = getLayoutData({
+          editMode: EditMode.Metadata,
+          pageState: LayoutServicePageState[pageState],
+          pageEditing: true,
+          clientData: {},
+          clientScripts: [],
+        });
+
+        const component = mount(
+          <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
+            <EditingScripts />
+          </SitecoreContext>
+        );
+
+        const scripts = component.find('EditingScripts');
+
+        expect(scripts.html()).to.equal('');
+        expect(scripts.find('script')).to.have.length(0);
+      });
+    });
+  });
+});

--- a/packages/sitecore-jss-react/src/components/EditingScripts.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { EditMode, LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
+import { useSitecoreContext } from '../enhancers/withSitecoreContext';
+
+/**
+ * Renders client scripts and data for editing/preview mode in Pages.
+ * This script is only rendered when EditMode is Metadata, otherwise it renders nothing.
+ */
+export const EditingScripts = (): JSX.Element => {
+  const {
+    sitecoreContext: { pageState, editMode, clientData, clientScripts },
+  } = useSitecoreContext();
+
+  // Don't render anything if not in editing/preview mode
+  if (pageState === LayoutServicePageState.Normal) return <></>;
+
+  if (editMode === EditMode.Metadata) {
+    return (
+      <>
+        {clientScripts?.map((src, index) => (
+          <script src={src} key={index} />
+        ))}
+        {clientData &&
+          Object.keys(clientData).map((id) => (
+            <script
+              key={id}
+              id={id}
+              type="application/json"
+              dangerouslySetInnerHTML={{ __html: JSON.stringify(clientData[id]) }}
+            />
+          ))}
+      </>
+    );
+  }
+
+  return <></>;
+};

--- a/packages/sitecore-jss-react/src/index.ts
+++ b/packages/sitecore-jss-react/src/index.ts
@@ -102,3 +102,4 @@ export { withDatasourceCheck } from './enhancers/withDatasourceCheck';
 export { EditFrameProps, EditFrame } from './components/EditFrame';
 export { ComponentBuilder, ComponentBuilderConfig } from './ComponentBuilder';
 export { withFieldMetadata } from './enhancers/withFieldMetadata';
+export { EditingScripts } from './components/EditingScripts';

--- a/packages/sitecore-jss/src/layout/models.ts
+++ b/packages/sitecore-jss/src/layout/models.ts
@@ -55,6 +55,8 @@ export interface LayoutServiceContext {
     name?: string;
   };
   editMode?: EditMode;
+  clientScripts?: string[];
+  clientData?: Record<string, Record<string, unknown>>;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
Introduced `EditingScripts` component to render clientScripts / clientData in editing. Pages requires scripts and data to be rendered in the app to enable editing features.
Used html `script` tag instead of next.js `Script` component since `Script` can't prerender the data if it's not used in a next.js custom `_document.tsx` file
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - Tested manually using mocked layout data. Local dev / prod.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
