### PR TITLE
[node-xmcloud-proxy] Set default PORT number to 3000

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
@@ -8,7 +8,7 @@ SITECORE_EDGE_CONTEXT_ID=
 # ========== XM Cloud Proxy ===========
 
 # Your XM Cloud Proxy hostname is needed to build the app and execute the client-side requests against the proxy server.
-PROXY_HOST=http://localhost:3001
+PROXY_HOST=http://localhost:3000
 
 # Your XM Cloud Proxy server path is needed to build the app. The build output will be copied to the proxy server path.
 PROXY_BUILD_PATH=<%- locals.relativeProxyAppDestination.replace(/\\/g, '\\\\') %>dist

--- a/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/.env
+++ b/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/.env
@@ -4,7 +4,7 @@
 # We recommend an alphanumeric value of at least 16 characters.
 JSS_EDITING_SECRET=
 
-# Your proxy port (default: 3001)
+# Your proxy port (default: 3000)
 PROXY_PORT=
 
 # Your proxy server bundle path

--- a/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/README.md
+++ b/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/README.md
@@ -33,4 +33,4 @@ The following environment variables can be set to configure the Proxy sample ins
 1. Run `npm run start`
 
 You should be able to see the following message:
-`server listening on port 3001!`.
+`server listening on port 3000!`.

--- a/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/src/config.ts
+++ b/packages/create-sitecore-jss/src/templates/node-xmcloud-proxy/src/config.ts
@@ -21,5 +21,5 @@ export const config: Config = {
   /**
    * Port which will be used when start the proxy
    */
-  port: process.env.PROXY_PORT || 3001,
+  port: process.env.PROXY_PORT || 3000,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated - Not needed, since it's a minor update
- [ ] Upgrade guide entry added

## Description / Motivation
Updated default PORT number to 3000, to be aligned with the rest of "node" based proxies.
It allows us to prevent an additional configuration in XM Cloud
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
