### PR TITLE
[create-sitecore-jss] Bug fix: Removes requirement for base initializer when adding appName to appNames array in case we are scaffolding a non base app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Our versioning strategy is as follows:
     * Rework Angular initializer to support XMCloud and SXP journeys;
     * Add SXA styles to xmcloud addon
 * `[create-sitecore-jss]` `[template/angular]` `[template/angular-xmcloud]` `[template/node-xmcloud-proxy]` Edge Proxy / Context Id support ([#1875](https://github.com/Sitecore/jss/pull/1875))([#1885](https://github.com/Sitecore/jss/pull/1885))
-* `[create-sitecore-jss]` Rework Angular initializer to support XMCloud and SXP journeys ([#1845](https://github.com/Sitecore/jss/pull/1845))([#1858](https://github.com/Sitecore/jss/pull/1858))([#1868](https://github.com/Sitecore/jss/pull/1868))([#1881](https://github.com/Sitecore/jss/pull/1881))([#1882](https://github.com/Sitecore/jss/pull/1882))
+* `[create-sitecore-jss]` Rework Angular initializer to support XMCloud and SXP journeys ([#1845](https://github.com/Sitecore/jss/pull/1845))([#1858](https://github.com/Sitecore/jss/pull/1858))([#1868](https://github.com/Sitecore/jss/pull/1868))([#1881](https://github.com/Sitecore/jss/pull/1881))([#1882](https://github.com/Sitecore/jss/pull/1882))([#1931](https://github.com/Sitecore/jss/pull/1931))
   * `[create-sitecore-jss]` Allow node-xmcloud-proxy app to be installed alongside Angular SPA application
   * `proxyAppDestination` arg can be passed into `create-sitecore-jss` command to define path for proxy to be installed in
 * `[templates/angular]` `[templates/angular-xmcloud]` `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/editing/config endpoint ([#1903](https://github.com/Sitecore/jss/pull/1903))

--- a/packages/create-sitecore-jss/src/init-runner.test.ts
+++ b/packages/create-sitecore-jss/src/init-runner.test.ts
@@ -168,6 +168,33 @@ describe('initRunner', () => {
     );
   });
 
+  it('should aggregate nextSteps when using non base, post-initializer template', async () => {
+    const templates = ['bar'];
+    const appName = 'test-app-bar';
+    const args = {
+      silent: false,
+      destination: 'samples/next',
+      templates,
+    };
+
+    const mockBar = mockInitializer(false, {
+      appName,
+      nextSteps: ['bar step 1', 'bar step 2'],
+      initializers: ['baz'],
+    });
+    const mockBaz = mockInitializer(false, { appName, nextSteps: ['baz step 1'] });
+    createStub = sinon.stub(InitializerFactory.prototype, 'create');
+    createStub.withArgs('bar').returns(mockBar);
+    createStub.withArgs('baz').returns(mockBaz);
+
+    await initRunner(templates, args);
+
+    expect(nextStepsStub).to.be.calledOnceWith(
+      [appName],
+      ['bar step 1', 'bar step 2', 'baz step 1']
+    );
+  });
+
   it('should pass two appNames when two main apps initialized', async () => {
     const templates = ['foo', 'bar'];
     const args = {

--- a/packages/create-sitecore-jss/src/init-runner.ts
+++ b/packages/create-sitecore-jss/src/init-runner.ts
@@ -27,9 +27,7 @@ export const initRunner = async (initializers: string[], args: BaseArgs) => {
       const response = await initializer.init(args);
 
       // We can have multiple appNames if base template requires to setup an additional standalone app (e.g. XM Cloud proxy)
-      if (initializer.isBase) {
-        appNames.add(response.appName);
-      }
+      appNames.add(response.appName);
       nextStepsArr = [...nextStepsArr, ...(response.nextSteps ?? [])];
       // process any returned initializers
       if (response.initializers && response.initializers.length > 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes requirement for base initializer when adding appName to appNames array in case we are scaffolding a non base app; fixes 'Should create nextjs app with Styleguide using post-initializer template only' development test

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
