### PR TITLE
[angular-xmcloud] Remove the hardcoded navigation module from sxa layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Our versioning strategy is as follows:
   * Angular placeholder now supports SXA components ([#1870](https://github.com/Sitecore/jss/pull/1870))
   * Richtext component ([#1864](https://github.com/Sitecore/jss/pull/1864))
   * Container component ([#1872](https://github.com/Sitecore/jss/pull/1872))
-  * Angular SXA layout ([#1873](https://github.com/Sitecore/jss/pull/1873))([#1880](https://github.com/Sitecore/jss/pull/1880))([#1890](https://github.com/Sitecore/jss/pull/1890))
+  * Angular SXA layout ([#1873](https://github.com/Sitecore/jss/pull/1873))([#1880](https://github.com/Sitecore/jss/pull/1880))([#1890](https://github.com/Sitecore/jss/pull/1890))([#1906](https://github.com/Sitecore/jss/pull/1906))
   * Row-Splitter ([#1901](https://github.com/Sitecore/jss/pull/1901))
   * Link-List ([#1898](https://github.com/Sitecore/jss/pull/1898))
   * Column-Splitter ([#1889](https://github.com/Sitecore/jss/pull/1889))

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/layout/layout.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/layout/layout.component.html
@@ -1,4 +1,3 @@
-<app-navigation></app-navigation>
 <div class="{{ mainClassPageEditing }}">
   <ng-container *ngIf="state === LayoutState.Layout">
     <app-scripts></app-scripts>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove the hardcoded navigation module from sxa layout

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
