### PR TITLE
[Chore][nextjs] Install sharp dependency for nextjs apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Our versioning strategy is as follows:
 
 * Update node/types to version 20 in all packages and samples ([#1810](https://github.com/Sitecore/jss/pull/1810))
 * Github - Teams integration ([#1823](https://github.com/Sitecore/jss/pull/1823))
+* [nextjs] Add `sharp` dependency to be in-line with nextjs's Image Optimizaion best practices: https://nextjs.org/docs/messages/install-sharp
 
 ## 22.0.0
 

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -117,6 +117,9 @@
         ...
     ```
 
+* It's highly recommended to install `sharp` dependency version `0.32.6` for nextjs apps in order to improve memory usage of Image Optimization feature. Run the `npm` command to install it:
+    `npm i sharp@0.32.6`
+
 # nextjs-xmcloud
 
 * Render a new `EditingScripts` component in your `Scripts.ts` file to support a new Editing Integration feature.

--- a/packages/create-sitecore-jss/src/templates/nextjs/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs/package.json
@@ -31,7 +31,8 @@
     "next": "^14.1.0",
     "next-localization": "^0.12.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sharp": "0.32.6"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated TBA
- [ ] Upgrade guide entry added TBA

## Description / Motivation
Install sharp in nextjs apps by default. https://nextjs.org/docs/messages/sharp-missing-in-production
Having sharp installed is recommended by Vercel to avoid issues with image optimization:
Version is locked to 0.32.6 due to this potential issue: https://github.com/vercel/next.js/issues/59516#issuecomment-1941850968 

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - app starts as before

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore 