### PR TITLE
[Chore] Bump node types to v20

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '16'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss]` `GraphQLRequestClientFactory` type is updated and `config` parameter is now optional. Since it should match `GraphQLRequestClient.createClientFactory` method return type ([#1806](https://github.com/Sitecore/jss/pull/1806))
 
+
+### 🧹 Chores
+
+* Update node/types to version 20 in all packages and samples ([#1810](https://github.com/Sitecore/jss/pull/1810))
+
 ## 22.0.0
 
 ### 🛠 Breaking Changes

--- a/packages/create-sitecore-jss/package.json
+++ b/packages/create-sitecore-jss/package.json
@@ -12,7 +12,7 @@
     "coverage": "nyc npm test"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",
@@ -49,7 +49,7 @@
     "@types/inquirer": "^9.0.3",
     "@types/minimist": "^1.2.2",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@types/sinon": "10.0.6",
     "@types/sinon-chai": "^3.2.9",
     "chai": "^4.3.7",

--- a/packages/create-sitecore-jss/src/common/processes/transform.test.ts
+++ b/packages/create-sitecore-jss/src/common/processes/transform.test.ts
@@ -64,7 +64,7 @@ describe('transform', () => {
         },
         devDependencies: {
           '@sitecore-jss/sitecore-jss-dev-tools': '^20.0.0-canary',
-          '@types/node': '^16.11.7',
+          '@types/node': '^20.14.2',
           typescript: '~4.3.5',
         },
         foo: {

--- a/packages/create-sitecore-jss/src/common/test-data/pkg.ts
+++ b/packages/create-sitecore-jss/src/common/test-data/pkg.ts
@@ -13,7 +13,7 @@ export const currentPkg = {
     chalk: '^4.1.2',
   },
   devDependencies: {
-    '@types/node': '^16.11.7',
+    '@types/node': '^20.14.2',
     typescript: '~4.3.5',
   },
   foo: {

--- a/packages/create-sitecore-jss/src/common/test-data/test.package.json
+++ b/packages/create-sitecore-jss/src/common/test-data/test.package.json
@@ -13,7 +13,7 @@
     "chalk": "^4.1.2"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "^20.14.2",
     "typescript": "~4.3.5"
   }
 }

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -88,7 +88,7 @@
     "@types/isomorphic-fetch": "0.0.35",
     "@types/jasmine": "~3.6.7",
     "@types/jasminewd2": "~2.0.8",
-    "@types/node": "~12.7.9",
+    "@types/node": "~20.14.2",
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "body-parser": "~1.19.0",

--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -44,7 +44,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@sitecore-jss/sitecore-jss-cli": "~22.1.0-canary",
     "@sitecore-jss/sitecore-jss-dev-tools": "~22.1.0-canary",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^5.49.0",

--- a/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/package.json
+++ b/packages/create-sitecore-jss/src/templates/node-headless-ssr-proxy/package.json
@@ -31,7 +31,7 @@
     "@types/compression": "^1.7.2",
     "@types/express": "^4.17.17",
     "@types/memory-cache": "^0.2.2",
-    "@types/node": "^18.14.0",
+    "@types/node": "^20.14.2",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5"
   },

--- a/packages/sitecore-jss-angular-schematics/package.json
+++ b/packages/sitecore-jss-angular-schematics/package.json
@@ -10,7 +10,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-angular-schematics src/jss-component/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.0",
-    "@types/node": "^18.19.0",
+    "@types/node": "^20.14.2",
     "jasmine": "^2.99.0",
     "nyc": "^15.1.0",
     "typescript": "~4.9.5"

--- a/packages/sitecore-jss-angular/package.json
+++ b/packages/sitecore-jss-angular/package.json
@@ -11,7 +11,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-angular src/public_api.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -34,7 +34,7 @@
     "@angular/platform-browser-dynamic": "~16.2.10",
     "@angular/router": "~16.2.10",
     "@types/jasmine": "^3.4.1",
-    "@types/node": "^18.19.0",
+    "@types/node": "^20.14.2",
     "codelyzer": "^6.0.1",
     "eslint": "~8.3.0",
     "eslint-plugin-deprecation": "^1.5.0",

--- a/packages/sitecore-jss-cli/package.json
+++ b/packages/sitecore-jss-cli/package.json
@@ -16,7 +16,7 @@
     "coverage": "nyc --require ts-node/register/transpile-only npm test"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "preferGlobal": true,
   "bin": {
@@ -46,7 +46,7 @@
     "@types/chai": "^4.2.4",
     "@types/cross-spawn": "^6.0.2",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@types/readline-sync": "^1.4.4",
     "@types/resolve": "^1.20.2",
     "@types/sinon": "^10.0.13",

--- a/packages/sitecore-jss-dev-tools/package.json
+++ b/packages/sitecore-jss-dev-tools/package.json
@@ -16,7 +16,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-dev-tools src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "bin": {
     "scjss-deploy": "./dist/cjs/bin/deploy.js",
@@ -36,7 +36,7 @@
     "@sitecore-jss/sitecore-jss": "22.1.0-canary.22",
     "axios": "^1.3.2",
     "chalk": "^4.1.2",
-    "chokidar": "^3.5.3",
+    "chokidar": "^3.6.0",
     "del": "^6.0.0",
     "express": "^4.18.2",
     "form-data": "^4.0.0",
@@ -66,7 +66,7 @@
     "@types/glob": "^8.0.1",
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@types/readline-sync": "^1.4.4",
     "@types/resolve": "^1.20.2",
     "@types/sinon": "^10.0.13",

--- a/packages/sitecore-jss-dev-tools/src/templating/utils.test.ts
+++ b/packages/sitecore-jss-dev-tools/src/templating/utils.test.ts
@@ -57,11 +57,13 @@ describe('utils', () => {
           ...baseDirent,
           isDirectory: () => true,
           name: 'parent',
+          parentPath: 'mockparent',
         },
         childFile: {
           ...baseDirent,
           isFile: () => true,
           name: 'child.tsx',
+          parentPath: 'mockparent',
         },
         resolveItemCb: callbackStub,
       };

--- a/packages/sitecore-jss-forms/package.json
+++ b/packages/sitecore-jss-forms/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-forms src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -30,7 +30,7 @@
     "@types/chai-string": "^1.4.2",
     "@types/lodash.unescape": "^4.0.7",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "axios": "^1.3.0",
     "chai": "^4.3.7",
     "chai-string": "^1.5.0",

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-nextjs --entryPoints src/index.ts --entryPoints src/monitoring/index.ts --entryPoints src/editing/index.ts --entryPoints src/middleware/index.ts --entryPoints src/context/index.ts --entryPoints src/utils/index.ts --entryPoints src/site/index.ts --entryPoints src/graphql/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -35,7 +35,7 @@
     "@types/chai-string": "^1.4.2",
     "@types/enzyme": "^3.10.12",
     "@types/mocha": "^10.0.1",
-    "@types/node": "~18.11.18",
+    "@types/node": "~20.14.2",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.0.10",

--- a/packages/sitecore-jss-proxy/package.json
+++ b/packages/sitecore-jss-proxy/package.json
@@ -15,7 +15,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-proxy src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -35,7 +35,7 @@
     "@types/chai": "^4.3.4",
     "@types/express": "^4.17.17",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.14.2",
+    "@types/node": "^20.14.2",
     "@types/set-cookie-parser": "^2.4.2",
     "chai": "^4.3.7",
     "del-cli": "^5.0.0",

--- a/packages/sitecore-jss-react-forms/package.json
+++ b/packages/sitecore-jss-react-forms/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-forms src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -29,7 +29,7 @@
     "@types/chai": "^4.3.4",
     "@types/enzyme": "^3.10.12",
     "@types/mocha": "^10.0.1",
-    "@types/node": "18.11.10",
+    "@types/node": "20.14.2",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",

--- a/packages/sitecore-jss-react-native/package.json
+++ b/packages/sitecore-jss-react-native/package.json
@@ -15,7 +15,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-react-native src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -62,7 +62,7 @@
     "react-native": "^0.63.4",
     "react-test-renderer": "^16.9.0",
     "ts-jest": "~26.0.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.7.0"
   },
   "overrides": {
     "@types/react-native": {

--- a/packages/sitecore-jss-react/package.json
+++ b/packages/sitecore-jss-react/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-react src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -31,7 +31,7 @@
     "@types/chai-string": "^1.4.2",
     "@types/enzyme": "^3.10.12",
     "@types/mocha": "^10.0.1",
-    "@types/node": "18.11.10",
+    "@types/node": "20.14.2",
     "@types/prop-types": "^15.7.5",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.0.10",

--- a/packages/sitecore-jss-rendering-host/package.json
+++ b/packages/sitecore-jss-rendering-host/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-rendering-host src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -40,7 +40,7 @@
     "@types/express-serve-static-core": "^4.17.33",
     "@types/glob": "^8.0.1",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@types/webpack": "5.28.5",
     "@types/webpack-dev-middleware": "2.0.5",
     "@types/webpack-dev-server": "3.1.7",

--- a/packages/sitecore-jss-vue/package.json
+++ b/packages/sitecore-jss-vue/package.json
@@ -15,7 +15,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss-vue src/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",
-    "@types/node": "^18.11.18",
+    "@types/node": "^20.14.2",
     "@vue/compiler-dom": "^3.2.45",
     "@vue/test-utils": "2.2.7",
     "@vue/vue3-jest": "^29.2.2",

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -14,7 +14,7 @@
     "generate-docs": "npx typedoc --plugin typedoc-plugin-markdown --readme none --out ../../ref-docs/sitecore-jss --entryPoints src/index.ts --entryPoints src/graphql/index.ts --entryPoints src/i18n/index.ts --entryPoints src/layout/index.ts --entryPoints src/media/index.ts --entryPoints src/personalize/index.ts --entryPoints src/site/index.ts --entryPoints src/tracking/index.ts --entryPoints src/utils/index.ts --entryPoints src/editing/index.ts --githubPages false"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "author": {
     "name": "Sitecore Corporation",
@@ -37,7 +37,7 @@
     "@types/lodash.unescape": "^4.0.6",
     "@types/memory-cache": "^0.2.1",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^16.11.6",
+    "@types/node": "^20.14.2",
     "@types/sinon": "^17.0.3",
     "@types/url-parse": "1.4.8",
     "chai": "^4.2.0",
@@ -51,7 +51,7 @@
     "sinon": "^17.0.1",
     "ts-node": "^8.4.1",
     "tslib": "^1.10.0",
-    "typescript": "~4.3.5"
+    "typescript": "~4.7.4"
   },
   "dependencies": {
     "axios": "^0.21.1",

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -7,11 +7,11 @@ import debug from './debug';
 
 use(spies);
 
-let fetchInput: RequestInfo | undefined;
+let fetchInput: URL | RequestInfo | undefined;
 let fetchInit: RequestInit | undefined;
 
 const mockFetch = (status: number, response: unknown = {}, jsonError?: string) => {
-  return (input: RequestInfo, init?: RequestInit) => {
+  return (input: URL | RequestInfo, init?: RequestInit) => {
     fetchInput = input;
     fetchInit = init;
     return Promise.resolve({

--- a/packages/sitecore-jss/tsconfig.json
+++ b/packages/sitecore-jss/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es6",
+    "useUnknownInCatchVariables": false,
     "module": "commonjs",
     "outDir": "dist/cjs",
     "typeRoots": ["node_modules/@types"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5507,7 +5507,7 @@ __metadata:
     "@angular-devkit/schematics": ~16.2.10
     "@schematics/angular": ~16.2.10
     "@types/jasmine": ^2.8.0
-    "@types/node": ^18.19.0
+    "@types/node": ^20.14.2
     chalk: ^2.4.2
     jasmine: ^2.99.0
     nyc: ^15.1.0
@@ -5531,7 +5531,7 @@ __metadata:
     "@angular/router": ~16.2.10
     "@sitecore-jss/sitecore-jss": 22.1.0-canary.22
     "@types/jasmine": ^3.4.1
-    "@types/node": ^18.19.0
+    "@types/node": ^20.14.2
     codelyzer: ^6.0.1
     eslint: ~8.3.0
     eslint-plugin-deprecation: ^1.5.0
@@ -5563,7 +5563,7 @@ __metadata:
     "@types/chai": ^4.2.4
     "@types/cross-spawn": ^6.0.2
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     "@types/readline-sync": ^1.4.4
     "@types/resolve": ^1.20.2
     "@types/sinon": ^10.0.13
@@ -5607,7 +5607,7 @@ __metadata:
     "@types/glob": ^8.0.1
     "@types/js-yaml": ^4.0.5
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     "@types/readline-sync": ^1.4.4
     "@types/resolve": ^1.20.2
     "@types/sinon": ^10.0.13
@@ -5617,7 +5617,7 @@ __metadata:
     axios: ^1.3.2
     chai: ^4.3.7
     chalk: ^4.1.2
-    chokidar: ^3.5.3
+    chokidar: ^3.6.0
     cross-env: ^7.0.3
     del: ^6.0.0
     del-cli: ^5.0.0
@@ -5659,7 +5659,7 @@ __metadata:
     "@types/chai-string": ^1.4.2
     "@types/lodash.unescape": ^4.0.7
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     axios: ^1.3.0
     chai: ^4.3.7
     chai-string: ^1.5.0
@@ -5686,7 +5686,7 @@ __metadata:
     "@types/chai-string": ^1.4.2
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
-    "@types/node": ~18.11.18
+    "@types/node": ~20.14.2
     "@types/prop-types": ^15.7.5
     "@types/react": ^18.2.22
     "@types/react-dom": ^18.0.10
@@ -5735,7 +5735,7 @@ __metadata:
     "@types/chai": ^4.3.4
     "@types/express": ^4.17.17
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.14.2
+    "@types/node": ^20.14.2
     "@types/set-cookie-parser": ^2.4.2
     chai: ^4.3.7
     del-cli: ^5.0.0
@@ -5758,7 +5758,7 @@ __metadata:
     "@types/chai": ^4.3.4
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
-    "@types/node": 18.11.10
+    "@types/node": 20.14.2
     "@types/prop-types": ^15.7.5
     "@types/react": ^18.0.25
     "@types/react-dom": ^18.0.9
@@ -5817,7 +5817,7 @@ __metadata:
     react-native-svg-uri: ^1.2.3
     react-test-renderer: ^16.9.0
     ts-jest: ~26.0.0
-    typescript: ~4.3.5
+    typescript: ~4.7.0
   peerDependencies:
     react: 16.13.1
     react-native: ^0.63.4
@@ -5834,7 +5834,7 @@ __metadata:
     "@types/chai-string": ^1.4.2
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
-    "@types/node": 18.11.10
+    "@types/node": 20.14.2
     "@types/prop-types": ^15.7.5
     "@types/react": ^18.2.22
     "@types/react-dom": ^18.0.10
@@ -5876,7 +5876,7 @@ __metadata:
     "@types/express-serve-static-core": ^4.17.33
     "@types/glob": ^8.0.1
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     "@types/webpack": 5.28.5
     "@types/webpack-dev-middleware": 2.0.5
     "@types/webpack-dev-server": 3.1.7
@@ -5903,7 +5903,7 @@ __metadata:
   dependencies:
     "@sitecore-jss/sitecore-jss": 22.1.0-canary.22
     "@types/jest": ^29.2.6
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     "@vue/compiler-dom": ^3.2.45
     "@vue/compiler-sfc": ^3.0.11
     "@vue/test-utils": 2.2.7
@@ -5935,7 +5935,7 @@ __metadata:
     "@types/lodash.unescape": ^4.0.6
     "@types/memory-cache": ^0.2.1
     "@types/mocha": ^9.0.0
-    "@types/node": ^16.11.6
+    "@types/node": ^20.14.2
     "@types/sinon": ^17.0.3
     "@types/url-parse": 1.4.8
     axios: ^0.21.1
@@ -5956,7 +5956,7 @@ __metadata:
     sinon: ^17.0.1
     ts-node: ^8.4.1
     tslib: ^1.10.0
-    typescript: ~4.3.5
+    typescript: ~4.7.4
     url-parse: ^1.5.9
   languageName: unknown
   linkType: soft
@@ -6631,26 +6631,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.11.10":
-  version: 18.11.10
-  resolution: "@types/node@npm:18.11.10"
-  checksum: 0f60cb090b2ee91fcd3dc4311bc1ed7889b92f14644c0069f100776f86474c12eebbcc6c75bc0d7d96b975a103b4d5d6b3c22b4e88bea6e7f4e2b1bb0daf5ea8
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^16.11.6":
-  version: 16.18.68
-  resolution: "@types/node@npm:16.18.68"
-  checksum: 094ae9ed80eed2af4bd34d551467e307f2ecb6efb0f8b872feebfb9da5ea4b446c5883c9abe2349f8ea2b78bdacd8726a946c27c2a246676c4c330e41ccb9284
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.11.18, @types/node@npm:^18.14.2, @types/node@npm:^18.19.0":
-  version: 18.19.3
-  resolution: "@types/node@npm:18.19.3"
+"@types/node@npm:20.14.2, @types/node@npm:^20.14.2, @types/node@npm:~20.14.2":
+  version: 20.14.2
+  resolution: "@types/node@npm:20.14.2"
   dependencies:
     undici-types: ~5.26.4
-  checksum: 58c4fa45a78fcec75c78182a4b266395905957633654eb0311c5f9c30ac15c179ea2287ab1af034e46c2db7bb0589ef0000ee64c1de8f568a0aad29eaadb100c
+  checksum: 265362479b8f3b50fcd1e3f9e9af6121feb01a478dff0335ae67cccc3babfe45d0f12209d3d350595eebd7e67471762697b877c380513f8e5d27a238fa50c805
   languageName: node
   linkType: hard
 
@@ -6658,13 +6644,6 @@ __metadata:
   version: 8.10.66
   resolution: "@types/node@npm:8.10.66"
   checksum: c52039de862654a139abdc6a51de532a69dd80516ac35a959c3b3a2831ecbaaf065b0df5f9db943f5e28b544ebb9a891730d52b52f7a169b86a82bc060210000
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:~18.11.18":
-  version: 18.11.19
-  resolution: "@types/node@npm:18.11.19"
-  checksum: d7cd19fcfc59cbdd3f9ba0b4072cb7adc21bd575bd8eb7d7e698975e63564aaa83f03434f32b12331f84f73d0b369d9cbe2371e359d9d7f5c3361f4987f4f7da
   languageName: node
   linkType: hard
 
@@ -10494,6 +10473,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "chokidar@npm:3.6.0"
+  dependencies:
+    anymatch: ~3.1.2
+    braces: ~3.0.2
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
+    is-binary-path: ~2.1.0
+    is-glob: ~4.0.1
+    normalize-path: ~3.0.0
+    readdirp: ~3.6.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: d2f29f499705dcd4f6f3bbed79a9ce2388cf530460122eed3b9c48efeab7a4e28739c6551fd15bec9245c6b9eeca7a32baa64694d64d9b6faeb74ddb8c4a413d
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -11332,7 +11330,7 @@ __metadata:
     "@types/inquirer": ^9.0.3
     "@types/minimist": ^1.2.2
     "@types/mocha": ^10.0.1
-    "@types/node": ^18.11.18
+    "@types/node": ^20.14.2
     "@types/sinon": 10.0.6
     "@types/sinon-chai": ^3.2.9
     chai: ^4.3.7
@@ -25588,17 +25586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.3.5":
-  version: 4.3.5
-  resolution: "typescript@npm:4.3.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
-  languageName: node
-  linkType: hard
-
-"typescript@npm:~4.7.4":
+"typescript@npm:~4.7.0, typescript@npm:~4.7.4":
   version: 4.7.4
   resolution: "typescript@npm:4.7.4"
   bin:
@@ -25618,17 +25606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.3.5#~builtin<compat/typescript>":
-  version: 4.3.5
-  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=ddd1e8"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 61fc1a2ca5037420de5bbe17c6ddc4cbcc0d52301ed94f0a7b5821c55ff9eb96307f0816f745ca8f0fc87ed92f3951cde6d97cd6fd6bc6920c02ea63b5b26259
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@~4.7.0#~builtin<compat/typescript>, typescript@patch:typescript@~4.7.4#~builtin<compat/typescript>":
   version: 4.7.4
   resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=ddd1e8"
   bin:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Simple update to node/types and dependencies that were failing with node 20.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - all packages and samples build OK

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore
