### PR TITLE
[Next.js] Missing Props type in Styleguide-Layout-Tabs component

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-Layout-Tabs.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-styleguide/src/components/styleguide/Styleguide-Layout-Tabs.tsx
@@ -104,7 +104,7 @@ const tabsComponentWithPlaceholderInjected = withPlaceholder({
 // We need to know if experience editor is active, to disable the dynamic tab behavior for editing.
 // Using the same technique as injecting the placeholder, we wrap the component again to inject the
 // `sitecoreContext` prop.
-const tabsWithPlaceholderAndSitecoreContext = withSitecoreContext()(
+const tabsWithPlaceholderAndSitecoreContext = withSitecoreContext()<StyleguideLayoutTabsProps>(
   tabsComponentWithPlaceholderInjected
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
