### PR TITLE
[sitecore-jss-nextjs]: removing header x-middleware-rewrite for redirects #SXA-6564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ Our versioning strategy is as follows:
 
 ### 🧹 Chores
 
+## 22.1.3
+
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextjs]` Addressed an issue where the x-middleware-rewrite header caused redirects to fail during execution on Netlify. ([#1915](https://github.com/Sitecore/jss/pull/1915))
+
 ## 22.1.2
 
 ### 🐛 Bug Fixes

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1,20 +1,19 @@
 ﻿/* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable dot-notation */
-import chai, { use } from 'chai';
-import chaiString from 'chai-string';
-import sinonChai from 'sinon-chai';
-import sinon, { spy } from 'sinon';
-import { NextRequest, NextResponse } from 'next/server';
-import { debug } from '@sitecore-jss/sitecore-jss';
+import { debug, GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
 import {
   REDIRECT_TYPE_301,
   REDIRECT_TYPE_302,
   REDIRECT_TYPE_SERVER_TRANSFER,
   SiteResolver,
 } from '@sitecore-jss/sitecore-jss/site';
+import chai, { use } from 'chai';
+import chaiString from 'chai-string';
+import { NextRequest, NextResponse } from 'next/server';
+import sinon, { spy } from 'sinon';
+import sinonChai from 'sinon-chai';
 import { RedirectsMiddleware } from './redirects-middleware';
-import { GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
 
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
@@ -1480,6 +1479,10 @@ describe('RedirectsMiddleware', () => {
         status: 301,
         url: '',
       });
+
+      // Check that the headers were not removed
+      expect(finalRes.headers.has('x-middleware-next')).to.equal(false);
+      expect(finalRes.headers.has('x-middleware-rewrite')).to.equal(false);
 
       expect(siteResolver.getByHost).not.called.to.equal(true);
       expect(siteResolver.getByName).to.be.calledWith(siteName);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1430,10 +1430,11 @@ describe('RedirectsMiddleware', () => {
       });
     });
 
-    it('should remove x-middleware-next header and redirect 301', async () => {
+    it('should remove x-middleware-next/x-middleware-rewrite headers and redirect 301', async () => {
       const siteName = 'foo';
       const res = NextResponse.redirect('http://localhost:3000/found', {});
       res.headers.set('x-middleware-next', '1');
+      res.headers.set('x-middleware-rewrite', '1');
       res.cookies.set('sc_site', siteName);
       const req = createRequest({
         nextUrl: {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -282,6 +282,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
     });
     if (res?.headers) {
       redirect.headers.delete('x-middleware-next');
+      redirect.headers.delete('x-middleware-rewrite');
     }
     return redirect;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
The core issue was that Next.js was setting the **x-middleware-rewrite** header during the **NextResponse.redirect** process. This caused the redirect to fail during execution on Netlify service, as the header interfered with its proper functioning.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
