### PR TITLE
[angular/xmcloud] Fix angular app initialization setup for xmc 

### DIFF
--- a/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
@@ -1,4 +1,11 @@
-import { ClientAppArgs, DEFAULT_APPNAME, Initializer } from '../../common';
+import path, { sep } from 'path';
+import {
+  ClientAppArgs,
+  DEFAULT_APPNAME,
+  Initializer,
+  transform,
+  openPackageJson,
+} from '../../common';
 import { InitializerResults } from '../../common/Initializer';
 
 export default class AngularXmCloudInitializer implements Initializer {
@@ -7,6 +14,18 @@ export default class AngularXmCloudInitializer implements Initializer {
   }
 
   async init(args: ClientAppArgs) {
+    const pkg = openPackageJson(`${args.destination}${sep}package.json`);
+
+    const mergedArgs = {
+      ...args,
+      appName: args.appName || pkg?.config?.appName || DEFAULT_APPNAME,
+      appPrefix: args.appPrefix || pkg?.config?.prefix || false,
+    };
+
+    const templatePath = path.resolve(__dirname, '../../templates/angular-xmcloud');
+
+    await transform(templatePath, mergedArgs);
+
     const response: InitializerResults = {
       nextSteps: [],
       appName: args.appName || DEFAULT_APPNAME,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Follow up to jss-3563 - Angular Initializer support
     - Add transform logic to the add-on
     - Scaffold of node-xmcloud-proxy app relatively to base angular app

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
