### PR TITLE
[create-sitecore-jss] New initializer journey for Angular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,23 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+### 🎉 New Features & Improvements
+
+### 🛠 Breaking Change
+
+* `[create-sitecore-jss]` Rework Angular initializer to support XMCloud and SXP journeys ([#1845](https://github.com/Sitecore/jss/pull/1845))
+
+### 🧹 Chores
+
+## 22.1.0
+
+### 🐛 Bug Fixes
+
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]` Changed formatting in temp/config to prevent parse issues in Unix systems ([#1787](https://github.com/Sitecore/jss/pull/1787))([#1791](https://github.com/Sitecore/jss/pull/1791))
 * `[templates/nextjs-sxa]` The banner variant of image component is fixed with supporting metadata mode. ([#1826](https://github.com/Sitecore/jss/pull/1826))
 * `[sitecore-jss]` `[sitecore-jss-react]` DateField empty value is not treated as empty ([#1836](https://github.com/Sitecore/jss/pull/1836))
 
 ### 🎉 New Features & Improvements
-
-* `[create-sitecore-jss]``[angular]``[sitecore-jss-angular]` Introduce support for XM Cloud for Angular apps
-  * `[create-sitecore-jss]` Rework Angular initializer ([#1845](https://github.com/Sitecore/jss/pull/1845))
 
 * `[sitecore-jss-react]` Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786))([#1790](https://github.com/Sitecore/jss/pull/1790))([#1793](https://github.com/Sitecore/jss/pull/1793))([#1794](https://github.com/Sitecore/jss/pull/1794))([#1799](https://github.com/Sitecore/jss/pull/1799))([#1807](https://github.com/Sitecore/jss/pull/1807))([#1829](https://github.com/Sitecore/jss/pull/1829))
 * `[sitecore-jss-nextjs]` Enforce CORS policy that matches Sitecore Pages domains for editing middleware API endpoints ([#1798](https://github.com/Sitecore/jss/pull/1798)[#1801](https://github.com/Sitecore/jss/pull/1801))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[create-sitecore-jss]``[angular]``[sitecore-jss-angular]` Introduce support for XM Cloud for Angular apps
+  * `[create-sitecore-jss]` Rework Angular initializer ([#1845](https://github.com/Sitecore/jss/pull/1845))
+
 * `[sitecore-jss-react]` Introduce ErrorBoundary component. All rendered components are wrapped with it and it will catch client or server side errors from any of its children, display appropriate message and prevent the rest of the application from failing. It accepts and can display custom error component and loading message if it is passed as a prop to parent Placeholder. ([#1786](https://github.com/Sitecore/jss/pull/1786))([#1790](https://github.com/Sitecore/jss/pull/1790))([#1793](https://github.com/Sitecore/jss/pull/1793))([#1794](https://github.com/Sitecore/jss/pull/1794))([#1799](https://github.com/Sitecore/jss/pull/1799))([#1807](https://github.com/Sitecore/jss/pull/1807))([#1829](https://github.com/Sitecore/jss/pull/1829))
 * `[sitecore-jss-nextjs]` Enforce CORS policy that matches Sitecore Pages domains for editing middleware API endpoints ([#1798](https://github.com/Sitecore/jss/pull/1798)[#1801](https://github.com/Sitecore/jss/pull/1801))
 * `[sitecore-jss]` _GraphQLRequestClient_ now can accept custom 'headers' in the constructor or via _createClientFactory_ ([#1806](https://github.com/Sitecore/jss/pull/1806))

--- a/packages/create-sitecore-jss/src/initializers/angular-sxp/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular-sxp/index.ts
@@ -1,0 +1,17 @@
+import { ClientAppArgs, DEFAULT_APPNAME, Initializer } from '../../common';
+import { InitializerResults } from '../../common/Initializer';
+
+export default class AngularXmCloudInitializer implements Initializer {
+  get isBase(): boolean {
+    return false;
+  }
+
+  async init(args: ClientAppArgs) {
+    const response: InitializerResults = {
+      nextSteps: [],
+      appName: args.appName || DEFAULT_APPNAME,
+    };
+
+    return response;
+  }
+}

--- a/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
@@ -1,0 +1,17 @@
+import { ClientAppArgs, DEFAULT_APPNAME, Initializer } from '../../common';
+import { InitializerResults } from '../../common/Initializer';
+
+export default class AngularXmCloudInitializer implements Initializer {
+  get isBase(): boolean {
+    return false;
+  }
+
+  async init(args: ClientAppArgs) {
+    const response: InitializerResults = {
+      nextSteps: [],
+      appName: args.appName || DEFAULT_APPNAME,
+    };
+
+    return response;
+  }
+}

--- a/packages/create-sitecore-jss/src/initializers/angular/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/index.ts
@@ -26,7 +26,7 @@ export default class AngularInitializer implements Initializer {
         addInitializers.push('angular-xmcloud');
       }
       if (!args.templates.includes('node-xmcloud-proxy')) {
-        addInitializers.push('angular-xmcloud');
+        addInitializers.push('node-xmcloud-proxy');
       }
     } else {
       if (!args.templates.includes('angular-sxp')) {

--- a/packages/create-sitecore-jss/src/initializers/angular/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/index.ts
@@ -19,10 +19,25 @@ export default class AngularInitializer implements Initializer {
     };
     const templatePath = path.resolve(__dirname, '../../templates/angular');
     await transform(templatePath, mergedArgs);
+    const addInitializers: string[] = [];
+
+    if (answers.xmcloud) {
+      if (!args.templates.includes('angular-xmcloud')) {
+        addInitializers.push('angular-xmcloud');
+      }
+      if (!args.templates.includes('node-xmcloud-proxy')) {
+        addInitializers.push('angular-xmcloud');
+      }
+    } else {
+      if (!args.templates.includes('angular-sxp')) {
+        addInitializers.push('angular-sxp');
+      }
+    }
 
     const response = {
       nextSteps: [`* Connect to Sitecore with ${chalk.green('jss setup')} (optional)`],
       appName: answers.appName,
+      initializers: addInitializers,
     };
 
     return response;

--- a/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
@@ -18,7 +18,7 @@ export const prompts = [
     message: 'Are you building for Sitecore XM Cloud?',
     default: false,
     when: (answers: AngularAnswer): boolean => {
-      // don't prompt if --yes or nextjs-xmcloud template was specified
+      // don't prompt if --yes or angular-xmcloud template was specified
       if (answers.yes) {
         return false;
       } else if (

--- a/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
@@ -5,23 +5,31 @@ import {
   styleguidePrompts,
 } from '../../common';
 
-export type AngularAnswer = ClientAppAnswer & StyleguideAnswer & {
-  xmcloud: boolean
-};
+export type AngularAnswer = ClientAppAnswer &
+  StyleguideAnswer & {
+    xmcloud: boolean;
+  };
 
-export const prompts = [...clientAppPrompts, {
-  type: 'confirm',
-  name: 'xmcloud',
-  message: 'Are you building for Sitecore XM Cloud?',
-  default: false,
-  when: (answers: AngularAnswer): boolean => {
-    // don't prompt if --yes or nextjs-xmcloud template was specified
-    if (answers.yes) {
-      return false;
-    } else if (answers.templates.includes('angular-xmcloud') && !answers.templates.includes('angular-sxp')) {
-      answers.xmcloud = true;
-      return false;
-    }
-    return true;
+export const prompts = [
+  ...clientAppPrompts,
+  {
+    type: 'confirm',
+    name: 'xmcloud',
+    message: 'Are you building for Sitecore XM Cloud?',
+    default: false,
+    when: (answers: AngularAnswer): boolean => {
+      // don't prompt if --yes or nextjs-xmcloud template was specified
+      if (answers.yes) {
+        return false;
+      } else if (
+        answers.templates.includes('angular-xmcloud') &&
+        !answers.templates.includes('angular-sxp')
+      ) {
+        answers.xmcloud = true;
+        return false;
+      }
+      return true;
+    },
   },
-}, ...styleguidePrompts];
+  ...styleguidePrompts,
+];

--- a/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular/prompts.ts
@@ -5,6 +5,23 @@ import {
   styleguidePrompts,
 } from '../../common';
 
-export type AngularAnswer = ClientAppAnswer & StyleguideAnswer;
+export type AngularAnswer = ClientAppAnswer & StyleguideAnswer & {
+  xmcloud: boolean
+};
 
-export const prompts = [...clientAppPrompts, ...styleguidePrompts];
+export const prompts = [...clientAppPrompts, {
+  type: 'confirm',
+  name: 'xmcloud',
+  message: 'Are you building for Sitecore XM Cloud?',
+  default: false,
+  when: (answers: AngularAnswer): boolean => {
+    // don't prompt if --yes or nextjs-xmcloud template was specified
+    if (answers.yes) {
+      return false;
+    } else if (answers.templates.includes('angular-xmcloud') && !answers.templates.includes('angular-sxp')) {
+      answers.xmcloud = true;
+      return false;
+    }
+    return true;
+  },
+}, ...styleguidePrompts];

--- a/packages/create-sitecore-jss/src/initializers/node-xmcloud-proxy/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/node-xmcloud-proxy/index.ts
@@ -1,0 +1,15 @@
+import { Initializer } from '../../common';
+
+export default class AngularXmCloudInitializer implements Initializer {
+  get isBase(): boolean {
+    return false;
+  }
+
+  async init() {
+    const response = {
+      appName: 'node-xmcloud-proxy',
+    };
+
+    return response;
+  }
+}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Angular will have XMC-only logic. This PR makes preparations for the new create-sitecore-jss init journey for Angular.

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
