### PR TITLE
[template/angular] Fix `/graphql` page for all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss]` Introduced _/editing_ submodule that contains all editing related functionality. Editing utils are now available in _/editing_ submodule. Editing utils exported from _/utils_ marked as deprecated. ([#1806](https://github.com/Sitecore/jss/pull/1806))
 * `[sitecore-jss-nextjs]` EditingRenderMiddleware `resolvePageUrl` function now accepts an object `(args: { serverUrl?: string; itemPath: string }) => string` instead of multiple parameters `(serverUrl: string, itemPath: string) => string`. `serverUrl` is now optional and omitted when Metadata Edit Mode is used.
 * `[templates/nextjs]` `[sitecore-jss-nextjs]` `[sitecore-jss]` Remove Partial rendering implementation as it will not be used by Pages in its current implementation - includes removing of EditingComponentPlaceholder component, few constants associated with it and RenderingType enum ([#1821](https://github.com/Sitecore/jss/pull/1821))
-* `[sitecore-jss-angular]``[sitecore-jss-schematics]``[templates/angular]` Upgrade Angular to v17 ([#1837](https://github.com/Sitecore/jss/pull/1837))
+* `[sitecore-jss-angular]``[sitecore-jss-schematics]``[templates/angular]` Upgrade Angular to v17 ([#1837](https://github.com/Sitecore/jss/pull/1837)) ([#1840](https://github.com/Sitecore/jss/pull/1840))
   * Updated Angular and core dependencies to ~17.3.11
   * Updated Typescript to ~5.2.2
   * Updated import statements from zone.js/dist/zone-node to zone.js

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -61,7 +61,7 @@
     "@ngx-translate/core": "~15.0.0",
     "@ngx-translate/http-loader": "~8.0.0",
     "@sitecore-jss/sitecore-jss-angular": "~22.0.0",
-    "apollo-angular": "~7.0.2",
+    "apollo-angular": "~5.0.2",
     "bootstrap": "^5.3.3",
     "core-js": "~3.37.1",
     "graphql": "15.5.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow up to Angular 17 upgrade.
Bug--> /graphql pages not working.
After reverting apollo-angular dependency everything works as expected.
Graphql dependencies will be updated with Angular 18 since some of them are not compatible with 17.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
