### PR TITLE
[Editing Integration] Metadata for root placeholder should use empty/default GUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Change
 
-* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))([#1809](https://github.com/Sitecore/jss/pull/1809))
+* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))([#1809](https://github.com/Sitecore/jss/pull/1809)) ([#1814](https://github.com/Sitecore/jss/pull/1814))
   * `[sitecore-jss-react]` Introduces `PlaceholderMetadata` component which supports the hydration of chromes on Pages by rendering  the components and placeholders with required metadata.
   * `[sitecore-jss]` Chromes are hydrated based on the basis of new `editMode` property derived from LayoutData, which is defined as an enum consisting of `metadata` and `chromes`.
   * `ComponentConsumerProps` is removed. You might need to reuse `WithSitecoreContextProps` type.

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -784,7 +784,7 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
   expect(renderedComponent.find('p').props().children).to.equal('Hidden Rendering');
 });
 
-describe.only('PlaceholderMetadata', () => {
+describe('PlaceholderMetadata', () => {
   const layoutDataForNestedPlaceholder = {
     sitecore: {
       context: {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -784,7 +784,7 @@ it('should render custom HiddenRendering when rendering is hidden', () => {
   expect(renderedComponent.find('p').props().children).to.equal('Hidden Rendering');
 });
 
-describe('PlaceholderMetadata', () => {
+describe.only('PlaceholderMetadata', () => {
   const layoutDataForNestedPlaceholder = {
     sitecore: {
       context: {
@@ -793,7 +793,6 @@ describe('PlaceholderMetadata', () => {
       },
       route: {
         name: 'main',
-        uid: 'root123',
         placeholders: {
           main: [
             {
@@ -842,7 +841,7 @@ describe('PlaceholderMetadata', () => {
 
     expect(wrapper.html()).to.equal(
       [
-        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_root123"></code>',
+        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_00000000-0000-0000-0000-000000000000"></code>',
         '<code type="text/sitecore" chrometype="rendering" class="scpm" kind="open" id="nested123"></code>',
         '<div class="header-wrapper">',
         '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="logo_nested123"></code>',
@@ -868,7 +867,6 @@ describe('PlaceholderMetadata', () => {
         },
         route: {
           name: 'main',
-          uid: 'root123',
           placeholders: {
             main: [],
           },
@@ -885,7 +883,7 @@ describe('PlaceholderMetadata', () => {
     expect(wrapper.html()).to.equal(
       [
         '<div class="sc-jss-empty-placeholder">',
-        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_root123"></code>',
+        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_00000000-0000-0000-0000-000000000000"></code>',
         '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="close"></code>',
         '</div>',
       ].join('')
@@ -901,7 +899,6 @@ describe('PlaceholderMetadata', () => {
         },
         route: {
           name: 'main',
-          uid: 'root123',
           placeholders: {
             main: [
               {
@@ -922,7 +919,7 @@ describe('PlaceholderMetadata', () => {
 
     expect(wrapper.html()).to.equal(
       [
-        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_root123"></code>',
+        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_00000000-0000-0000-0000-000000000000"></code>',
         '<code type="text/sitecore" chrometype="rendering" class="scpm" kind="open" id="123"></code>',
         '<div style="background:darkorange;outline:5px solid orange;padding:10px;color:white;max-width:500px"><h2>Unknown</h2><p>JSS component is missing React implementation. See the developer console for more information.</p></div>',
         '<code type="text/sitecore" chrometype="rendering" class="scpm" kind="close"></code>',

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -305,12 +305,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       .filter((element) => element); // remove nulls
 
     if (this.props.sitecoreContext?.editMode === EditMode.Metadata) {
-      // default value of uid for root placeholder when uid is not present.
-      const default_UID = '00000000-0000-0000-0000-000000000000';
       return [
         <PlaceholderMetadata
           key={(this.props.rendering as ComponentRendering).uid}
-          uid={(this.props.rendering as ComponentRendering).uid || default_UID}
+          uid={(this.props.rendering as ComponentRendering).uid}
           placeholderName={name}
         >
           {transformedComponents}

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -305,10 +305,12 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       .filter((element) => element); // remove nulls
 
     if (this.props.sitecoreContext?.editMode === EditMode.Metadata) {
+      // default value of uid for root placeholder when uid is not present.
+      const default_UID = '00000000-0000-0000-0000-000000000000';
       return [
         <PlaceholderMetadata
           key={(this.props.rendering as ComponentRendering).uid}
-          uid={(this.props.rendering as ComponentRendering).uid}
+          uid={(this.props.rendering as ComponentRendering).uid || default_UID}
           placeholderName={name}
         >
           {transformedComponents}

--- a/packages/sitecore-jss-react/src/components/PlaceholderMetadata.test.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderMetadata.test.tsx
@@ -46,6 +46,29 @@ describe('PlaceholderMetadata', () => {
     );
   });
 
+  it('renders placeholder code blocks when metadataType is a root placeholder and uid is undefined', () => {
+    const children = <div className="richtext-mock"></div>;
+    const wrapper = shallow(
+      <PlaceholderMetadata
+        rendering={{
+          componentName: 'RichText',
+          placeholders: { main: [] },
+        }}
+        placeholderName={'main'}
+      >
+        {children}
+      </PlaceholderMetadata>
+    );
+
+    expect(wrapper.html()).to.equal(
+      [
+        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="open" id="main_00000000-0000-0000-0000-000000000000"></code>',
+        '<div class="richtext-mock"></div>',
+        '<code type="text/sitecore" chrometype="placeholder" class="scpm" kind="close"></code>',
+      ].join('')
+    );
+  });
+
   it('renders placeholder code blocks when metadataType is dynamic placeholder', () => {
     const children = <div className="richtext-mock"></div>;
     const wrapper = shallow(

--- a/packages/sitecore-jss-react/src/components/PlaceholderMetadata.test.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderMetadata.test.tsx
@@ -46,7 +46,7 @@ describe('PlaceholderMetadata', () => {
     );
   });
 
-  it('renders placeholder code blocks when metadataType is a root placeholder and uid is undefined', () => {
+  it('renders placeholder code blocks with DEFAULT_PLACEHOLDER_UID value when metadataType is a placeholder(root) and uid is not present', () => {
     const children = <div className="richtext-mock"></div>;
     const wrapper = shallow(
       <PlaceholderMetadata

--- a/packages/sitecore-jss-react/src/components/PlaceholderMetadata.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderMetadata.tsx
@@ -29,7 +29,7 @@ export type CodeBlockAttributes = {
  * @returns {JSX.Element} A React fragment containing open and close code blocks surrounding the children elements.
  */
 export const PlaceholderMetadata = ({
-  uid,
+  uid = '00000000-0000-0000-0000-000000000000',
   placeholderName,
   children,
 }: PlaceholderMetadataProps): JSX.Element => {

--- a/packages/sitecore-jss-react/src/components/PlaceholderMetadata.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderMetadata.tsx
@@ -20,6 +20,11 @@ export type CodeBlockAttributes = {
 };
 
 /**
+ * default value of uid for root placeholder when uid is not present.
+ */
+const DEFAULT_PLACEHOLDER_UID = '00000000-0000-0000-0000-000000000000';
+
+/**
  * A React component to generate metadata blocks for a placeholder or rendering.
  * It utilizes dynamic attributes based on whether the component acts as a placeholder
  * or as a rendering to properly render the surrounding code blocks.
@@ -55,7 +60,9 @@ export const PlaceholderMetadata = ({
 
         for (const placeholder of Object.keys(rendering.placeholders)) {
           if (placeholderName === placeholder) {
-            phId = `${placeholderName}_${id}`;
+            phId = id
+              ? `${placeholderName}_${id}`
+              : `${placeholderName}_${DEFAULT_PLACEHOLDER_UID}`;
             break;
           }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fix root placeholder code tags to use empty rendering UID

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
