### PR TITLE
[sitecore-jss-nexts] Consider existing CORS header when running enforceCors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-react]`Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786) [#1790](https://github.com/Sitecore/jss/pull/1790) [#1793](https://github.com/Sitecore/jss/pull/1793) [#1794](https://github.com/Sitecore/jss/pull/1794) [#1799](https://github.com/Sitecore/jss/pull/1799))
 
-* `[sitecore-jss-nextjs]` Enforce CORS policy that matches Sitecore Pages domains for editing middleware API endpoints ([#1798](https://github.com/Sitecore/jss/pull/1798))
+* `[sitecore-jss-nextjs]` Enforce CORS policy that matches Sitecore Pages domains for editing middleware API endpoints ([#1798](https://github.com/Sitecore/jss/pull/1798)[#1801](https://github.com/Sitecore/jss/pull/1801))
 
 ## 22.0.0
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.test.ts
@@ -33,6 +33,9 @@ const mockResponse = () => {
   res.setHeader = spy(() => {
     return res;
   });
+  res.getHeader = spy(() => {
+    return undefined;
+  });
   return res;
 };
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-middleware.test.ts
@@ -48,6 +48,9 @@ const mockResponse = () => {
   res.setHeader = spy(() => {
     return res;
   });
+  res.getHeader = spy(() => {
+    return undefined;
+  });
   return res;
 };
 

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -50,6 +50,9 @@ const mockResponse = () => {
   res.redirect = spy(() => {
     return res;
   });
+  res.getHeader = spy(() => {
+    return undefined;
+  });
 
   return res;
 };

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -107,10 +107,18 @@ export const enforceCors = (
   res: OutgoingMessage,
   allowedOrigins?: string[]
 ): boolean => {
+  if (!req.headers.origin) {
+    return true;
+  }
+
   const defaultAllowedOrigins = process.env.JSS_ALLOWED_ORIGINS
     ? process.env.JSS_ALLOWED_ORIGINS.replace(' ', '').split(',')
     : [];
   allowedOrigins = defaultAllowedOrigins.concat(allowedOrigins || []);
+  const presetCors = res.getHeader('Access-Control-Allow-Origin');
+  if (presetCors) {
+    allowedOrigins.push(presetCors as string);
+  }
   const origin = req.headers.origin;
   if (
     origin &&

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -118,7 +118,7 @@ export const enforceCors = (
     : [];
   // the allowedOrigins prop
   allowedOrigins = defaultAllowedOrigins.concat(allowedOrigins || []);
-  // and the existing CORS header, if present
+  // and the existing CORS header, if present (i.e. set by nextjs config)
   const presetCors = res.getHeader('Access-Control-Allow-Origin');
   if (presetCors) {
     allowedOrigins.push(presetCors as string);

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -95,7 +95,8 @@ const convertToWildcardRegex = (pattern: string) => {
 
 /**
  * Tests origin from incoming request against allowed origins list that can be
- * set in JSS's JSS_ALLOWED_ORIGINS env variable and/or passed via allowedOrigins param.
+ * set in JSS's JSS_ALLOWED_ORIGINS env variable, passed via allowedOrigins param and/or
+ * be already set in Access-Control-Allow-Origin by other logic.
  * Applies Access-Control-Allow-Origin and Access-Control-Allow-Methods on match
  * @param {IncomingMessage} req incoming request
  * @param {OutgoingMessage} res response to set CORS headers for
@@ -107,18 +108,22 @@ export const enforceCors = (
   res: OutgoingMessage,
   allowedOrigins?: string[]
 ): boolean => {
+  // origin in not present for non-CORS requests (e.g. server-side) - so we skip the checks
   if (!req.headers.origin) {
     return true;
   }
-
+  // 3 sources of allowed origins are considered: the env value
   const defaultAllowedOrigins = process.env.JSS_ALLOWED_ORIGINS
     ? process.env.JSS_ALLOWED_ORIGINS.replace(' ', '').split(',')
     : [];
+  // the allowedOrigins prop
   allowedOrigins = defaultAllowedOrigins.concat(allowedOrigins || []);
+  // and the existing CORS header, if present
   const presetCors = res.getHeader('Access-Control-Allow-Origin');
   if (presetCors) {
     allowedOrigins.push(presetCors as string);
   }
+
   const origin = req.headers.origin;
   if (
     origin &&


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Followup to https://github.com/Sitecore/jss/pull/1798 
EnforceCors function should also check the previously set CORS headers if present, as editing middleware will be requested from sitecoreApiHost too.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
