### PR TITLE
[templates/nextjs-sxa]: Image component has been fixed for metadata mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]` Changed formatting in temp/config to prevent parse issues in Unix systems ([#1787](https://github.com/Sitecore/jss/pull/1787))([#1791](https://github.com/Sitecore/jss/pull/1791))
+* `[templates/nextjs-sxa]` The banner variant of image component is fixed with supporting metadata mode. ([#1826](https://github.com/Sitecore/jss/pull/1826))
 
 ### 🎉 New Features & Improvements
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
@@ -1,14 +1,14 @@
-import React, { CSSProperties } from 'react';
 import {
+  EditMode,
+  Field,
+  ImageField,
   Image as JssImage,
   Link as JssLink,
-  ImageField,
-  Field,
   LinkField,
   Text,
   useSitecoreContext,
-  EditMode,
 } from '@sitecore-jss/sitecore-jss-nextjs';
+import React, { CSSProperties } from 'react';
 
 interface Fields {
   Image: ImageField & { metadata?: { [key: string]: unknown } };
@@ -48,7 +48,14 @@ export const Banner = (props: ImageProps): JSX.Element => {
           ?.replace(`width="${props?.fields?.Image?.value?.width}"`, 'width="100%"')
           .replace(`height="${props?.fields?.Image?.value?.height}"`, 'height="100%"'),
       }
-    : { ...props.fields.Image };
+    : {
+      ...props.fields.Image,
+      value: {
+        ...props.fields.Image.value,
+        width: "100%",
+        height: "100%",
+      },
+    };
 
   return (
     <div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
Banner variant of image component has been fixed for metadata mode
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
