### PR TITLE
[sitecore-jss-nextjs] Fix edit mode for localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Our versioning strategy is as follows:
 * `[sitecore-jss]` `[sitecore-jss-react]` DateField empty value is not treated as empty ([#1836](https://github.com/Sitecore/jss/pull/1836))
 * `[templates/nextjs-sxa]` Fix styles of title component in metadata mode. ([#1839](https://github.com/Sitecore/jss/pull/1839))
 * `[templates/nextjs-sxa]` Fix missing value of field property in Title component. ([#1842](https://github.com/Sitecore/jss/pull/1842))
+* `[sitecore-jss-nextjs]` Fix edit mode for localhost. ([#1849](https://github.com/Sitecore/jss/pull/1849))
+
 
 ### 🎉 New Features & Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Our versioning strategy is as follows:
 * `[sitecore-jss]` `[sitecore-jss-react]` DateField empty value is not treated as empty ([#1836](https://github.com/Sitecore/jss/pull/1836))
 * `[templates/nextjs-sxa]` Fix styles of title component in metadata mode. ([#1839](https://github.com/Sitecore/jss/pull/1839))
 * `[templates/nextjs-sxa]` Fix missing value of field property in Title component. ([#1842](https://github.com/Sitecore/jss/pull/1842))
-* `[sitecore-jss-nextjs]` Fix edit mode for localhost. ([#1849](https://github.com/Sitecore/jss/pull/1849))
 
 
 ### 🎉 New Features & Improvements
@@ -35,7 +34,7 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Change
 
-* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))([#1809](https://github.com/Sitecore/jss/pull/1809))([#1814](https://github.com/Sitecore/jss/pull/1814))([#1816](https://github.com/Sitecore/jss/pull/1816))([#1819](https://github.com/Sitecore/jss/pull/1819))([#1828](https://github.com/Sitecore/jss/pull/1828))([#1835](https://github.com/Sitecore/jss/pull/1835))
+* Editing Integration Support: ([#1776](https://github.com/Sitecore/jss/pull/1776))([#1792](https://github.com/Sitecore/jss/pull/1792))([#1773](https://github.com/Sitecore/jss/pull/1773))([#1797](https://github.com/Sitecore/jss/pull/1797))([#1800](https://github.com/Sitecore/jss/pull/1800))([#1803](https://github.com/Sitecore/jss/pull/1803))([#1806](https://github.com/Sitecore/jss/pull/1806))([#1809](https://github.com/Sitecore/jss/pull/1809))([#1814](https://github.com/Sitecore/jss/pull/1814))([#1816](https://github.com/Sitecore/jss/pull/1816))([#1819](https://github.com/Sitecore/jss/pull/1819))([#1828](https://github.com/Sitecore/jss/pull/1828))([#1835](https://github.com/Sitecore/jss/pull/1835)) ([#1849](https://github.com/Sitecore/jss/pull/1849))
   * `[sitecore-jss-react]` Introduces `PlaceholderMetadata` component which supports the hydration of chromes on Pages by rendering  the components and placeholders with required metadata.
   * `[sitecore-jss]` Chromes are hydrated based on the basis of new `editMode` property derived from LayoutData, which is defined as an enum consisting of `metadata` and `chromes`.
   * `ComponentConsumerProps` is removed. You might need to reuse `WithSitecoreContextProps` type.

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -24,8 +24,8 @@ import sinonChai from 'sinon-chai';
 use(sinonChai);
 
 const mockNextJsPreviewCookies = [
-  '__prerender_bypass:1122334455',
-  '__next_preview_data:6677889900',
+  '__prerender_bypass=1122334455; Path=/; SameSite=Lax',
+  '__next_preview_data=6677889900; Path=/; SameSite=Lax',
 ];
 
 type Query = {
@@ -338,6 +338,21 @@ describe('EditingRenderMiddleware', () => {
 
       expect(isEditingMetadataPreviewData(metadataPreviewData)).to.be.true;
       expect(isEditingMetadataPreviewData(chromesPreviewData)).to.be.false;
+    });
+
+    it('should modify the Set-Cookie header', async () => {
+      const req = mockRequest(EE_BODY, query, 'GET');
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware();
+      const handler = middleware.getHandler();
+
+      await handler(req, res);
+
+      expect(res.setHeader).to.have.been.calledWith('Set-Cookie', [
+        '__prerender_bypass=1122334455; Path=/; SameSite=None; Secure',
+        '__next_preview_data=6677889900; Path=/; SameSite=None; Secure',
+      ]);
     });
   });
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -363,6 +363,27 @@ export class MetadataHandler {
       }
     );
 
+    const setCookieHeader = res.getHeader('Set-Cookie');
+
+    if (setCookieHeader && Array.isArray(setCookieHeader)) {
+      const modifiedCookies = setCookieHeader.map((cookie) => {
+        const cookieIdentifiers: { [key: string]: RegExp } = {
+          __prerender_bypass: /^__prerender_bypass=/,
+          __next_preview_data: /^__next_preview_data=/,
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for (const [_, regex] of Object.entries(cookieIdentifiers)) {
+          if (cookie.match(regex)) {
+            return cookie.replace(/SameSite=Lax/, 'SameSite=None; Secure');
+          }
+        }
+        return cookie;
+      });
+
+      res.setHeader('Set-Cookie', modifiedCookies);
+    }
+
     const route =
       this.config.resolvePageUrl?.({
         itemPath: query.route,

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -363,6 +363,11 @@ export class MetadataHandler {
       }
     );
 
+    // Cookies with the SameSite=Lax policy set by Next.js setPreviewData function causes CORS issue
+    // when Next.js preview mode is activated, resulting the page to render in normal mode instead.
+    // By replacing it with "SameSite=None; Secure", we ensure cookies are correctly sent with
+    // cross-origin requests, allowing the page to be editable. This change should be reverted
+    // once vercel addresses this open issue: https://github.com/vercel/next.js/issues/49927
     const setCookieHeader = res.getHeader('Set-Cookie');
 
     if (setCookieHeader && Array.isArray(setCookieHeader)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fix CORs issue for editMode when pointing Pages to a running localhost instance to use as the site editing host by modifying the cookies set by the setPreviewData from SameSite=Lax to SameSite=None

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
