### PR TITLE
[sitecore-jss] [sitecore-jss-angular] Default Placeholder Content for empty fields in editMode metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Our versioning strategy is as follows:
   * Promo component ([#1897](https://github.com/Sitecore/jss/pull/1897))
   * PageContent component ([#1905](https://github.com/Sitecore/jss/pull/1905))
   * Navigation component ([#1894](https://github.com/Sitecore/jss/pull/1894))
+* `[sitecore-jss]``[sitecore-jss-angular]` Default Placeholder Content for empty fields in editMode metadata - in edit mode metadata in Pages, angular package field directives will render default or custom placeholder content if the provided field is empty; base package's GenericFieldValue model is updated to accept Date type ([#1916](https://github.com/Sitecore/jss/pull/1916))
 
 ### 🛠 Breaking Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,16 @@ Our versioning strategy is as follows:
   * Promo component ([#1897](https://github.com/Sitecore/jss/pull/1897))
   * PageContent component ([#1905](https://github.com/Sitecore/jss/pull/1905))
   * Navigation component ([#1894](https://github.com/Sitecore/jss/pull/1894))
-* `[sitecore-jss]``[sitecore-jss-angular]` Default Placeholder Content for empty fields in editMode metadata - in edit mode metadata in Pages, angular package field directives will render default or custom placeholder content if the provided field is empty; base package's GenericFieldValue model is updated to accept Date type ([#1916](https://github.com/Sitecore/jss/pull/1916))
+* `[sitecore-jss]``[sitecore-jss-angular]` Default Placeholder Content for empty fields in editMode metadata - in edit mode metadata in Pages, angular package field directives will render default or custom placeholder content if the provided field is empty; ([#1916](https://github.com/Sitecore/jss/pull/1916))
+  * custom placeholder content can be provided to field directives by passing the corresponding input:
+   - `scDateEmptyFieldEditingTemplate` for _scDate_
+   - `scGenericLinkEmptyFieldEditingTemplate` for _scGenericLink_
+   - `scImageEmptyFieldEditingTemplate` for _scImage_
+   - `scLinkEmptyFieldEditingTemplate` for _scLink_
+   - `scRichTextEmptyFieldEditingTemplate` for _scRichText_
+   - `scRouterLinkEmptyFieldEditingTemplate` for _scRouterLink_
+   - `scTextEmptyFieldEditingTemplate` for _scText_
+* `[sitecore-jss]` GenericFieldValue model is updated to accept Date type ([#1916](https://github.com/Sitecore/jss/pull/1916))
 
 ### 🛠 Breaking Change
 

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.spec.ts
@@ -1,0 +1,170 @@
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { TextField } from './rendering-field';
+import { TestBaseDirective } from '../test-data/test-base.directive';
+
+@Component({
+  selector: 'test-base',
+  template: `
+    <span *scTestBase="field; editable: editable"></span>
+  `,
+})
+class TestComponent {
+  @Input() field: TextField;
+  @Input() editable = true;
+}
+
+const emptyTextFieldEditingTemplateId = 'emptyTextFieldEditingTemplate';
+const emptyTextFieldEditingTemplate =
+  '<span>[This is a *custom* empty field component for text]</span>';
+
+@Component({
+  selector: 'test-base-template',
+  template: `
+    <span
+      *scTestBase="
+        field;
+        editable: editable;
+        emptyFieldEditingTemplate: ${emptyTextFieldEditingTemplateId}
+      "
+    ></span>
+
+    <ng-template #${emptyTextFieldEditingTemplateId}>
+      ${emptyTextFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: TextField;
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+  @Input() editable = true;
+}
+
+describe('<span *scTestBase />', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let de: DebugElement;
+  let deSpan: DebugElement;
+  let comp: TestComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestBaseDirective, TestComponent, TestEmptyTemplateComponent],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    de = fixture.debugElement;
+    deSpan = de.query(By.css('span'));
+    comp = fixture.componentInstance;
+  });
+
+  describe('edit mode cromes', () => {
+    it('should render field value if it is present', () => {
+      const field: { [prop: string]: unknown } = {
+        value: 'value',
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe('value');
+    });
+
+    it('should render field editable if it is present', () => {
+      const field: { [prop: string]: unknown } = {
+        value: 'value',
+        editable: 'editable',
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe(field.editable);
+    });
+
+    it('should render nothing if field.editable and value are missing', () => {
+      const field: { [prop: string]: unknown } = {
+        value: '',
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe('');
+    });
+  });
+
+  describe('edit mode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'single-line',
+      rawValue: 'Test1',
+    };
+
+    it('should render field value if field value is not empty', () => {
+      const field: { [prop: string]: unknown } = {
+        value: 'value',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe('value');
+    });
+
+    describe('field value is empty', () => {
+      it('should render default empty editing component if custom is not provided', () => {
+        const field = {
+          value: '',
+          metadata: testMetadata,
+        };
+        comp.field = field;
+        fixture.detectChanges();
+
+        const rendered = de.nativeElement.innerHTML;
+        expect(rendered).toContain('<span>[No text in field]</span>');
+      });
+
+      it('should render custom empty editing template if provided', () => {
+        fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+        fixture.detectChanges();
+
+        de = fixture.debugElement;
+        comp = fixture.componentInstance;
+
+        const field = {
+          value: '',
+          metadata: testMetadata,
+        };
+        comp.field = field;
+        fixture.detectChanges();
+
+        const rendered = de.nativeElement.innerHTML;
+        expect(rendered).toContain(emptyTextFieldEditingTemplate);
+      });
+
+      it('should render nothing when field value is empty, when editing is explicitly disabled', () => {
+        const field = {
+          value: '',
+          metadata: testMetadata,
+        };
+        comp.field = field;
+        comp.editable = false;
+        fixture.detectChanges();
+
+        const rendered = deSpan.nativeElement.innerHTML;
+        expect(rendered).toBe('');
+      });
+    });
+  });
+});

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.spec.ts
@@ -61,7 +61,7 @@ describe('<span *scTestBase />', () => {
     comp = fixture.componentInstance;
   });
 
-  describe('edit mode cromes', () => {
+  describe('edit mode chromes', () => {
     it('should render field value if it is present', () => {
       const field: { [prop: string]: unknown } = {
         value: 'value',

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -1,19 +1,32 @@
 import { Directive, Type, ViewContainerRef, EmbeddedViewRef, TemplateRef } from '@angular/core';
+import { RenderingField } from './rendering-field';
+import { GenericFieldValue, isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
 @Directive()
 export abstract class BaseFieldDirective {
   protected viewRef: EmbeddedViewRef<unknown>;
+  protected abstract field: RenderingField<GenericFieldValue>;
+  protected abstract emptyFieldEditingTemplate: TemplateRef<unknown>;
+  protected abstract editable: boolean;
 
   constructor(protected viewContainer: ViewContainerRef) {}
 
-  protected renderEmptyFieldEditingComponent(
-    emptyFieldEditingComponent: Type<unknown> | TemplateRef<unknown>
-  ) {
-    if (typeof emptyFieldEditingComponent === 'object') {
-      this.viewContainer.createEmbeddedView(emptyFieldEditingComponent as TemplateRef<unknown>);
-    } else {
-      this.viewContainer.clear();
-      this.viewContainer.createComponent(emptyFieldEditingComponent as Type<unknown>);
+  protected shouldRender() {
+    return this.field?.editable || !isFieldValueEmpty(this.field);
+  }
+
+  protected shouldRenderEmptyEditingComponent() {
+    return this.field?.metadata && this.editable;
+  }
+
+  protected renderEmpty(emptyFieldEditingComponent: Type<unknown>) {
+    if (this.shouldRenderEmptyEditingComponent()) {
+      if (this.emptyFieldEditingTemplate) {
+        this.viewContainer.createEmbeddedView(this.emptyFieldEditingTemplate);
+      } else {
+        this.viewContainer.clear();
+        this.viewContainer.createComponent(emptyFieldEditingComponent);
+      }
     }
   }
 }

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -10,7 +10,13 @@ export abstract class BaseFieldDirective {
   protected viewRef: EmbeddedViewRef<unknown>;
   protected abstract field: RenderingField<GenericFieldValue>;
   protected abstract editable: boolean;
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   protected abstract emptyFieldEditingTemplate: TemplateRef<unknown>;
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected abstract defaultFieldEditingComponent: Type<unknown>;
 
   constructor(protected viewContainer: ViewContainerRef) {}

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -15,10 +15,6 @@ export abstract class BaseFieldDirective {
     return !!this.field?.editable || !isFieldValueEmpty(this.field);
   }
 
-  private shouldRenderEmptyEditingComponent() {
-    return this.field?.metadata && this.editable;
-  }
-
   protected renderEmpty(emptyFieldEditingComponent: Type<unknown>) {
     if (this.shouldRenderEmptyEditingComponent()) {
       if (this.emptyFieldEditingTemplate) {
@@ -28,5 +24,9 @@ export abstract class BaseFieldDirective {
         this.viewContainer.createComponent(emptyFieldEditingComponent);
       }
     }
+  }
+
+  private shouldRenderEmptyEditingComponent() {
+    return this.field?.metadata && this.editable;
   }
 }

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -33,7 +33,7 @@ export abstract class BaseFieldDirective {
    * Renders the empty field markup which is required by Pages in editMode 'metadata' in case field is empty.
    */
   protected renderEmpty() {
-    if (this.shouldRenderEmptyEditingComponent()) {
+    if (this.field?.metadata && this.editable) {
       if (this.emptyFieldEditingTemplate) {
         this.viewContainer.createEmbeddedView(this.emptyFieldEditingTemplate);
       } else {
@@ -41,12 +41,5 @@ export abstract class BaseFieldDirective {
         this.viewContainer.createComponent(this.defaultFieldEditingComponent);
       }
     }
-  }
-
-  /**
-   * Determines if empty editing markup should be rendered for edit mode 'metadata'
-   */
-  private shouldRenderEmptyEditingComponent() {
-    return this.field?.metadata && this.editable;
   }
 }

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -9,8 +9,9 @@ import { GenericFieldValue, isFieldValueEmpty } from '@sitecore-jss/sitecore-jss
 export abstract class BaseFieldDirective {
   protected viewRef: EmbeddedViewRef<unknown>;
   protected abstract field: RenderingField<GenericFieldValue>;
-  protected abstract emptyFieldEditingTemplate: TemplateRef<unknown>;
   protected abstract editable: boolean;
+  protected abstract emptyFieldEditingTemplate: TemplateRef<unknown>;
+  protected abstract defaultFieldEditingComponent: Type<unknown>;
 
   constructor(protected viewContainer: ViewContainerRef) {}
 
@@ -25,13 +26,13 @@ export abstract class BaseFieldDirective {
   /**
    * Renders the empty field markup which is required by Pages in editMode 'metadata' in case field is empty.
    */
-  protected renderEmpty(emptyFieldEditingComponent: Type<unknown>) {
+  protected renderEmpty() {
     if (this.shouldRenderEmptyEditingComponent()) {
       if (this.emptyFieldEditingTemplate) {
         this.viewContainer.createEmbeddedView(this.emptyFieldEditingTemplate);
       } else {
         this.viewContainer.clear();
-        this.viewContainer.createComponent(emptyFieldEditingComponent);
+        this.viewContainer.createComponent(this.defaultFieldEditingComponent);
       }
     }
   }

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -12,10 +12,10 @@ export abstract class BaseFieldDirective {
   constructor(protected viewContainer: ViewContainerRef) {}
 
   protected shouldRender() {
-    return this.field?.editable || !isFieldValueEmpty(this.field);
+    return !!this.field?.editable || !isFieldValueEmpty(this.field);
   }
 
-  protected shouldRenderEmptyEditingComponent() {
+  private shouldRenderEmptyEditingComponent() {
     return this.field?.metadata && this.editable;
   }
 

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, Type, ViewContainerRef, EmbeddedViewRef, TemplateRef } from '@angular/core';
+
+@Directive()
+export abstract class BaseFieldDirective {
+  protected viewRef: EmbeddedViewRef<unknown>;
+
+  constructor(protected viewContainer: ViewContainerRef) {}
+
+  protected renderEmptyFieldEditingComponent(
+    emptyFieldEditingComponent: Type<unknown> | TemplateRef<unknown>
+  ) {
+    if (typeof emptyFieldEditingComponent === 'object') {
+      this.viewContainer.createEmbeddedView(emptyFieldEditingComponent as TemplateRef<unknown>);
+    } else {
+      this.viewContainer.clear();
+      this.viewContainer.createComponent(emptyFieldEditingComponent as Type<unknown>);
+    }
+  }
+}

--- a/packages/sitecore-jss-angular/src/components/base-field.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/base-field.directive.ts
@@ -2,6 +2,9 @@ import { Directive, Type, ViewContainerRef, EmbeddedViewRef, TemplateRef } from 
 import { RenderingField } from './rendering-field';
 import { GenericFieldValue, isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
+/**
+ * Base class that contains common functionality for the field directives.
+ */
 @Directive()
 export abstract class BaseFieldDirective {
   protected viewRef: EmbeddedViewRef<unknown>;
@@ -11,10 +14,17 @@ export abstract class BaseFieldDirective {
 
   constructor(protected viewContainer: ViewContainerRef) {}
 
+  /**
+   * Determines if directive should render the field as is
+   * Returns true if we are in edit mode 'chromes' (field.editable is present) or field is not empty
+   */
   protected shouldRender() {
     return !!this.field?.editable || !isFieldValueEmpty(this.field);
   }
 
+  /**
+   * Renders the empty field markup which is required by Pages in editMode 'metadata' in case field is empty.
+   */
   protected renderEmpty(emptyFieldEditingComponent: Type<unknown>) {
     if (this.shouldRenderEmptyEditingComponent()) {
       if (this.emptyFieldEditingTemplate) {
@@ -26,6 +36,9 @@ export abstract class BaseFieldDirective {
     }
   }
 
+  /**
+   * Determines if empty editing markup should be rendered for edit mode 'metadata'
+   */
   private shouldRenderEmptyEditingComponent() {
     return this.field?.metadata && this.editable;
   }

--- a/packages/sitecore-jss-angular/src/components/date.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.spec.ts
@@ -1,10 +1,11 @@
 import { DatePipe, formatDate } from '@angular/common';
-import { Component, DebugElement, Input } from '@angular/core';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { textField as eeTextData } from '../test-data/ee-data';
 import { DateDirective } from './date.directive';
 import { TextField } from './rendering-field';
+import { EMPTY_DATE_FIELD_VALUE } from '@sitecore-jss/sitecore-jss/layout';
 
 const testDate = new Date('2010-12-12T12:00Z');
 const testIsoDateValue = testDate.toISOString();
@@ -29,26 +30,56 @@ class TestComponent {
   @Input() timezone = testTimezone;
 }
 
+const emptyDateFieldEditingTemplateId = 'emptyDateFieldEditingTemplate';
+const emptyDateFieldEditingTemplate =
+  '<span>[This is a *custom* empty field component for date]</span>';
+
+@Component({
+  selector: 'test-empty-template-date',
+  template: `
+    <span
+      *scDate="
+        field;
+        editable: editable;
+        emptyFieldEditingTemplate: ${emptyDateFieldEditingTemplateId}
+      "
+    ></span>
+    <ng-template #${emptyDateFieldEditingTemplateId}>
+      ${emptyDateFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: TextField;
+  @Input() editable = true;
+  @Input() format = testFormat;
+  @Input() locale = testLocale;
+  @Input() timezone = testTimezone;
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+}
+
 describe('<span *scDate />', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
+  let deSpan: DebugElement;
   let comp: TestComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DateDirective, TestComponent],
+      declarations: [DateDirective, TestComponent, TestEmptyTemplateComponent],
       providers: [DatePipe],
     });
 
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
-    de = fixture.debugElement.query(By.css('span'));
+    de = fixture.debugElement;
+    deSpan = de.query(By.css('span'));
     comp = fixture.componentInstance;
   });
 
   it('should render nothing with missing field', () => {
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('');
   });
 
@@ -57,7 +88,7 @@ describe('<span *scDate />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('');
   });
 
@@ -69,7 +100,7 @@ describe('<span *scDate />', () => {
 
     comp.field = field;
     fixture.detectChanges();
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('editable');
   });
 
@@ -82,7 +113,7 @@ describe('<span *scDate />', () => {
     comp.editable = false;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe(defaultFormattedDate);
   });
 
@@ -93,7 +124,7 @@ describe('<span *scDate />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe(defaultFormattedDate);
   });
 
@@ -104,8 +135,95 @@ describe('<span *scDate />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toContain('<input');
     expect(rendered).toContain('<span class="scChromeData">');
+  });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'date',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value is empty', () => {
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain('<span>[No text in field]</span>');
+    });
+
+    it('should render default empty field component when field value is the default empty date value', () => {
+      const field = {
+        value: EMPTY_DATE_FIELD_VALUE,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain('<span>[No text in field]</span>');
+    });
+
+    it('should render custom empty field component when provided, when field value is empty', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyDateFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field value the default empty date value', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: EMPTY_DATE_FIELD_VALUE,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyDateFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value is empty, when editing is explicitly disabled', () => {
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe('');
+    });
   });
 });

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { DateField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
+import { DefaultEmptyFieldEditingComponent } from './default-empty-text-field-editing-placeholder.component';
 
 @Directive({
   selector: '[scDate]',

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -5,6 +5,7 @@ import {
   OnChanges,
   SimpleChanges,
   TemplateRef,
+  Type,
   ViewContainerRef,
 } from '@angular/core';
 import { DateField } from './rendering-field';
@@ -27,12 +28,15 @@ export class DateDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scDateEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  protected defaultFieldEditingComponent: Type<unknown>;
+
   constructor(
     viewContainer: ViewContainerRef,
     private templateRef: TemplateRef<unknown>,
     private datePipe: DatePipe
   ) {
     super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyFieldEditingComponent;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -48,7 +52,7 @@ export class DateDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      super.renderEmpty(DefaultEmptyFieldEditingComponent);
+      super.renderEmpty();
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -26,8 +26,14 @@ export class DateDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scDate') field: DateField;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scDateEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected defaultFieldEditingComponent: Type<unknown>;
 
   constructor(

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/core';
 import { DateField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
 
 @Directive({
@@ -48,17 +47,12 @@ export class DateDirective extends BaseFieldDirective implements OnChanges {
   }
 
   private updateView() {
-    const field = this.field;
-
-    if (!field?.editable && isFieldValueEmpty(this.field)) {
-      if (this.field?.metadata && this.editable) {
-        super.renderEmptyFieldEditingComponent(
-          this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
-        );
-      }
-
+    if (!this.shouldRender()) {
+      super.renderEmpty(DefaultEmptyFieldEditingComponent);
       return;
     }
+
+    const field = this.field;
 
     const html = field.editable && this.editable ? field.editable : field.value;
     const setDangerously = field.editable && this.editable;

--- a/packages/sitecore-jss-angular/src/components/date.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/date.directive.ts
@@ -56,6 +56,8 @@ export class DateDirective extends BaseFieldDirective implements OnChanges {
           this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
         );
       }
+
+      return;
     }
 
     const html = field.editable && this.editable ? field.editable : field.value;

--- a/packages/sitecore-jss-angular/src/components/default-empty-field-editing-image.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-field-editing-image.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+/**
+ * Default component that will be rendered in pages when image field is empty.
+ */
+@Component({
+  selector: 'app-default-empty-field-editing-image',
+  template: `
+    <img
+      alt=""
+      src='data:image/svg+xml,%3Csvg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 240 240" style="enable-background:new 0 0 240 240;" xml:space="preserve"%3E%3Cstyle type="text/css"%3E .st0%7Bfill:none;%7D .st1%7Bfill:%23969696;%7D .st2%7Bfill:%23FFFFFF;%7D .st3%7Bfill:%23FFFFFF;stroke:%23FFFFFF;stroke-width:0.75;stroke-miterlimit:10;%7D%0A%3C/style%3E%3Cg%3E%3Crect class="st0" width="240" height="240"/%3E%3Cg%3E%3Cg%3E%3Crect x="20" y="20" class="st1" width="200" height="200"/%3E%3C/g%3E%3Cg%3E%3Ccircle class="st2" cx="174" cy="67" r="14"/%3E%3Cpath class="st2" d="M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z"/%3E%3C/g%3E%3Cpolyline class="st3" points="29.5,179.25 81.32,122.25 95.41,137.75 137.23,91.75 209.5,179.75 "/%3E%3C/g%3E%3C/g%3E%3C/svg%3E'
+      className="scEmptyImage"
+      style="min-width:48px;min-height:48px;max-width:400px;max-height:400px;cursor:pointer"
+    />
+  `,
+})
+export class DefaultEmptyFieldEditingImageComponent {}

--- a/packages/sitecore-jss-angular/src/components/default-empty-field-editing.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-field-editing.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+/**
+ * Demonstrates usage of a Rich Text (HTML) content field within JSS.
+ */
+@Component({
+  selector: 'app-default-empty-field-editing',
+  template: '<span>[No text in field]</span>',
+})
+export class DefaultEmptyFieldEditingComponent {}

--- a/packages/sitecore-jss-angular/src/components/default-empty-field-editing.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-field-editing.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 /**
- * Demonstrates usage of a Rich Text (HTML) content field within JSS.
+ * Default component that will be rendered in pages when field is empty; applies for text, richtext, date and link fields.
  */
 @Component({
   selector: 'app-default-empty-field-editing',

--- a/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
  * Default component that will be rendered in pages when image field is empty.
  */
 @Component({
-  selector: 'app-default-empty-field-editing-image',
+  selector: 'app-default-empty-image-field-editing-placeholder',
   template: `
     <img
       alt=""

--- a/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
@@ -12,6 +12,7 @@ import { Component } from '@angular/core';
       class="scEmptyImage"
     />
   `,
-  styles: `img { min-width:48px; min-height:48px; max-width:400px; max-height:400px; cursor:pointer }`,
+  styles:
+    'img { min-width:48px; min-height:48px; max-width:400px; max-height:400px; cursor:pointer }',
 })
 export class DefaultEmptyImageFieldEditingComponent {}

--- a/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
@@ -9,9 +9,9 @@ import { Component } from '@angular/core';
     <img
       alt=""
       src='data:image/svg+xml,%3Csvg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 240 240" style="enable-background:new 0 0 240 240;" xml:space="preserve"%3E%3Cstyle type="text/css"%3E .st0%7Bfill:none;%7D .st1%7Bfill:%23969696;%7D .st2%7Bfill:%23FFFFFF;%7D .st3%7Bfill:%23FFFFFF;stroke:%23FFFFFF;stroke-width:0.75;stroke-miterlimit:10;%7D%0A%3C/style%3E%3Cg%3E%3Crect class="st0" width="240" height="240"/%3E%3Cg%3E%3Cg%3E%3Crect x="20" y="20" class="st1" width="200" height="200"/%3E%3C/g%3E%3Cg%3E%3Ccircle class="st2" cx="174" cy="67" r="14"/%3E%3Cpath class="st2" d="M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z"/%3E%3C/g%3E%3Cpolyline class="st3" points="29.5,179.25 81.32,122.25 95.41,137.75 137.23,91.75 209.5,179.75 "/%3E%3C/g%3E%3C/g%3E%3C/svg%3E'
-      className="scEmptyImage"
-      style="min-width:48px;min-height:48px;max-width:400px;max-height:400px;cursor:pointer"
+      class="scEmptyImage"
     />
   `,
+  styles: `img { min-width:48px; min-height:48px; max-width:400px; max-height:400px; cursor:pointer }`,
 })
-export class DefaultEmptyFieldEditingImageComponent {}
+export class DefaultEmptyImageFieldEditingComponent {}

--- a/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
  * Default component that will be rendered in pages when image field is empty.
  */
 @Component({
-  selector: 'app-default-empty-image-field-editing-placeholder',
+  selector: 'sc-default-empty-image-field-editing-placeholder',
   template: `
     <img
       alt=""

--- a/packages/sitecore-jss-angular/src/components/default-empty-text-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-text-field-editing-placeholder.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
  * Default component that will be rendered in pages when field is empty; applies for text, richtext, date and link fields.
  */
 @Component({
-  selector: 'app-default-empty-field-editing',
+  selector: 'app-default-empty-text-field-editing-placeholder',
   template: '<span>[No text in field]</span>',
 })
 export class DefaultEmptyFieldEditingComponent {}

--- a/packages/sitecore-jss-angular/src/components/default-empty-text-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-text-field-editing-placeholder.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
  * Default component that will be rendered in pages when field is empty; applies for text, richtext, date and link fields.
  */
 @Component({
-  selector: 'app-default-empty-text-field-editing-placeholder',
+  selector: 'sc-default-empty-text-field-editing-placeholder',
   template: '<span>[No text in field]</span>',
 })
 export class DefaultEmptyFieldEditingComponent {}

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
@@ -25,7 +25,7 @@ class TestComponent {
   @Input() extras = {};
 }
 
-const emptyLinkFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyLinkFieldEditingTemplateId = 'emptyLinkFieldEditingTemplate';
 const emptyLinkFieldEditingTemplate = '<span>[This is a *custom* empty field template]</span>';
 const emptyLinkFieldEditingTemplateDefaultTestString = '<span>[No text in field]</span>';
 

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Input } from '@angular/core';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -25,6 +25,37 @@ class TestComponent {
   @Input() extras = {};
 }
 
+const emptyLinkFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyLinkFieldEditingTemplate = '<span>[This is a *custom* empty field template]</span>';
+const emptyLinkFieldEditingTemplateDefaultTestString = '<span>[No text in field]</span>';
+
+@Component({
+  selector: 'test-empty-template-generic-link',
+  template: `
+    <a
+      *scGenericLink="
+        field;
+        editable: editable;
+        attrs: attrs;
+        extras: extras;
+        emptyFieldEditingTemplate: ${emptyLinkFieldEditingTemplateId}
+      "
+      class="external-css-class"
+      id="my-link"
+    ></a>
+    <ng-template #${emptyLinkFieldEditingTemplateId}>
+      ${emptyLinkFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: LinkField;
+  @Input() editable = true;
+  @Input() attrs = {};
+  @Input() extras = {};
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+}
+
 describe('<a *scGenericLink />', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
@@ -32,7 +63,7 @@ describe('<a *scGenericLink />', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [GenericLinkDirective, TestComponent],
+      declarations: [GenericLinkDirective, TestComponent, TestEmptyTemplateComponent],
       imports: [RouterTestingModule],
     });
 
@@ -173,6 +204,102 @@ describe('<a *scGenericLink />', () => {
     expect(rendered.nativeElement.title).toBe('footip');
     expect(rendered.nativeElement.className).toBe('external-css-class my-link');
   });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'link',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value href is not present', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render default empty field component when field href is not present', () => {
+      const field = {
+        hred: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render custom empty field component when provided, when field value href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value href is not present, when editing is explicitly disabled', () => {
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+
+    it('should render nothing when field href is empty, when editing is explicitly disabled', () => {
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+  });
 });
 
 @Component({
@@ -190,6 +317,33 @@ class TestWithChildrenComponent {
   @Input() extras = {};
 }
 
+@Component({
+  selector: 'test-empty-template-generic-link',
+  template: `
+    <a
+      *scGenericLink="
+        field;
+        editable: editable;
+        attrs: attrs;
+        extras: extras;
+        emptyFieldEditingTemplate: ${emptyLinkFieldEditingTemplateId}
+      "
+      id="my-link"
+      ><span *ngIf="true">hello world</span></a
+    >
+    <ng-template #${emptyLinkFieldEditingTemplateId}>
+      ${emptyLinkFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateWithChildrenComponent {
+  @Input() field: LinkField;
+  @Input() editable = true;
+  @Input() attrs = {};
+  @Input() extras = {};
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+}
+
 describe('<a *scGenericLink>children</a>', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
@@ -197,7 +351,11 @@ describe('<a *scGenericLink>children</a>', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [GenericLinkDirective, TestWithChildrenComponent],
+      declarations: [
+        GenericLinkDirective,
+        TestWithChildrenComponent,
+        TestEmptyTemplateWithChildrenComponent,
+      ],
       imports: [RouterTestingModule],
     });
 
@@ -229,6 +387,102 @@ describe('<a *scGenericLink>children</a>', () => {
 
     const rendered = de.query(By.css('a'));
     expect(rendered.nativeElement.innerHTML).toContain('<span>hello world</span>');
+  });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'link',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value href is not present', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render default empty field component when field href is not present', () => {
+      const field = {
+        hred: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render custom empty field component when provided, when field value href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateWithChildrenComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateWithChildrenComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value href is not present, when editing is explicitly disabled', () => {
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+
+    it('should render nothing when field href is empty, when editing is explicitly disabled', () => {
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
   });
 });
 

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
@@ -21,6 +21,10 @@ export class GenericLinkDirective extends LinkDirective {
 
   @Input('scGenericLinkExtras') extras?: NavigationExtras;
 
+  @Input('scGenericLinkEmptyFieldEditingTemplate') declare emptyFieldEditingTemplate: TemplateRef<
+    unknown
+  >;
+
   constructor(
     viewContainer: ViewContainerRef,
     templateRef: TemplateRef<unknown>,

--- a/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/generic-link.directive.ts
@@ -21,6 +21,9 @@ export class GenericLinkDirective extends LinkDirective {
 
   @Input('scGenericLinkExtras') extras?: NavigationExtras;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scGenericLinkEmptyFieldEditingTemplate') declare emptyFieldEditingTemplate: TemplateRef<
     unknown
   >;

--- a/packages/sitecore-jss-angular/src/components/image.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Input } from '@angular/core';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -41,6 +41,34 @@ class AnotherTestComponent {
   @Input() mediaUrlPrefix?: RegExp;
 }
 
+const emptyImageFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyImageFieldEditingTemplate = '<img src="" alt="Empty image">';
+const emptyImageFieldEditingTemplateDefaultTestString =
+  'M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z';
+
+@Component({
+  selector: 'test-empty-template-image',
+  template: `
+    <img
+      class="some"
+      id="another"
+      *scImage="
+        field;
+        editable: editable;
+        emptyFieldEditingTemplate: ${emptyImageFieldEditingTemplateId}
+      "
+    />
+    <ng-template #${emptyImageFieldEditingTemplateId}>
+      ${emptyImageFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: ImageField;
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+  @Input() editable = true;
+}
+
 describe('<img *scImage />', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
@@ -48,7 +76,12 @@ describe('<img *scImage />', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ImageDirective, TestComponent, AnotherTestComponent],
+      declarations: [
+        ImageDirective,
+        TestComponent,
+        AnotherTestComponent,
+        TestEmptyTemplateComponent,
+      ],
     });
 
     fixture = TestBed.createComponent(TestComponent);
@@ -343,6 +376,104 @@ describe('<img *scImage />', () => {
 
       expect(img.src).toContain(media.value.src); // src also contains <base> href which is OK.
       expect(img.alt).toBe(media.value.alt);
+    });
+  });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'image',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component for Image when field value src is not present', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyImageFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render default empty field component for Image when field src is not present', () => {
+      const field = {
+        src: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyImageFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render custom empty field component when provided, when field value src is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyImageFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field src is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        src: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyImageFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value src is not present, when editing is explicitly disabled', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+
+      expect(de.children.length).toBe(0);
+    });
+
+    it('should render nothing when field src is not present, when editing is explicitly disabled', () => {
+      const field = {
+        src: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+
+      expect(de.children.length).toBe(0);
     });
   });
 

--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -20,8 +20,14 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scImageEditable') editable = true;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scImageEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected defaultFieldEditingComponent: Type<unknown>;
 
   /**

--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -11,7 +11,7 @@ import {
 import { mediaApi } from '@sitecore-jss/sitecore-jss/media';
 import { ImageField, ImageFieldValue } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { DefaultEmptyFieldEditingImageComponent } from './default-empty-field-editing-image.component';
+import { DefaultEmptyImageFieldEditingComponent } from './default-empty-image-field-editing-placeholder.component';
 
 @Directive({ selector: '[scImage]' })
 export class ImageDirective extends BaseFieldDirective implements OnChanges {
@@ -59,7 +59,7 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      super.renderEmpty(DefaultEmptyFieldEditingImageComponent);
+      super.renderEmpty(DefaultEmptyImageFieldEditingComponent);
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -21,16 +21,6 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
   @Input('scImageEditable') editable = true;
 
   /**
-   * Custom template to render in Pages in Metadata edit mode if field value is empty
-   */
-  @Input('scImageEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
-
-  /**
-   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
-   */
-  protected defaultFieldEditingComponent: Type<unknown>;
-
-  /**
    * Custom regexp that finds media URL prefix that will be replaced by `/-/jssmedia` or `/~/jssmedia`.
    * @example
    * /\/([-~]{1})assets\//i
@@ -42,6 +32,16 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
   @Input('scImageUrlParams') urlParams: { [param: string]: string | number } = {};
 
   @Input('scImageAttrs') attrs: { [param: string]: unknown } = {};
+
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
+  @Input('scImageEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
+
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
+  protected defaultFieldEditingComponent: Type<unknown>;
 
   private inlineRef: HTMLSpanElement | null = null;
 

--- a/packages/sitecore-jss-angular/src/components/image.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/image.directive.ts
@@ -6,6 +6,7 @@ import {
   Renderer2,
   SimpleChanges,
   TemplateRef,
+  Type,
   ViewContainerRef,
 } from '@angular/core';
 import { mediaApi } from '@sitecore-jss/sitecore-jss/media';
@@ -20,6 +21,8 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
   @Input('scImageEditable') editable = true;
 
   @Input('scImageEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
+
+  protected defaultFieldEditingComponent: Type<unknown>;
 
   /**
    * Custom regexp that finds media URL prefix that will be replaced by `/-/jssmedia` or `/~/jssmedia`.
@@ -43,6 +46,7 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
     private elementRef: ElementRef
   ) {
     super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyImageFieldEditingComponent;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -59,7 +63,7 @@ export class ImageDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      super.renderEmpty(DefaultEmptyImageFieldEditingComponent);
+      super.renderEmpty();
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
@@ -18,7 +18,7 @@ class TestComponent {
   @Input() attrs = {};
 }
 
-const emptyLinkFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyLinkFieldEditingTemplateId = 'emptyLinkFieldEditingTemplate';
 const emptyLinkFieldEditingTemplate = '<span>[This is a *custom* empty field template]</span>';
 const emptyLinkFieldEditingTemplateDefaultTestString = '<span>[No text in field]</span>';
 

--- a/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.spec.ts
@@ -213,7 +213,7 @@ describe('<a *scLink />', () => {
       comp.editable = false;
       comp.field = field;
       fixture.detectChanges();
-      console.log(de.nativeElement);
+
       const rendered = de.query(By.css('a'));
 
       expect(rendered.nativeElement.href).toBe('');

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -84,7 +84,7 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
 
   protected shouldRender() {
     // render the field if field is empty but we have 'text' and we are not in edditing mode, to preserve existing functionality
-    return super.shouldRender() || (this.field?.text && !this.field?.metadata);
+    return super.shouldRender() || !!(this.field?.text && !this.field?.metadata);
   }
 
   private updateView() {

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -82,6 +82,11 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
     }
   }
 
+  protected shouldRender() {
+    // render the field if field is empty but we have 'text' and we are not in edditing mode, to preserve existing functionality
+    return super.shouldRender() || (this.field?.text && !this.field?.metadata);
+  }
+
   private updateView() {
     const field = this.field;
     if (this.editable && field && field.editableFirstPart && field.editableLastPart) {
@@ -142,10 +147,5 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
     }
     view.destroy();
     return attrs;
-  }
-
-  protected shouldRender() {
-    // render the field if field is empty but we have 'text' and we are not in edditing mode, to preserve existing functionality
-    return super.shouldRender() || (this.field?.text && !this.field?.metadata);
   }
 }

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -143,4 +143,9 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
     view.destroy();
     return attrs;
   }
+
+  protected shouldRender() {
+    // render the field if field is empty but we have 'text' and we are not in edditing mode, to preserve existing functionality
+    return super.shouldRender() || (this.field?.text && !this.field?.metadata);
+  }
 }

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -6,6 +6,7 @@ import {
   Renderer2,
   SimpleChanges,
   TemplateRef,
+  Type,
   ViewContainerRef,
 } from '@angular/core';
 import { LinkField } from './rendering-field';
@@ -22,6 +23,8 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scLinkEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  protected defaultFieldEditingComponent: Type<unknown>;
+
   private inlineRef: HTMLSpanElement | null = null;
 
   constructor(
@@ -31,6 +34,7 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
     private elementRef: ElementRef
   ) {
     super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyFieldEditingComponent;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -101,7 +105,7 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
       this.renderInlineWrapper(field.editableFirstPart, field.editableLastPart);
     } else {
       if (!this.shouldRender()) {
-        super.renderEmpty(DefaultEmptyFieldEditingComponent);
+        super.renderEmpty();
         return;
       }
 

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -82,9 +82,17 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
     }
   }
 
+  /**
+   * Determines if directive should render the field as is
+   * Returns true if we are in edit mode 'chromes' (field.editable is present) or field is not empty
+   * or link field text is present and we are not in edit mode 'metadata'
+   * The right side of the expression was added to preserve existing functionality
+   */
   protected shouldRender() {
-    // render the field if field is empty but we have 'text' and we are not in edditing mode, to preserve existing functionality
-    return super.shouldRender() || !!(this.field?.text && !this.field?.metadata);
+    return (
+      super.shouldRender() ||
+      !!((this.field?.text || this.field?.value?.text) && !this.field?.metadata)
+    );
   }
 
   private updateView() {

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { LinkField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
+import { DefaultEmptyFieldEditingComponent } from './default-empty-text-field-editing-placeholder.component';
 
 @Directive({ selector: '[scLink]' })
 export class LinkDirective extends BaseFieldDirective implements OnChanges {

--- a/packages/sitecore-jss-angular/src/components/link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/link.directive.ts
@@ -21,8 +21,14 @@ export class LinkDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scLink') field: LinkField;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scLinkEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected defaultFieldEditingComponent: Type<unknown>;
 
   private inlineRef: HTMLSpanElement | null = null;

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
+import { FieldMetadata, GenericFieldValue } from '@sitecore-jss/sitecore-jss/layout';
 
-export interface RenderingField<V = unknown> extends FieldMetadata {
+export interface RenderingField<V = GenericFieldValue> extends FieldMetadata {
   value?: V;
   editable?: string;
 }
@@ -14,9 +14,7 @@ export interface FileFieldValue {
   displayName?: string;
 }
 
-export interface FileField extends FileFieldValue, RenderingField {
-  value?: FileFieldValue;
-}
+export interface FileField extends FileFieldValue, RenderingField<FileFieldValue> {}
 
 export interface ImageFieldValue {
   [key: string]: unknown;

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -6,9 +6,7 @@ export interface RenderingField<V = unknown> extends FieldMetadata {
   editable?: string;
 }
 
-export interface DateField extends RenderingField {
-  value?: string | number | Date;
-}
+export interface DateField extends RenderingField<string> {}
 
 export interface FileFieldValue {
   src?: string;

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-export interface RenderingField<V = unknown> {
+import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
+
+export interface RenderingField<V = unknown> extends FieldMetadata {
   value?: V;
   editable?: string;
 }
 
-export interface DateField {
+export interface DateField extends RenderingField {
   value?: string | number | Date;
-  editable?: string;
 }
 
 export interface FileFieldValue {

--- a/packages/sitecore-jss-angular/src/components/rendering-field.ts
+++ b/packages/sitecore-jss-angular/src/components/rendering-field.ts
@@ -6,7 +6,7 @@ export interface RenderingField<V = GenericFieldValue> extends FieldMetadata {
   editable?: string;
 }
 
-export interface DateField extends RenderingField<string> {}
+export interface DateField extends RenderingField<string | number | Date> {}
 
 export interface FileFieldValue {
   src?: string;

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -22,8 +22,14 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scRichText') field: RichTextField;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scRichTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected defaultFieldEditingComponent: Type<unknown>;
 
   constructor(

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -6,6 +6,7 @@ import {
   TemplateRef,
   ViewContainerRef,
   Renderer2,
+  Type,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { isAbsoluteUrl } from '@sitecore-jss/sitecore-jss/utils';
@@ -23,6 +24,8 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scRichTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  protected defaultFieldEditingComponent: Type<unknown>;
+
   constructor(
     viewContainer: ViewContainerRef,
     private templateRef: TemplateRef<unknown>,
@@ -30,6 +33,7 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
     private router: Router
   ) {
     super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyFieldEditingComponent;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -45,7 +49,7 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      super.renderEmpty(DefaultEmptyFieldEditingComponent);
+      super.renderEmpty();
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -12,7 +12,6 @@ import { isAbsoluteUrl } from '@sitecore-jss/sitecore-jss/utils';
 import { RichTextField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
 import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
-import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
 @Directive({
   selector: '[scRichText]',
@@ -45,17 +44,12 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
   }
 
   private updateView() {
-    const field = this.field;
-    if (!field?.editable && isFieldValueEmpty(this.field)) {
-      if (this.field?.metadata && this.editable) {
-        super.renderEmptyFieldEditingComponent(
-          this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
-        );
-      }
-
+    if (!this.shouldRender()) {
+      super.renderEmpty(DefaultEmptyFieldEditingComponent);
       return;
     }
 
+    const field = this.field;
     const html = field.editable && this.editable ? field.editable : field.value;
     this.viewRef.rootNodes.forEach((node) => {
       node.innerHTML = html;

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -1,6 +1,5 @@
 import {
   Directive,
-  EmbeddedViewRef,
   Input,
   OnChanges,
   SimpleChanges,
@@ -11,23 +10,29 @@ import {
 import { Router } from '@angular/router';
 import { isAbsoluteUrl } from '@sitecore-jss/sitecore-jss/utils';
 import { RichTextField } from './rendering-field';
+import { BaseFieldDirective } from './base-field.directive';
+import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
+import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
 @Directive({
   selector: '[scRichText]',
 })
-export class RichTextDirective implements OnChanges {
+export class RichTextDirective extends BaseFieldDirective implements OnChanges {
   @Input('scRichTextEditable') editable = true;
+  @Input('scRichTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
   @Input('scRichText') field: RichTextField;
 
-  private viewRef: EmbeddedViewRef<unknown>;
-
   constructor(
-    private viewContainer: ViewContainerRef,
+    viewContainer: ViewContainerRef,
     private templateRef: TemplateRef<unknown>,
     private renderer: Renderer2,
     private router: Router
-  ) {}
+  ) {
+    super(viewContainer);
+  }
+
+  ngOnInit() {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.field || changes.editable) {
@@ -42,7 +47,13 @@ export class RichTextDirective implements OnChanges {
 
   private updateView() {
     const field = this.field;
-    if (!field || (!field.editable && !field.value)) {
+    if (!field?.editable && isFieldValueEmpty(this.field)) {
+      if (this.field?.metadata && this.editable) {
+        super.renderEmptyFieldEditingComponent(
+          this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
+        );
+      }
+
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -11,7 +11,7 @@ import { Router } from '@angular/router';
 import { isAbsoluteUrl } from '@sitecore-jss/sitecore-jss/utils';
 import { RichTextField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
+import { DefaultEmptyFieldEditingComponent } from './default-empty-text-field-editing-placeholder.component';
 
 @Directive({
   selector: '[scRichText]',

--- a/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/rich-text.directive.ts
@@ -19,9 +19,10 @@ import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 })
 export class RichTextDirective extends BaseFieldDirective implements OnChanges {
   @Input('scRichTextEditable') editable = true;
-  @Input('scRichTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
   @Input('scRichText') field: RichTextField;
+
+  @Input('scRichTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
   constructor(
     viewContainer: ViewContainerRef,
@@ -31,8 +32,6 @@ export class RichTextDirective extends BaseFieldDirective implements OnChanges {
   ) {
     super(viewContainer);
   }
-
-  ngOnInit() {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.field || changes.editable) {

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
@@ -23,7 +23,7 @@ class TestComponent {
   @Input() attrs = {};
 }
 
-const emptyLinkFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyLinkFieldEditingTemplateId = 'emptyLinkFieldEditingTemplate';
 const emptyLinkFieldEditingTemplate = '<span>[This is a *custom* empty field template]</span>';
 const emptyLinkFieldEditingTemplateDefaultTestString = '<span>[No text in field]</span>';
 

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Input } from '@angular/core';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -23,6 +23,35 @@ class TestComponent {
   @Input() attrs = {};
 }
 
+const emptyLinkFieldEditingTemplateId = 'emptyImageFieldEditingTemplate';
+const emptyLinkFieldEditingTemplate = '<span>[This is a *custom* empty field template]</span>';
+const emptyLinkFieldEditingTemplateDefaultTestString = '<span>[No text in field]</span>';
+
+@Component({
+  selector: 'test-empty-template-router-link',
+  template: `
+    <a
+      *scRouterLink="
+        field;
+        editable: editable;
+        attrs: attrs;
+        emptyFieldEditingTemplate: ${emptyLinkFieldEditingTemplateId}
+      "
+      class="external-css-class"
+      id="my-link"
+    ></a>
+    <ng-template #${emptyLinkFieldEditingTemplateId}>
+      ${emptyLinkFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: LinkField;
+  @Input() editable = true;
+  @Input() attrs = {};
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+}
+
 describe('<a *scRouterLink />', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
@@ -30,7 +59,7 @@ describe('<a *scRouterLink />', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [RouterLinkDirective, TestComponent],
+      declarations: [RouterLinkDirective, TestComponent, TestEmptyTemplateComponent],
       imports: [RouterTestingModule],
     });
 
@@ -173,6 +202,102 @@ describe('<a *scRouterLink />', () => {
     expect(rendered.nativeElement.title).toBe('footip');
     expect(rendered.nativeElement.className).toBe('external-css-class my-link');
   });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'link',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value href is not present', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render default empty field component when field href is not present', () => {
+      const field = {
+        hred: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render custom empty field component when provided, when field value href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value href is not present, when editing is explicitly disabled', () => {
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+
+    it('should render nothing when field href is empty, when editing is explicitly disabled', () => {
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+  });
 });
 
 @Component({
@@ -189,6 +314,31 @@ class TestWithChildrenComponent {
   @Input() attrs = {};
 }
 
+@Component({
+  selector: 'test-empty-template-link',
+  template: `
+    <a
+      *scRouterLink="
+        field;
+        editable: editable;
+        attrs: attrs;
+        emptyFieldEditingTemplate: ${emptyLinkFieldEditingTemplateId}
+      "
+      id="my-link"
+      ><span *ngIf="true">hello world</span></a
+    >
+    <ng-template #${emptyLinkFieldEditingTemplateId}>
+      ${emptyLinkFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateWithChildrenComponent {
+  @Input() field: LinkField;
+  @Input() editable = true;
+  @Input() attrs = {};
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+}
+
 describe('<a *scRouterLink>children</a>', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
@@ -196,7 +346,11 @@ describe('<a *scRouterLink>children</a>', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [RouterLinkDirective, TestWithChildrenComponent],
+      declarations: [
+        RouterLinkDirective,
+        TestWithChildrenComponent,
+        TestEmptyTemplateWithChildrenComponent,
+      ],
       imports: [RouterTestingModule],
     });
 
@@ -228,5 +382,101 @@ describe('<a *scRouterLink>children</a>', () => {
 
     const rendered = de.query(By.css('a'));
     expect(rendered.nativeElement.innerHTML).toContain('<span>hello world</span>');
+  });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'link',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value href is not present', () => {
+      const field = {
+        value: { src: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render default empty field component when field href is not present', () => {
+      const field = {
+        hred: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplateDefaultTestString);
+    });
+
+    it('should render custom empty field component when provided, when field value href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateWithChildrenComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render custom empty field component when provided, when field href is not present', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateWithChildrenComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyLinkFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value href is not present, when editing is explicitly disabled', () => {
+      const field = {
+        value: { href: undefined },
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
+
+    it('should render nothing when field href is empty, when editing is explicitly disabled', () => {
+      const field = {
+        href: undefined,
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+      expect(de.children.length).toBe(0);
+    });
   });
 });

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.ts
@@ -18,6 +18,9 @@ export class RouterLinkDirective extends LinkDirective {
 
   @Input('scRouterLink') declare field: LinkField;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scRouterLinkEmptyFieldEditingTemplate') declare emptyFieldEditingTemplate: TemplateRef<
     unknown
   >;

--- a/packages/sitecore-jss-angular/src/components/router-link.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/router-link.directive.ts
@@ -18,6 +18,10 @@ export class RouterLinkDirective extends LinkDirective {
 
   @Input('scRouterLink') declare field: LinkField;
 
+  @Input('scRouterLinkEmptyFieldEditingTemplate') declare emptyFieldEditingTemplate: TemplateRef<
+    unknown
+  >;
+
   constructor(
     viewContainer: ViewContainerRef,
     templateRef: TemplateRef<unknown>,

--- a/packages/sitecore-jss-angular/src/components/text.directive.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, Input } from '@angular/core';
+import { Component, DebugElement, Input, TemplateRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -18,25 +18,55 @@ class TestComponent {
   @Input() encode = true;
 }
 
+const emptyTextFieldEditingTemplateId = 'emptyTextFieldEditingTemplate';
+const emptyTextFieldEditingTemplate =
+  '<span>[This is a *custom* empty field component for text]</span>';
+
+@Component({
+  selector: 'test-empty-template-text',
+  template: `
+    <span
+      *scText="
+        field;
+        editable: editable;
+        encode: encode;
+        emptyFieldEditingTemplate: ${emptyTextFieldEditingTemplateId}
+      "
+    ></span>
+
+    <ng-template #${emptyTextFieldEditingTemplateId}>
+      ${emptyTextFieldEditingTemplate}
+    </ng-template>
+  `,
+})
+class TestEmptyTemplateComponent {
+  @Input() field: TextField;
+  @Input() emptyFieldEditingTemplate: TemplateRef<unknown>;
+  @Input() editable = true;
+  @Input() encode = true;
+}
+
 describe('<span *scText />', () => {
   let fixture: ComponentFixture<TestComponent>;
   let de: DebugElement;
+  let deSpan: DebugElement;
   let comp: TestComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TextDirective, TestComponent],
+      declarations: [TextDirective, TestComponent, TestEmptyTemplateComponent],
     });
 
     fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
-    de = fixture.debugElement.query(By.css('span'));
+    de = fixture.debugElement;
+    deSpan = de.query(By.css('span'));
     comp = fixture.componentInstance;
   });
 
   it('should render nothing with missing field', () => {
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('');
   });
 
@@ -45,7 +75,7 @@ describe('<span *scText />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('');
   });
 
@@ -56,7 +86,7 @@ describe('<span *scText />', () => {
 
     comp.field = field;
     fixture.detectChanges();
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('');
   });
 
@@ -68,7 +98,7 @@ describe('<span *scText />', () => {
 
     comp.field = field;
     fixture.detectChanges();
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('editable');
   });
 
@@ -81,7 +111,7 @@ describe('<span *scText />', () => {
     comp.editable = false;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('value');
   });
 
@@ -94,7 +124,7 @@ describe('<span *scText />', () => {
     comp.editable = false;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toContain('&lt; &gt;');
   });
 
@@ -105,7 +135,7 @@ describe('<span *scText />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('value');
   });
 
@@ -116,7 +146,7 @@ describe('<span *scText />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('1.23');
   });
 
@@ -127,7 +157,7 @@ describe('<span *scText />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe('0');
   });
 
@@ -139,7 +169,7 @@ describe('<span *scText />', () => {
     comp.encode = false;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toBe(field.value);
   });
 
@@ -150,7 +180,7 @@ describe('<span *scText />', () => {
     comp.field = field;
     fixture.detectChanges();
 
-    const rendered = de.nativeElement.innerHTML;
+    const rendered = deSpan.nativeElement.innerHTML;
     expect(rendered).toContain('<input');
     expect(rendered).toContain('<span class="scChromeData">');
   });
@@ -164,4 +194,61 @@ describe('<span *scText />', () => {
   //   expect(rendered.html()).to.contain('<h1 class="cssClass" id="lorem">');
   //   expect(rendered.html()).to.contain('value');
   // });
+
+  describe('editMode metadata', () => {
+    const testMetadata = {
+      contextItem: {
+        id: '{09A07660-6834-476C-B93B-584248D3003B}',
+        language: 'en',
+        revision: 'a0b36ce0a7db49418edf90eb9621e145',
+        version: 1,
+      },
+      fieldId: '{414061F4-FBB1-4591-BC37-BFFA67F745EB}',
+      fieldType: 'single-line',
+      rawValue: 'Test1',
+    };
+
+    it('should render default empty field component when field value is empty', () => {
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain('<span>[No text in field]</span>');
+    });
+
+    it('should render custom empty field component when provided, when field value is empty', () => {
+      fixture = TestBed.createComponent(TestEmptyTemplateComponent);
+      fixture.detectChanges();
+
+      de = fixture.debugElement;
+      comp = fixture.componentInstance;
+
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      fixture.detectChanges();
+
+      const rendered = de.nativeElement.innerHTML;
+      expect(rendered).toContain(emptyTextFieldEditingTemplate);
+    });
+
+    it('should render nothing when field value is empty, when editing is explicitly disabled', () => {
+      const field = {
+        value: '',
+        metadata: testMetadata,
+      };
+      comp.field = field;
+      comp.editable = false;
+      fixture.detectChanges();
+
+      const rendered = deSpan.nativeElement.innerHTML;
+      expect(rendered).toBe('');
+    });
+  });
 });

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -4,6 +4,7 @@ import {
   OnChanges,
   SimpleChanges,
   TemplateRef,
+  Type,
   ViewContainerRef,
 } from '@angular/core';
 import { TextField } from './rendering-field';
@@ -22,8 +23,11 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  protected defaultFieldEditingComponent: Type<unknown>;
+
   constructor(viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {
     super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyFieldEditingComponent;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -39,7 +43,7 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      super.renderEmpty(DefaultEmptyFieldEditingComponent);
+      super.renderEmpty();
       return;
     }
 

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -39,7 +39,6 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
 
   private updateView() {
     if (!this.shouldRender()) {
-      console.log('should not render');
       super.renderEmpty(DefaultEmptyFieldEditingComponent);
       return;
     }

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -48,6 +48,8 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
           this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
         );
       }
+
+      return;
     }
 
     // can't use editable value if we want to output unencoded

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/core';
 import { TextField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
+import { DefaultEmptyFieldEditingComponent } from './default-empty-text-field-editing-placeholder.component';
 
 @Directive({
   selector: '[scText]',

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -8,7 +8,6 @@ import {
 } from '@angular/core';
 import { TextField } from './rendering-field';
 import { BaseFieldDirective } from './base-field.directive';
-import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 import { DefaultEmptyFieldEditingComponent } from './default-empty-field-editing.component';
 
 @Directive({
@@ -39,18 +38,14 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
   }
 
   private updateView() {
-    const field = this.field;
-    let editable = this.editable;
-
-    if (!field?.editable && isFieldValueEmpty(this.field)) {
-      if (this.field?.metadata && this.editable) {
-        super.renderEmptyFieldEditingComponent(
-          this.emptyFieldEditingTemplate ?? DefaultEmptyFieldEditingComponent
-        );
-      }
-
+    if (!this.shouldRender()) {
+      console.log('should not render');
+      super.renderEmpty(DefaultEmptyFieldEditingComponent);
       return;
     }
+
+    const field = this.field;
+    let editable = this.editable;
 
     // can't use editable value if we want to output unencoded
     if (!this.encode) {

--- a/packages/sitecore-jss-angular/src/components/text.directive.ts
+++ b/packages/sitecore-jss-angular/src/components/text.directive.ts
@@ -21,8 +21,14 @@ export class TextDirective extends BaseFieldDirective implements OnChanges {
 
   @Input('scText') field: TextField;
 
+  /**
+   * Custom template to render in Pages in Metadata edit mode if field value is empty
+   */
   @Input('scTextEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
 
+  /**
+   * Default component to render in Pages in Metadata edit mode if field value is empty and emptyFieldEditingTemplate is not provided
+   */
   protected defaultFieldEditingComponent: Type<unknown>;
 
   constructor(viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {

--- a/packages/sitecore-jss-angular/src/test-data/test-base.directive.ts
+++ b/packages/sitecore-jss-angular/src/test-data/test-base.directive.ts
@@ -43,7 +43,7 @@ export class TestBaseDirective extends BaseFieldDirective implements OnChanges {
     }
 
     const field = this.field;
-    let editable = this.editable;
+    const editable = this.editable;
 
     const html = field.editable && editable ? field.editable : field.value;
 

--- a/packages/sitecore-jss-angular/src/test-data/test-base.directive.ts
+++ b/packages/sitecore-jss-angular/src/test-data/test-base.directive.ts
@@ -1,0 +1,54 @@
+import {
+  Directive,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  TemplateRef,
+  Type,
+  ViewContainerRef,
+} from '@angular/core';
+import { TextField } from '../components/rendering-field';
+import { BaseFieldDirective } from '../components/base-field.directive';
+import { DefaultEmptyFieldEditingComponent } from '../components/default-empty-text-field-editing-placeholder.component';
+
+@Directive({
+  selector: '[scTestBase]',
+})
+export class TestBaseDirective extends BaseFieldDirective implements OnChanges {
+  @Input('scTestBaseEditable') editable = true;
+  @Input('scTestBase') field: TextField;
+  @Input('scTestBaseEmptyFieldEditingTemplate') emptyFieldEditingTemplate: TemplateRef<unknown>;
+  protected defaultFieldEditingComponent: Type<unknown>;
+
+  constructor(viewContainer: ViewContainerRef, private templateRef: TemplateRef<unknown>) {
+    super(viewContainer);
+    this.defaultFieldEditingComponent = DefaultEmptyFieldEditingComponent;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.field || changes.editable || changes.encode) {
+      if (!this.viewRef) {
+        this.viewContainer.clear();
+        this.viewRef = this.viewContainer.createEmbeddedView(this.templateRef);
+      }
+
+      this.updateView();
+    }
+  }
+
+  private updateView() {
+    if (!this.shouldRender()) {
+      super.renderEmpty();
+      return;
+    }
+
+    const field = this.field;
+    let editable = this.editable;
+
+    const html = field.editable && editable ? field.editable : field.value;
+
+    this.viewRef.rootNodes.forEach((node) => {
+      node.textContent = html;
+    });
+  }
+}

--- a/packages/sitecore-jss/src/layout/models.ts
+++ b/packages/sitecore-jss/src/layout/models.ts
@@ -121,6 +121,7 @@ export type GenericFieldValue =
   | string
   | boolean
   | number
+  | Date
   | { [key: string]: unknown }
   | Array<{ [key: string]: unknown }>;
 

--- a/packages/sitecore-jss/src/layout/utils.test.ts
+++ b/packages/sitecore-jss/src/layout/utils.test.ts
@@ -197,6 +197,14 @@ describe('sitecore-jss layout utils', () => {
         const result = isFieldValueEmpty(field);
         expect(result).to.be.false;
       });
+
+      it('should return true if Date field is invalid for Date type', () => {
+        const field = {
+          value: new Date('invalid-date-string'),
+        };
+        const result = isFieldValueEmpty(field);
+        expect(result).to.be.true;
+      })
     });
 
     describe('boolean', () => {

--- a/packages/sitecore-jss/src/layout/utils.test.ts
+++ b/packages/sitecore-jss/src/layout/utils.test.ts
@@ -181,6 +181,22 @@ describe('sitecore-jss layout utils', () => {
         const result = isFieldValueEmpty(field);
         expect(result).to.be.false;
       });
+
+      it('should return true if Date field is empty for Date type', () => {
+        expect(
+          isFieldValueEmpty({
+            value: undefined,
+          })
+        ).to.be.true;
+      });
+
+      it('should return false if Date field is not empty for Date type', () => {
+        const field = {
+          value: new Date('2024-01-01T00:00:00Z'),
+        };
+        const result = isFieldValueEmpty(field);
+        expect(result).to.be.false;
+      });
     });
 
     describe('boolean', () => {

--- a/packages/sitecore-jss/src/layout/utils.test.ts
+++ b/packages/sitecore-jss/src/layout/utils.test.ts
@@ -204,7 +204,7 @@ describe('sitecore-jss layout utils', () => {
         };
         const result = isFieldValueEmpty(field);
         expect(result).to.be.true;
-      })
+      });
     });
 
     describe('boolean', () => {

--- a/packages/sitecore-jss/src/layout/utils.ts
+++ b/packages/sitecore-jss/src/layout/utils.ts
@@ -117,7 +117,7 @@ export function isFieldValueEmpty(field: GenericFieldValue | Partial<Field>): bo
     if (typeof fieldValue === 'string') {
       return fieldValue === EMPTY_DATE_FIELD_VALUE;
     } else {
-      return !(typeof (fieldValue as Date)?.getMonth === 'function');
+      return !(typeof (fieldValue as Date)?.getMonth === 'function' && !isNaN((fieldValue as Date)?.getMonth()));
     }
   };
 

--- a/packages/sitecore-jss/src/layout/utils.ts
+++ b/packages/sitecore-jss/src/layout/utils.ts
@@ -113,7 +113,13 @@ export function isFieldValueEmpty(field: GenericFieldValue | Partial<Field>): bo
     !(fieldValue as { [key: string]: unknown }).src;
   const isLinkFieldEmpty = (fieldValue: GenericFieldValue) =>
     !(fieldValue as { [key: string]: unknown }).href;
-  const isDateFieldEmpty = (fieldValue: GenericFieldValue) => fieldValue === EMPTY_DATE_FIELD_VALUE;
+  const isDateFieldEmpty = (fieldValue: GenericFieldValue) => {
+    if (typeof fieldValue === 'string') {
+      return fieldValue === EMPTY_DATE_FIELD_VALUE;
+    } else {
+      return !(typeof (fieldValue as Date)?.getMonth === 'function');
+    }
+  };
 
   const isEmpty = (fieldValue: GenericFieldValue) => {
     if (fieldValue === null || fieldValue === undefined) {
@@ -124,7 +130,8 @@ export function isFieldValueEmpty(field: GenericFieldValue | Partial<Field>): bo
       return (
         isImageFieldEmpty(fieldValue) &&
         isFileFieldEmpty(fieldValue) &&
-        isLinkFieldEmpty(fieldValue)
+        isLinkFieldEmpty(fieldValue) &&
+        isDateFieldEmpty(fieldValue)
       );
     } else if (typeof fieldValue === 'number' || typeof fieldValue === 'boolean') {
       // Avoid returning true for 0 and false values

--- a/packages/sitecore-jss/src/layout/utils.ts
+++ b/packages/sitecore-jss/src/layout/utils.ts
@@ -117,7 +117,10 @@ export function isFieldValueEmpty(field: GenericFieldValue | Partial<Field>): bo
     if (typeof fieldValue === 'string') {
       return fieldValue === EMPTY_DATE_FIELD_VALUE;
     } else {
-      return !(typeof (fieldValue as Date)?.getMonth === 'function' && !isNaN((fieldValue as Date)?.getMonth()));
+      return !(
+        typeof (fieldValue as Date)?.getMonth === 'function' &&
+        !isNaN((fieldValue as Date)?.getMonth())
+      );
     }
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR enhances the rendering of fields in editing mode for editMode metadata. When a field value is empty, a placeholder content should be rendered to signify that the field has no value. The placeholder should be interactable, so user can add value to the field. Additionally developers can provide their own custom empty field template via the field directive's emptyFieldEditingTemplate imput property, which will be rendered instead of the default one.
The fields with this functionality are:
- [sitecore-jss-angular] image.directive.ts
- [sitecore-jss-angular] date.directive.ts
- [sitecore-jss-angular] rich-text.directive.ts
- [sitecore-jss-angular] text.directive.ts
- [sitecore-jss-angular] link.directive.ts
- [sitecore-jss-angular] router-link.directive.ts
- [sitecore-jss-angular] generic-link.directive.spec.ts

The PR also includes update to the GenericFieldValue base package type to accept Date type; this change has been made in order to make the base type compatible with the field date type defined in the angular package


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
