### PR TITLE
[create-sitecore-jss] Only put FETCH_WITH for SXP template, pass proxyPath to prompt

### DIFF
--- a/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/angular-xmcloud/index.ts
@@ -30,6 +30,7 @@ export default class AngularXmCloudInitializer implements Initializer {
       yes: args.yes,
       destination: args.destination,
       proxyName: 'node-xmcloud-proxy',
+      proxyAppDestination: args.proxyAppDestination,
     };
     const proxyDetails = await inquirer.prompt<ProxyArgs>(proxyPrompts, promptArgs);
     args.proxyAppDestination = proxyDetails.proxyAppDestination;

--- a/packages/create-sitecore-jss/src/templates/angular-sxp/.env
+++ b/packages/create-sitecore-jss/src/templates/angular-sxp/.env
@@ -1,0 +1,2 @@
+# The way in which layout and dictionary data is fetched from Sitecore
+FETCH_WITH=<%- fetchWith %>

--- a/packages/create-sitecore-jss/src/templates/angular/.env
+++ b/packages/create-sitecore-jss/src/templates/angular/.env
@@ -25,11 +25,6 @@ GRAPH_QL_ENDPOINT=
 # Uses your `package.json` config `appName` if empty.
 SITECORE_SITE_NAME=
 
-<% if (!locals.xmcloud) { -%>
-# The way in which layout and dictionary data is fetched from Sitecore
-FETCH_WITH=<%- fetchWith %>
-<% } -%>
-
 # Your default app language.
 DEFAULT_LANGUAGE=
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- fetchWith prompt will only appear during angular-sxp intializer execution - but it's expected in base angular template. We prevent an error from happening by moving FETCH_WITH into sxp-only .env file
- proxyAppDestination from flags was ignored by prompt logic in angular-xmcloud initializer. This is fixed too.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
