### PR TITLE
[sitecore-jss] fix isEditorActive for XMCloud Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
-* `[sitecore-jss]` Fix isEditorActive returning false in XMCloud Pages ([#1912](https://github.com/Sitecore/jss/pull/1912))
 
 ### 🎉 New Features & Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ Our versioning strategy is as follows:
 
 ### 🧹 Chores
 
+## 22.1.2
+
+### 🐛 Bug Fixes
+
+* `[sitecore-jss]` Fix isEditorActive returning false in XMCloud Pages ([#1912](https://github.com/Sitecore/jss/pull/1912))
+
+
 ## 22.1.1
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
+* `[sitecore-jss]` Fix isEditorActive returning false in XMCloud Pages ([#1912](https://github.com/Sitecore/jss/pull/1912))
 
 ### 🎉 New Features & Improvements
 

--- a/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
@@ -76,47 +76,6 @@ describe('<EditingScripts />', () => {
     expect(scripts.find('script')).to.have.length(0);
   });
 
-  it('should render nothing when in Preview pageState and Chromes editmode', () => {
-    const layoutData = getLayoutData({
-      editMode: EditMode.Chromes,
-      pageState: LayoutServicePageState.Preview,
-      pageEditing: true,
-    });
-
-    const component = mount(
-      <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
-        <EditingScripts />
-      </SitecoreContext>
-    );
-
-    const scripts = component.find('EditingScripts');
-
-    expect(scripts.html()).to.be.null;
-    expect(scripts.find('script')).to.have.length(0);
-  });
-
-  it('should render JSS client data script elements in Edit pageState and Chromes editmode', () => {
-    const layoutData = getLayoutData({
-      editMode: EditMode.Chromes,
-      pageState: LayoutServicePageState.Edit,
-      pageEditing: true,
-    });
-
-    const component = mount(
-      <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
-        <EditingScripts />
-      </SitecoreContext>
-    );
-
-    const scripts = component.find('EditingScripts');
-    const ids = Object.keys(getJssHorizonClientData());
-    expect(scripts.html()).to.not.be.null;
-    ids.forEach((id) => {
-      expect(scripts.exists(`#${id}`)).to.equal(true);
-    });
-    expect(scripts.find('script')).to.have.length(ids.length);
-  });
-
   [
     {
       pageState: 'Edit',
@@ -127,6 +86,25 @@ describe('<EditingScripts />', () => {
       jssData: {},
     },
   ].forEach((scenario) => {
+    it(`should render nothing when in ${scenario.pageState} pageState and Chromes editmode`, () => {
+      const layoutData = getLayoutData({
+        editMode: EditMode.Chromes,
+        pageState: LayoutServicePageState.Preview,
+        pageEditing: true,
+      });
+
+      const component = mount(
+        <SitecoreContext componentFactory={mockComponentFactory} layoutData={layoutData}>
+          <EditingScripts />
+        </SitecoreContext>
+      );
+
+      const scripts = component.find('EditingScripts');
+
+      expect(scripts.html()).to.be.null;
+      expect(scripts.find('script')).to.have.length(0);
+    });
+
     describe(`should render Pages scripts when ${scenario.pageState} and edit mode is Metadata`, () => {
       it('should render scripts', () => {
         const layoutData = getLayoutData({

--- a/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.test.tsx
@@ -76,7 +76,7 @@ describe('<EditingScripts />', () => {
     expect(scripts.find('script')).to.have.length(0);
   });
 
-  it('should render nothing when Preview and edit mode is Chromes', () => {
+  it('should render nothing when in Preview pageState and Chromes editmode', () => {
     const layoutData = getLayoutData({
       editMode: EditMode.Chromes,
       pageState: LayoutServicePageState.Preview,
@@ -95,7 +95,7 @@ describe('<EditingScripts />', () => {
     expect(scripts.find('script')).to.have.length(0);
   });
 
-  it('should render JSS client data script elements when Edit and edit mode is Chromes', () => {
+  it('should render JSS client data script elements in Edit pageState and Chromes editmode', () => {
     const layoutData = getLayoutData({
       editMode: EditMode.Chromes,
       pageState: LayoutServicePageState.Edit,

--- a/packages/sitecore-jss-react/src/components/EditingScripts.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EditMode, LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
 import { useSitecoreContext } from '../enhancers/withSitecoreContext';
-import { getJssHorizonClientData } from '@sitecore-jss/sitecore-jss/editing';
+import { getJssPagesClientData } from '@sitecore-jss/sitecore-jss/editing';
 
 /**
  * Renders client scripts and data for editing/preview mode in Pages.
@@ -16,10 +16,7 @@ export const EditingScripts = (): JSX.Element => {
   if (pageState === LayoutServicePageState.Normal) return <></>;
 
   if (editMode === EditMode.Metadata) {
-    let jssClientData: Record<string, unknown> = clientData;
-    if (pageState === LayoutServicePageState.Edit) {
-      jssClientData = { ...jssClientData, ...getJssHorizonClientData() };
-    }
+    const jssClientData = { ...clientData, ...getJssPagesClientData() };
 
     return (
       <>

--- a/packages/sitecore-jss-react/src/components/EditingScripts.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.tsx
@@ -12,38 +12,28 @@ export const EditingScripts = (): JSX.Element => {
     sitecoreContext: { pageState, editMode, clientData, clientScripts },
   } = useSitecoreContext();
 
-  const renderClientData = () => (
-    <>
-      {Object.keys(jssClientData).map((id) => (
-        <script
-          key={id}
-          id={id}
-          type="application/json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jssClientData[id]) }}
-        />
-      ))}
-    </>
-  );
-
   // Don't render anything if not in editing/preview mode
   if (pageState === LayoutServicePageState.Normal) return <></>;
 
-  let jssClientData: Record<string, unknown> = {};
-  if (pageState === LayoutServicePageState.Edit) {
-    jssClientData = getJssHorizonClientData();
-    if (editMode === EditMode.Chromes) {
-      return renderClientData();
-    }
-  }
-
   if (editMode === EditMode.Metadata) {
-    jssClientData = { ...clientData, ...jssClientData };
+    let jssClientData: Record<string, unknown> = clientData;
+    if (pageState === LayoutServicePageState.Edit) {
+      jssClientData = { ...jssClientData, ...getJssHorizonClientData() };
+    }
+
     return (
       <>
         {clientScripts?.map((src, index) => (
           <script src={src} key={index} />
         ))}
-        {renderClientData()}
+        {Object.keys(jssClientData).map((id) => (
+          <script
+            key={id}
+            id={id}
+            type="application/json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jssClientData[id]) }}
+          />
+        ))}
       </>
     );
   }

--- a/packages/sitecore-jss-react/src/components/EditingScripts.tsx
+++ b/packages/sitecore-jss-react/src/components/EditingScripts.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { EditMode, LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
 import { useSitecoreContext } from '../enhancers/withSitecoreContext';
+import { getJssHorizonClientData } from '@sitecore-jss/sitecore-jss/editing';
 
 /**
  * Renders client scripts and data for editing/preview mode in Pages.
@@ -11,24 +12,38 @@ export const EditingScripts = (): JSX.Element => {
     sitecoreContext: { pageState, editMode, clientData, clientScripts },
   } = useSitecoreContext();
 
+  const renderClientData = () => (
+    <>
+      {Object.keys(jssClientData).map((id) => (
+        <script
+          key={id}
+          id={id}
+          type="application/json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jssClientData[id]) }}
+        />
+      ))}
+    </>
+  );
+
   // Don't render anything if not in editing/preview mode
   if (pageState === LayoutServicePageState.Normal) return <></>;
 
+  let jssClientData: Record<string, unknown> = {};
+  if (pageState === LayoutServicePageState.Edit) {
+    jssClientData = getJssHorizonClientData();
+    if (editMode === EditMode.Chromes) {
+      return renderClientData();
+    }
+  }
+
   if (editMode === EditMode.Metadata) {
+    jssClientData = { ...clientData, ...jssClientData };
     return (
       <>
         {clientScripts?.map((src, index) => (
           <script src={src} key={index} />
         ))}
-        {clientData &&
-          Object.keys(clientData).map((id) => (
-            <script
-              key={id}
-              id={id}
-              type="application/json"
-              dangerouslySetInnerHTML={{ __html: JSON.stringify(clientData[id]) }}
-            />
-          ))}
+        {renderClientData()}
       </>
     );
   }

--- a/packages/sitecore-jss/src/editing/index.ts
+++ b/packages/sitecore-jss/src/editing/index.ts
@@ -6,7 +6,7 @@ export {
   resetEditorChromes,
   handleEditorAnchors,
   Metadata,
-  getJssHorizonClientData,
+  getJssPagesClientData,
   EDITING_ALLOWED_ORIGINS,
   QUERY_PARAM_EDITING_SECRET,
   PAGES_EDITING_MARKER,

--- a/packages/sitecore-jss/src/editing/index.ts
+++ b/packages/sitecore-jss/src/editing/index.ts
@@ -6,8 +6,10 @@ export {
   resetEditorChromes,
   handleEditorAnchors,
   Metadata,
+  getJssHorizonClientData,
   EDITING_ALLOWED_ORIGINS,
   QUERY_PARAM_EDITING_SECRET,
+  PAGES_EDITING_MARKER,
 } from './utils';
 export {
   DefaultEditFrameButton,

--- a/packages/sitecore-jss/src/editing/utils.test.ts
+++ b/packages/sitecore-jss/src/editing/utils.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-unused-expressions */
 import { expect, spy } from 'chai';
-import { isEditorActive, resetEditorChromes, ChromeRediscoveryGlobalFunctionName } from './utils';
+import {
+  isEditorActive,
+  resetEditorChromes,
+  ChromeRediscoveryGlobalFunctionName,
+  PAGES_EDITING_MARKER,
+} from './utils';
 
 // must make TypeScript happy with `global` variable modification
 interface CustomWindow {
@@ -15,12 +20,12 @@ interface Global {
 declare const global: Global;
 
 describe('utils', () => {
-  const pagesDocument = {
-    getElementById: (id: unknown) => (id === 'hrz-canvas-state' ? 'present' : null),
+  const pagesEditingDocument = {
+    getElementById: (id: unknown) => (id === PAGES_EDITING_MARKER ? 'present' : null),
   };
 
-  const nonPagesDocument = {
-    getElementById: (id: unknown) => (id === 'hrz-canvas-state' ? null : 'present'),
+  const nonPagesEditingDocument = {
+    getElementById: (id: unknown) => (id === PAGES_EDITING_MARKER ? null : 'present'),
   };
 
   describe('isEditorActive', () => {
@@ -30,7 +35,7 @@ describe('utils', () => {
 
     it('should return true when EE is active', () => {
       global.window = {
-        document: nonPagesDocument,
+        document: nonPagesEditingDocument,
         location: { search: '' },
         Sitecore: { PageModes: { ChromeManager: {} } },
       };
@@ -39,7 +44,7 @@ describe('utils', () => {
 
     it('should return true when XMC Pages edit mode is active', () => {
       global.window = {
-        document: pagesDocument,
+        document: pagesEditingDocument,
         location: { search: '' },
         Sitecore: null,
       };
@@ -48,7 +53,7 @@ describe('utils', () => {
 
     it('should return false when XMC Pages preview mode is active', () => {
       global.window = {
-        document: pagesDocument,
+        document: nonPagesEditingDocument,
         location: { search: '?sc_horizon=preview' },
         Sitecore: null,
       };
@@ -57,7 +62,7 @@ describe('utils', () => {
 
     it('should return false when EE and XMC Pages are not active', () => {
       global.window = {
-        document: nonPagesDocument,
+        document: nonPagesEditingDocument,
         location: { search: '' },
         Sitecore: null,
       };
@@ -77,7 +82,7 @@ describe('utils', () => {
     it('should reset chromes when EE is active', () => {
       const resetChromes = spy();
       global.window = {
-        document: nonPagesDocument,
+        document: nonPagesEditingDocument,
         location: { search: '' },
         Sitecore: { PageModes: { ChromeManager: { resetChromes } } },
       };
@@ -88,7 +93,7 @@ describe('utils', () => {
     it('should reset chromes when XMC Pages edit mode is active', () => {
       const resetChromes = spy();
       global.window = {
-        document: pagesDocument,
+        document: pagesEditingDocument,
         location: { search: '' },
         Sitecore: null,
       };
@@ -99,7 +104,7 @@ describe('utils', () => {
 
     it('should not throw when EE and XMC Pages are not active', () => {
       global.window = {
-        document: nonPagesDocument,
+        document: nonPagesEditingDocument,
         location: { search: '' },
         Sitecore: null,
       };

--- a/packages/sitecore-jss/src/editing/utils.test.ts
+++ b/packages/sitecore-jss/src/editing/utils.test.ts
@@ -15,6 +15,14 @@ interface Global {
 declare const global: Global;
 
 describe('utils', () => {
+  const pagesDocument = {
+    getElementById: (id: unknown) => (id === 'hrz-canvas-state' ? 'present' : null),
+  };
+
+  const nonPagesDocument = {
+    getElementById: (id: unknown) => (id === 'hrz-canvas-state' ? null : 'present'),
+  };
+
   describe('isEditorActive', () => {
     it('should return false when invoked on server', () => {
       expect(isEditorActive()).to.be.false;
@@ -22,25 +30,34 @@ describe('utils', () => {
 
     it('should return true when EE is active', () => {
       global.window = {
-        document: {},
+        document: nonPagesDocument,
         location: { search: '' },
         Sitecore: { PageModes: { ChromeManager: {} } },
       };
       expect(isEditorActive()).to.be.true;
     });
 
-    it('should return true when Horizon is active', () => {
+    it('should return true when XMC Pages edit mode is active', () => {
       global.window = {
-        document: {},
-        location: { search: '?sc_horizon=editor' },
+        document: pagesDocument,
+        location: { search: '' },
         Sitecore: null,
       };
       expect(isEditorActive()).to.be.true;
     });
 
-    it('should return false when EE and Horizon are not active', () => {
+    it('should return false when XMC Pages preview mode is active', () => {
       global.window = {
-        document: {},
+        document: pagesDocument,
+        location: { search: '?sc_horizon=preview' },
+        Sitecore: null,
+      };
+      expect(isEditorActive()).to.be.false;
+    });
+
+    it('should return false when EE and XMC Pages are not active', () => {
+      global.window = {
+        document: nonPagesDocument,
         location: { search: '' },
         Sitecore: null,
       };
@@ -60,7 +77,7 @@ describe('utils', () => {
     it('should reset chromes when EE is active', () => {
       const resetChromes = spy();
       global.window = {
-        document: {},
+        document: nonPagesDocument,
         location: { search: '' },
         Sitecore: { PageModes: { ChromeManager: { resetChromes } } },
       };
@@ -68,11 +85,11 @@ describe('utils', () => {
       expect(resetChromes).to.have.been.called.once;
     });
 
-    it('should reset chromes when Horizon is active', () => {
+    it('should reset chromes when XMC Pages edit mode is active', () => {
       const resetChromes = spy();
       global.window = {
-        document: {},
-        location: { search: '?sc_horizon=editor' },
+        document: pagesDocument,
+        location: { search: '' },
         Sitecore: null,
       };
       global.window[ChromeRediscoveryGlobalFunctionName.name] = resetChromes;
@@ -80,9 +97,9 @@ describe('utils', () => {
       expect(resetChromes).to.have.been.called.once;
     });
 
-    it('should not throw when EE and Horizon are not active', () => {
+    it('should not throw when EE and XMC Pages are not active', () => {
       global.window = {
-        document: {},
+        document: nonPagesDocument,
         location: { search: '' },
         Sitecore: null,
       };

--- a/packages/sitecore-jss/src/editing/utils.ts
+++ b/packages/sitecore-jss/src/editing/utils.ts
@@ -74,8 +74,12 @@ export class HorizonEditor {
     if (isServer()) {
       return false;
     }
-    // Horizon will add "sc_horizon=editor" query string parameter for the editor and "sc_horizon=simulator" for the preview
-    return window.location.search.indexOf('sc_horizon=editor') > -1;
+    // XMCloud Pages (ex-Horizon) will have hrz-canvas-state element present in Edit and Preview
+    // But Edit would not have the have the sc_horizon query string param
+    return (
+      !!window.document.getElementById('hrz-canvas-state') &&
+      window.location.search.indexOf('sc_horizon=preview') === -1
+    );
   }
   static resetChromes(): void {
     if (isServer()) {

--- a/packages/sitecore-jss/src/editing/utils.ts
+++ b/packages/sitecore-jss/src/editing/utils.ts
@@ -158,7 +158,7 @@ export const handleEditorAnchors = () => {
  * Gets extra JSS clientData scripts to render in XMC Pages in addition to clientData from Pages itself
  * @returns {Record} collection of clientData
  */
-export const getJssHorizonClientData = () => {
+export const getJssPagesClientData = () => {
   const clientData: Record<string, Record<string, unknown>> = {};
   clientData[PAGES_EDITING_MARKER] = {};
 

--- a/packages/sitecore-jss/src/editing/utils.ts
+++ b/packages/sitecore-jss/src/editing/utils.ts
@@ -68,28 +68,28 @@ export const ChromeRediscoveryGlobalFunctionName = {
 };
 
 /**
- * Static utility class for Sitecore Horizon Editor
+ * Static utility class for Sitecore Pages Editor (ex-Horizon)
  */
 export class HorizonEditor {
   /**
-   * Determines whether the current execution context is within a Horizon Editor.
-   * Horizon Editor environment can be identified only in the browser
-   * @returns true if executing within a Horizon Editor
+   * Determines whether the current execution context is within a Pages Editor.
+   * Pages Editor environment can be identified only in the browser
+   * @returns true if executing within a Pages Editor
    */
   static isActive(): boolean {
     if (isServer()) {
       return false;
     }
-    // Legacy check for Horizon. Only active in Chromes mode, and may be removed later
-    const legacyCheck = window.location.search.indexOf('sc_horizon=editor') > -1;
-    // JSS will render a jss-exclusive script element to indicate edit mode in Pages
-    return legacyCheck || !!window.document.getElementById(PAGES_EDITING_MARKER);
+    // Check for Chromes mode
+    const chromesCheck = window.location.search.indexOf('sc_headless_mode=edit') > -1;
+    // JSS will render a jss-exclusive script element in Metadata mode to indicate edit mode in Pages
+    return chromesCheck || !!window.document.getElementById(PAGES_EDITING_MARKER);
   }
   static resetChromes(): void {
     if (isServer()) {
       return;
     }
-    // Reset chromes in Horizon
+    // Reset chromes in Pages
     (window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] &&
       ((window as ExtendedWindow)[ChromeRediscoveryGlobalFunctionName.name] as () => void)();
   }

--- a/packages/sitecore-jss/src/editing/utils.ts
+++ b/packages/sitecore-jss/src/editing/utils.ts
@@ -6,6 +6,12 @@ import isServer from '../utils/is-server';
 export const QUERY_PARAM_EDITING_SECRET = 'secret';
 
 /**
+ * ID to be used as a marker for a script rendered in XMC Pages
+ * Should identify app is in XM Cloud Pages editing mode
+ */
+export const PAGES_EDITING_MARKER = 'jss-hrz-editing';
+
+/**
  * Default allowed origins for editing requests. This is used to enforce CORS, CSP headers.
  */
 export const EDITING_ALLOWED_ORIGINS = ['https://pages.sitecorecloud.io'];
@@ -74,12 +80,10 @@ export class HorizonEditor {
     if (isServer()) {
       return false;
     }
-    // XMCloud Pages (ex-Horizon) will have hrz-canvas-state element present in Edit and Preview
-    // But Edit would not have the have the sc_horizon query string param
-    return (
-      !!window.document.getElementById('hrz-canvas-state') &&
-      window.location.search.indexOf('sc_horizon=preview') === -1
-    );
+    // Legacy check for Horizon. Only active in Chromes mode, and may be removed later
+    const legacyCheck = window.location.search.indexOf('sc_horizon=editor') > -1;
+    // JSS will render a jss-exclusive script element to indicate edit mode in Pages
+    return legacyCheck || !!window.document.getElementById(PAGES_EDITING_MARKER);
   }
   static resetChromes(): void {
     if (isServer()) {
@@ -148,4 +152,15 @@ export const handleEditorAnchors = () => {
   if (targetNode) {
     observer.observe(targetNode, observerOptions);
   }
+};
+
+/**
+ * Gets extra JSS clientData scripts to render in XMC Pages in addition to clientData from Pages itself
+ * @returns {Record} collection of clientData
+ */
+export const getJssHorizonClientData = () => {
+  const clientData: Record<string, Record<string, unknown>> = {};
+  clientData[PAGES_EDITING_MARKER] = {};
+
+  return clientData;
 };


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
isEditorActive() call would return false for when called from XMCloud Pages. This has been fixed.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
