### PR TITLE
[sitecore-jss-react] Address later comments from PR 1807

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Change
 
-* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))
+* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))([#1809](https://github.com/Sitecore/jss/pull/1809))
   * `[sitecore-jss-react]` Introduces `PlaceholderMetadata` component which supports the hydration of chromes on Pages by rendering  the components and placeholders with required metadata.
   * `[sitecore-jss]` Chromes are hydrated based on the basis of new `editMode` property derived from LayoutData, which is defined as an enum consisting of `metadata` and `chromes`.
   * `ComponentConsumerProps` is removed. You might need to reuse `WithSitecoreContextProps` type.

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -95,7 +95,7 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
       isRawRendering(rendering)
     );
 
-    const components = this.getComponentsForRenderingData(placeholderData, this.isEmpty);
+    const components = this.getComponentsForRenderingData(placeholderData);
 
     if (this.props.renderEmpty && this.isEmpty) {
       const rendered = this.props.renderEmpty(components);

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -189,10 +189,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     );
   }
 
-  getComponentsForRenderingData(
-    placeholderData: (ComponentRendering | HtmlElementRendering)[],
-    isEmpty?: boolean
-  ) {
+  getComponentsForRenderingData(placeholderData: (ComponentRendering | HtmlElementRendering)[]) {
     const {
       name,
       fields: placeholderFields,
@@ -208,7 +205,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           ? (rendering as ComponentRendering).uid
           : `component-${index}`;
         const commonProps = { key };
-
+        let isEmpty = false;
         // if the element is not a 'component rendering', render it 'raw'
         if (
           !(rendering as ComponentRendering).componentName &&
@@ -223,8 +220,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
 
         if (componentRendering.componentName === HIDDEN_RENDERING_NAME) {
           component = hiddenRenderingComponent ?? HiddenRendering;
+          isEmpty = true;
         } else if (!componentRendering.componentName) {
           component = () => <></>;
+          isEmpty = true;
         } else {
           component = this.getComponentForRendering(componentRendering);
         }
@@ -248,6 +247,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           );
 
           component = missingComponentComponent ?? MissingComponent;
+          isEmpty = true;
         }
 
         const finalProps = {
@@ -272,8 +272,11 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           this.props.modifyComponentProps ? this.props.modifyComponentProps(finalProps) : finalProps
         );
 
-        const type = rendered.props.type === 'text/sitecore' ? rendered.props.type : '';
         if (!isEmpty) {
+          // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
+          const type = rendered.props.type === 'text/sitecore' ? rendered.props.type : '';
+          // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
+          // that's why we need to expose element's props here
           rendered = (
             <ErrorBoundary
               key={rendered.type + '-' + index}

--- a/packages/sitecore-jss-react/src/components/sharedTypes.ts
+++ b/packages/sitecore-jss-react/src/components/sharedTypes.ts
@@ -4,7 +4,10 @@ import { ComponentType } from 'react';
  * @param {string} componentName component to be imported from the component factory
  * @param {string?} exportName component to be imported in case you export multiple components from the same file
  */
-export type ComponentFactory = (componentName: string, exportName?: string) => ComponentType | null;
+export type ComponentFactory = (
+  componentName: string,
+  exportName?: string
+) => JssComponentType | null;
 
 /**
  * Component type returned from component builder / factory

--- a/packages/sitecore-jss-react/src/components/sharedTypes.ts
+++ b/packages/sitecore-jss-react/src/components/sharedTypes.ts
@@ -13,6 +13,7 @@ export type ComponentFactory = (
  * Component type returned from component builder / factory
  */
 export type JssComponentType = ComponentType & {
-  // all dynamic elements will have a separate render prop
+  // all elements created with nextjs dynamic() will have a separate render prop
+  // react elements will not have it - so it's optional here
   render?: { [key: string]: unknown };
 };


### PR DESCRIPTION
A quick follow up for https://github.com/Sitecore/jss/pull/1807 to address post-merge comments.
- Add missing comments
- Adjust the types in sharedTypes
- streamline the logic for not wrapping empty components in placeholder