### PR TITLE
[templates/nextjs-sxa] Fix SXA Image sizing in Metadata mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]` Changed formatting in temp/config to prevent parse issues in Unix systems ([#1787](https://github.com/Sitecore/jss/pull/1787))([#1791](https://github.com/Sitecore/jss/pull/1791))
 * `[sitecore-jss]` `GraphQLRequestClientFactory` type is updated and `config` parameter is now optional. Since it should match `GraphQLRequestClient.createClientFactory` method return type ([#1806](https://github.com/Sitecore/jss/pull/1806))
-* `[templates/nextjs-sxa]` The banner variant of image component is fixed with supporting metadata mode. ([#1826](https://github.com/Sitecore/jss/pull/1826))
+* `[templates/nextjs-sxa]` The banner variant of image component is fixed with supporting metadata mode. ([#1826](https://github.com/Sitecore/jss/pull/1826))([#1861](https://github.com/Sitecore/jss/pull/1861))
 * `[sitecore-jss]` `[sitecore-jss-react]` DateField empty value is not treated as empty ([#1836](https://github.com/Sitecore/jss/pull/1836))
 * `[templates/nextjs-sxa]` Fix styles of title component in metadata mode. ([#1839](https://github.com/Sitecore/jss/pull/1839))
 * `[templates/nextjs-sxa]` Fix missing value of field property in Title component. ([#1842](https://github.com/Sitecore/jss/pull/1842))

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Image.tsx
@@ -41,22 +41,27 @@ export const Banner = (props: ImageProps): JSX.Element => {
   const backgroundStyle = (props?.fields?.Image?.value?.src && {
     backgroundImage: `url('${props.fields.Image.value.src}')`,
   }) as CSSProperties;
-  const modifyImageProps = !isMetadataMode
-    ? {
-        ...props.fields.Image,
-        editable: props?.fields?.Image?.editable
-          ?.replace(`width="${props?.fields?.Image?.value?.width}"`, 'width="100%"')
-          .replace(`height="${props?.fields?.Image?.value?.height}"`, 'height="100%"'),
-      }
-    : {
-      ...props.fields.Image,
+  let modifyImageProps = props.fields.Image;
+  if (isMetadataMode) {
+    if (modifyImageProps.value) {
+      delete modifyImageProps.value.width;
+      delete modifyImageProps.value.height;
+    }
+    modifyImageProps = {
+      ...modifyImageProps,
       value: {
-        ...props.fields.Image.value,
-        width: "100%",
-        height: "100%",
+        ...modifyImageProps.value,
+        sizes: '100vw',
       },
     };
-
+  } else {
+    modifyImageProps = {
+      ...modifyImageProps,
+      editable: props?.fields?.Image?.editable
+        ?.replace(`width="${props?.fields?.Image?.value?.width}"`, 'width="100%"')
+        .replace(`height="${props?.fields?.Image?.value?.height}"`, 'height="100%"'),
+    };
+  }
   return (
     <div
       className={`component hero-banner ${props.params.styles} ${classHeroBannerEmpty}`}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
next/image cannot handle width/height prop values of '100%'. We gotta use 'sizes' prop instead. https://nextjs.org/docs/pages/api-reference/components/image#responsive-images


## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
