### PR TITLE
[Next.js] [Editing Integration] Secure hosting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Enforce CORS policy that matches Sitecore Pages domains for editing middleware API endpoints ([#1798](https://github.com/Sitecore/jss/pull/1798)[#1801](https://github.com/Sitecore/jss/pull/1801))
 * `[sitecore-jss]` _GraphQLRequestClient_ now can accept custom 'headers' in the constructor or via _createClientFactory_ ([#1806](https://github.com/Sitecore/jss/pull/1806))
 * `[templates/nextjs]` Removed cors header for API endpoints from _lib/next-config/plugins/cors-header_ plugin since cors is handled by API handlers / middlewares ([#1806](https://github.com/Sitecore/jss/pull/1806))
+* `[sitecore-jss-nextjs]` Updates to Next.js editing integration to further support secure hosting scenarios (on XM Cloud & Vercel) ([#1832](https://github.com/Sitecore/jss/pull/1832))
 
 ### 🛠 Breaking Change
 

--- a/packages/sitecore-jss-nextjs/src/editing/constants.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/constants.ts
@@ -1,6 +1,13 @@
 export const QUERY_PARAM_EDITING_SECRET = 'secret';
-export const QUERY_PARAM_PROTECTION_BYPASS_SITECORE = 'x-sitecore-protection-bypass';
-export const QUERY_PARAM_PROTECTION_BYPASS_VERCEL = 'x-vercel-protection-bypass';
+export const QUERY_PARAM_VERCEL_PROTECTION_BYPASS = 'x-vercel-protection-bypass';
+export const QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE = 'x-vercel-set-bypass-cookie';
+
+/**
+ * Headers that should be passed along to (Editing Chromes handler) SSR request.
+ * Note these are in lowercase format to match expected `IncomingHttpHeaders`.
+ */
+export const EDITING_PASS_THROUGH_HEADERS = ['authorization', 'cookie'];
+
 /**
  * Default allowed origins for editing requests. This is used to enforce CORS, CSP headers.
  */

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -5,8 +5,8 @@ import { expect, use } from 'chai';
 import { NextApiRequest, NextApiResponse } from 'next';
 import {
   QUERY_PARAM_EDITING_SECRET,
-  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
-  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+  QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
+  QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
 } from './constants';
 import { FEAASRenderMiddleware } from './feaas-render-middleware';
 import { spy } from 'sinon';
@@ -219,11 +219,11 @@ describe('FEAASRenderMiddleware', () => {
 
   it('should pass along protection bypass query parameters', async () => {
     const query = {} as Query;
-    const bypassTokenSitecore = 'token1234Sitecore';
-    const bypassTokenVercel = 'token1234Vercel';
+    const vercelBypassToken = 'token1234Vercel';
+    const vercelBypassCookie = 'samesitenone';
     query[QUERY_PARAM_EDITING_SECRET] = secret;
-    query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = bypassTokenSitecore;
-    query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = bypassTokenVercel;
+    query[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = vercelBypassToken;
+    query[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = vercelBypassCookie;
     const previewData = {};
 
     const req = mockRequest(query);
@@ -237,7 +237,7 @@ describe('FEAASRenderMiddleware', () => {
     expect(res.setPreviewData, 'set preview mode w/ data').to.have.been.calledWith(previewData);
     expect(res.redirect).to.have.been.calledOnce;
     expect(res.redirect).to.have.been.calledWith(
-      '/feaas/render?x-sitecore-protection-bypass=token1234Sitecore&x-vercel-protection-bypass=token1234Vercel'
+      `/feaas/render?${QUERY_PARAM_VERCEL_PROTECTION_BYPASS}=${vercelBypassToken}&${QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE}=${vercelBypassCookie}`
     );
   });
 });

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.test.ts
@@ -4,8 +4,9 @@ import chaiString from 'chai-string';
 import { RenderMiddlewareBase } from './render-middleware';
 import {
   QUERY_PARAM_EDITING_SECRET,
-  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
-  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+  QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
+  QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
+  EDITING_PASS_THROUGH_HEADERS,
 } from './constants';
 
 const expect = chai.use(chaiString).expect;
@@ -23,16 +24,32 @@ describe('RenderMiddlewareBase', () => {
 
       const secret = 'secret1234';
       const query = {} as Query;
-      const bypassTokenSitecore = 'token1234Sitecore';
-      const bypassTokenVercel = 'token1234Vercel';
+      const vercelBypassToken = 'token1234Vercel';
+      const vercelBypassCookie = 'samesitenone';
       query[QUERY_PARAM_EDITING_SECRET] = secret;
-      query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = bypassTokenSitecore;
-      query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = bypassTokenVercel;
+      query[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = vercelBypassToken;
+      query[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = vercelBypassCookie;
 
       expect(middleware['getQueryParamsForPropagation'](query)).to.deep.equal({
-        [QUERY_PARAM_PROTECTION_BYPASS_SITECORE]: bypassTokenSitecore,
-        [QUERY_PARAM_PROTECTION_BYPASS_VERCEL]: bypassTokenVercel,
+        [QUERY_PARAM_VERCEL_PROTECTION_BYPASS]: vercelBypassToken,
+        [QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE]: vercelBypassCookie,
       });
+    });
+  });
+
+  describe('getHeadersForPropagation', () => {
+    it('should return approved headers', () => {
+      const middleware = new SampleMiddleware();
+
+      const approvedHeaders = {};
+      EDITING_PASS_THROUGH_HEADERS.forEach((key) => (approvedHeaders[key] = `${key}-value`));
+      const allHeaders = {
+        ...approvedHeaders,
+        nope: 'nope',
+        'should-not-pass': 'n/a',
+      };
+
+      expect(middleware['getHeadersForPropagation'](allHeaders)).to.deep.equal(approvedHeaders);
     });
   });
 });

--- a/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/render-middleware.ts
@@ -1,7 +1,9 @@
 import {
-  QUERY_PARAM_PROTECTION_BYPASS_SITECORE,
-  QUERY_PARAM_PROTECTION_BYPASS_VERCEL,
+  QUERY_PARAM_VERCEL_PROTECTION_BYPASS,
+  QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE,
+  EDITING_PASS_THROUGH_HEADERS,
 } from './constants';
+import { IncomingHttpHeaders } from 'http';
 
 /**
  * Base class for middleware that handles pages and components rendering in Sitecore Editors.
@@ -16,16 +18,33 @@ export abstract class RenderMiddlewareBase {
     query: Partial<{ [key: string]: string | string[] }>
   ): { [key: string]: string } => {
     const params: { [key: string]: string } = {};
-    if (query[QUERY_PARAM_PROTECTION_BYPASS_SITECORE]) {
-      params[QUERY_PARAM_PROTECTION_BYPASS_SITECORE] = query[
-        QUERY_PARAM_PROTECTION_BYPASS_SITECORE
+    if (query[QUERY_PARAM_VERCEL_PROTECTION_BYPASS]) {
+      params[QUERY_PARAM_VERCEL_PROTECTION_BYPASS] = query[
+        QUERY_PARAM_VERCEL_PROTECTION_BYPASS
       ] as string;
     }
-    if (query[QUERY_PARAM_PROTECTION_BYPASS_VERCEL]) {
-      params[QUERY_PARAM_PROTECTION_BYPASS_VERCEL] = query[
-        QUERY_PARAM_PROTECTION_BYPASS_VERCEL
+    if (query[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE]) {
+      params[QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE] = query[
+        QUERY_PARAM_VERCEL_SET_BYPASS_COOKIE
       ] as string;
     }
     return params;
+  };
+
+  /**
+   * Get headers that should be passed along to subsequent requests
+   * @param {IncomingHttpHeaders} headers Incoming HTTP Headers
+   * @returns Object of approved headers
+   */
+  protected getHeadersForPropagation = (
+    headers: IncomingHttpHeaders
+  ): { [key: string]: string | string[] } => {
+    const result: { [key: string]: string | string[] } = {};
+    EDITING_PASS_THROUGH_HEADERS.forEach((header) => {
+      if (headers[header]) {
+        result[header] = headers[header]!;
+      }
+    });
+    return result;
   };
 }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation

Updates to Next.js editing integration to further support secure hosting scenarios (on XM Cloud & Vercel), including:

* Added header pass-through capability to the editing handler SSR request (_chromes_ edit mode). Headers which will be passed: `authorization`, `cookie`
* Removed experimental `x-sitecore-protection-bypass` query param propagation
* Added support for `x-vercel-set-bypass-cookie` query param propagation

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
