### PR TITLE
[template/angular] Prevent client-side dictionary API call when SSR data is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
+* `[template/angular]` Prevent client-side dictionary API call when SSR data is available ([#1930](https://github.com/Sitecore/jss/pull/1930))
 
 ### 🎉 New Features & Improvements
 

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -47,6 +47,44 @@
             }
         ```
 
+* Update jss-translation-client-loader service to get the performance improvement during fetching Dictionary Data Fetching for SSR
+    * In `/src/app/i18n/jss-translation-client-loader.service.ts`
+        * Add import for TranferState and of
+            ```
+                import { TransferState } from '@angular/core';
+                import { of } from 'rxjs';
+            ```
+        * Update `dictionaryStateKe`y` variable type
+            ```
+                export const dictionaryStateKey = makeStateKey<{ [key: string]: string }>('jssDictionary');
+            ```
+        * Add `tranferState` variable to constructor
+            ```
+                constructor(private fallbackLoader: TranslateLoader, private transferState: TransferState) {}
+            ```
+        * Update the `getTranslation` method
+            ```
+                getTranslation(lang: string) {
+                        const storedDictionary = this.transferState.get<{ [key: string]: string } | null>(
+                        dictionaryStateKey,
+                        null
+                        );
+
+                        if (storedDictionary !== null && Object.keys(storedDictionary).length > 0) {
+                        return of(storedDictionary);
+                        }
+
+                        ...
+                }
+            ```
+    * Update `/src/templates/angular/src/app/app.module.ts`
+         ```
+           ...
+            useFactory: (transferState: TransferState) =>
+                new JssTranslationClientLoaderService(new JssTranslationLoaderService(), transferState),
+            ...
+        ```
+
 # Angular - XMCloud
 
 If you plan to use the Angular SDK with XMCloud, you will need to perform next steps:

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -54,7 +54,7 @@
                 import { TransferState } from '@angular/core';
                 import { of } from 'rxjs';
             ```
-        * Update `dictionaryStateKe`y` variable type
+        * Update `dictionaryStateKey` variable type
             ```
                 export const dictionaryStateKey = makeStateKey<{ [key: string]: string }>('jssDictionary');
             ```

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -47,7 +47,7 @@
             }
         ```
 
-* Update jss-translation-client-loader service to get the performance improvement during fetching Dictionary Data Fetching for SSR
+* Update jss-translation-client-loader service to get the performance improvement during fetching Dictionary Data for SSR
     * In `/src/app/i18n/jss-translation-client-loader.service.ts`
         * Add import for TranferState and of
             ```
@@ -58,7 +58,7 @@
             ```
                 export const dictionaryStateKey = makeStateKey<{ [key: string]: string }>('jssDictionary');
             ```
-        * Add `tranferState` variable to constructor
+        * Add `transferState` variable to constructor
             ```
                 constructor(private fallbackLoader: TranslateLoader, private transferState: TransferState) {}
             ```
@@ -66,12 +66,12 @@
             ```
                 getTranslation(lang: string) {
                         const storedDictionary = this.transferState.get<{ [key: string]: string } | null>(
-                        dictionaryStateKey,
-                        null
+                            dictionaryStateKey,
+                            null
                         );
 
                         if (storedDictionary !== null && Object.keys(storedDictionary).length > 0) {
-                        return of(storedDictionary);
+                            return of(storedDictionary);
                         }
 
                         ...
@@ -79,7 +79,7 @@
             ```
     * Update `/src/templates/angular/src/app/app.module.ts`
          ```
-           ...
+            ...
             useFactory: (transferState: TransferState) =>
                 new JssTranslationClientLoaderService(new JssTranslationLoaderService(), transferState),
             ...

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/app.module.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/app.module.ts
@@ -20,7 +20,8 @@ import { JssContextService } from './jss-context.service';
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
-        useFactory: () => new JssTranslationClientLoaderService(new JssTranslationLoaderService()),
+        useFactory: (transferState: TransferState) =>
+          new JssTranslationClientLoaderService(new JssTranslationLoaderService(), transferState),
         deps: [HttpClient, TransferState],
       },
     }),

--- a/packages/create-sitecore-jss/src/templates/angular/src/app/i18n/jss-translation-client-loader.service.ts
+++ b/packages/create-sitecore-jss/src/templates/angular/src/app/i18n/jss-translation-client-loader.service.ts
@@ -1,16 +1,23 @@
-import { makeStateKey, Injectable } from '@angular/core';
+import { makeStateKey, Injectable, TransferState } from '@angular/core';
 import { TranslateLoader } from '@ngx-translate/core';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 
-export const dictionaryStateKey = makeStateKey('jssDictionary');
+export const dictionaryStateKey = makeStateKey<{ [key: string]: string }>('jssDictionary');
 
 @Injectable()
 export class JssTranslationClientLoaderService implements TranslateLoader {
-  constructor(
-    private fallbackLoader: TranslateLoader,
-  ) { }
+  constructor(private fallbackLoader: TranslateLoader, private transferState: TransferState) {}
 
   getTranslation(lang: string) {
+    const storedDictionary = this.transferState.get<{ [key: string]: string } | null>(
+      dictionaryStateKey,
+      null
+    );
+
+    if (storedDictionary !== null && Object.keys(storedDictionary).length > 0) {
+      return of(storedDictionary);
+    }
+
     if (!this.fallbackLoader) {
       return EMPTY;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
When SSR is executed, the data is pre-fetched and populated by Node.js server. However the DictionaryService API call is still executed in a browser on initial page load. We now transfer the pre-fetched SSR data to the client, preventing unnecessary client-side API calls and improving app's performance.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
