### PR TITLE
[angular-xmcloud] Promo SXA component

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.html
@@ -1,0 +1,27 @@
+<div class="component promo {{ styles }}"  [attr.id]="id">
+  <div class="component-content">
+    <ng-container *ngIf="!empty; else emptyPromo">
+      <div class="field-promoicon">
+        <img *scImage="rendering.fields.PromoIcon"/>
+      </div>
+      <div class="promo-text">
+        <div>
+          <div class="field-promotext">
+            <div class="{{ withText ? 'promo-text': undefined }}" *scRichText="rendering.fields.PromoText"></div>
+          </div>
+        </div>
+        <div *ngIf="withText; else jssLink" class="field-promotext">
+          <div class="promo-text" *scRichText="rendering.fields.PromoText2"></div>
+        </div>
+      </div>
+    </ng-container>    
+  </div>
+  <ng-template #emptyPromo>
+    <span class="is-empty-hint">Promo</span>
+  </ng-template>
+  <ng-template #jssLink>
+    <div class="field-promolink">
+      <a *scLink="rendering.fields.PromoLink"></a>
+    </div>
+  </ng-template>
+</div>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { SxaComponent } from '../sxa.component';
+
+@Component({
+  selector: 'app-promo',
+  templateUrl: './promo.component.html',
+})
+export class PromoComponent extends SxaComponent implements OnInit {
+  empty: boolean;
+  withText: boolean;
+
+  ngOnInit() {
+    super.ngOnInit();
+    this.empty = !this.rendering.fields;
+    if (!this.empty) {
+      this.withText = this.rendering.params?.Variant === 'withText';
+    }
+    console.log(this.rendering.fields);
+  }
+}

--- a/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
@@ -47,6 +47,16 @@ describe('<a *scLink />', () => {
     expect(de.children.length).toBe(0);
   });
 
+  it('should render nothing for empty field', () => {
+    const field = {
+      value: { href: '' },
+    };
+    comp.field = field;
+    fixture.detectChanges();
+
+    expect(de.children.length).toBe(0);
+  });
+
   it('should render editable with an editable value', () => {
     const field = {
       editableFirstPart: '<a class="yo" href="/services">Lorem',

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -76,11 +76,15 @@ export class LinkDirective implements OnChanges {
     }
   }
 
+  private shouldRender() {
+    return this.field && (this.field.href || this.field.value?.href || this.field.text);
+  }
+
   private updateView() {
     const field = this.field;
     if (this.editable && field && field.editableFirstPart && field.editableLastPart) {
       this.renderInlineWrapper(field.editableFirstPart, field.editableLastPart);
-    } else if (field && (field.href || field.value)) {
+    } else if (this.shouldRender()) {
       const props = field.href ? field : field.value;
 
       const linkText = field.text || field.value?.text || field.href || field.value?.href;


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Introduces SXA Promo component to Angular XMC
- Fixes an scLink bug - it should render nothing when href and text are absent

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
