### PR TITLE
 [sitecore-jss-nextjs]: Redirects with double and more parameters has been fixed for netlify #SXA-7554

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
 * `[template/angular]` Prevent client-side dictionary API call when SSR data is available ([#1930](https://github.com/Sitecore/jss/pull/1930)) ([#1932](https://github.com/Sitecore/jss/pull/1932))
-* `[sitecore-jss-nextjs]` Resolved an issue with Netlify where URL query parameters were being sorted, causing redirect failures. Added a method to generate all possible permutations of query parameters, ensuring proper matching with URL patterns regardless of their order. ([#1935](https://github.com/Sitecore/jss/pull/1935))
+* `[sitecore-jss-nextjs]` `[sitecore-jss]` Resolved an issue with Netlify where URL query parameters were being sorted, causing redirect failures. Added a method to generate all possible permutations of query parameters, ensuring proper matching with URL patterns regardless of their order. ([#1935](https://github.com/Sitecore/jss/pull/1935))
 
 ### 🎉 New Features & Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
 * `[template/angular]` Prevent client-side dictionary API call when SSR data is available ([#1930](https://github.com/Sitecore/jss/pull/1930)) ([#1932](https://github.com/Sitecore/jss/pull/1932))
+* `[sitecore-jss-nextjs]` Resolved an issue with Netlify where URL query parameters were being sorted, causing redirect failures. Added a method to generate all possible permutations of query parameters, ensuring proper matching with URL patterns regardless of their order. ([#1935](https://github.com/Sitecore/jss/pull/1935))
 
 ### 🎉 New Features & Improvements
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -8,6 +8,7 @@ import {
   RedirectInfo,
   SiteInfo,
 } from '@sitecore-jss/sitecore-jss/site';
+import { getPermutations } from '@sitecore-jss/sitecore-jss/utils';
 import { NextRequest, NextResponse } from 'next/server';
 import regexParser from 'regex-parser';
 import { MiddlewareBase, MiddlewareBaseConfig } from './middleware';
@@ -193,21 +194,53 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
     return modifyRedirects.length
       ? modifyRedirects.find((redirect: RedirectInfo & { matchedQueryString?: string }) => {
+          // Modify the redirect pattern to ignore the language prefix in the path
           redirect.pattern = redirect.pattern.replace(RegExp(`^[^]?/${language}/`, 'gi'), '');
+
+          // Prepare the redirect pattern as a regular expression, making it more flexible for matching URLs
           redirect.pattern = `/^\/${redirect.pattern
-            .replace(/^\/|\/$/g, '')
-            .replace(/^\^\/|\/\$$/g, '')
-            .replace(/^\^|\$$/g, '')
-            .replace(/(?<!\\)\?/g, '\\?')
-            .replace(/\$\/gi$/g, '')}[\/]?$/i`;
+            .replace(/^\/|\/$/g, '') // Removes leading and trailing slashes
+            .replace(/^\^\/|\/\$$/g, '') // Removes unnecessary start (^) and end ($) anchors
+            .replace(/^\^|\$$/g, '') // Further cleans up anchors
+            .replace(/(?<!\\)\?/g, '\\?') // Escapes question marks in the pattern
+            .replace(/\$\/gi$/g, '')}[\/]?$/i`; // Ensures the pattern allows an optional trailing slash
+
+          /**
+           * This line checks whether the current URL query string (and all its possible permutations)
+           * matches the redirect pattern.
+           *
+           * Query parameters in URLs can come in different orders, but logically they represent the
+           * same information (e.g., "key1=value1&key2=value2" is the same as "key2=value2&key1=value1").
+           * To account for this, the method `isPermutedQueryMatch` generates all possible permutations
+           * of the query parameters and checks if any of those permutations match the regex pattern for the redirect.
+           *
+           * NOTE: This fix is specifically implemented for Netlify, where query parameters are sometimes
+           * automatically sorted, which can cause issues with matching redirects if the order of query
+           * parameters is important. By checking every possible permutation, we ensure that redirects
+           * work correctly on Netlify despite this behavior.
+           *
+           * It passes several pieces of information to the function:
+           * 1. `pathname`: The normalized URL path without query parameters (e.g., '/about').
+           * 2. `queryString`: The current query string from the URL, which will be permuted and matched (e.g., '?key1=value1&key2=value2').
+           * 3. `pattern`: The regex pattern for the redirect that we are trying to match against the URL (e.g., '/about?key1=value1').
+           * 4. `locale`: The locale part of the URL (if any), which helps support multilingual URLs.
+           *
+           * If one of the permutations of the query string matches the redirect pattern, the function
+           * returns the matched query string, which is stored in `matchedQueryString`. If no match is found,
+           * it returns `undefined`. The `matchedQueryString` is later used to indicate whether the query
+           * string contributed to a successful redirect match.
+           */
           const matchedQueryString = this.isPermutedQueryMatch({
             pathname: tragetURL,
             queryString: targetQS,
             pattern: redirect.pattern,
             locale: req.nextUrl.locale,
           });
+
+          // Save the matched query string (if found) into the redirect object
           redirect.matchedQueryString = matchedQueryString || '';
 
+          // Return the redirect if the URL path or any query string permutation matches the pattern
           return (
             (regexParser(redirect.pattern).test(tragetURL) ||
               regexParser(redirect.pattern).test(`/${req.nextUrl.locale}${tragetURL}`) ||
@@ -291,21 +324,6 @@ export class RedirectsMiddleware extends MiddlewareBase {
   }
 
   /**
-   * Generates all possible permutations of an array of key-value pairs.
-   * This is used to create every possible combination of URL query parameters.
-   * @param {Array<[string, string]>} array - The array of key-value pairs to permute.
-   * @returns {Array<Array<[string, string]>>} - A 2D array where each inner array is a unique permutation of the input.
-   */
-  private getPermutations(array: [string, string][]): [string, string][][] {
-    if (array.length <= 1) return [array];
-
-    return array.flatMap((current, i) => {
-      const remaining = array.filter((_, idx) => idx !== i);
-      return this.getPermutations(remaining).map((permutation) => [current, ...permutation]);
-    });
-  }
-
-  /**
    * Checks if the current URL query matches the provided pattern, considering all permutations of query parameters.
    * It constructs all possible query parameter permutations and tests them against the pattern.
    * @param {Object} params - The parameters for the URL match.
@@ -327,12 +345,13 @@ export class RedirectsMiddleware extends MiddlewareBase {
     locale?: string;
   }): string | undefined {
     const paramsArray = Array.from(new URLSearchParams(queryString).entries());
-    const listOfPermuted = this.getPermutations(paramsArray).map(
-      (permutation) => '?' + permutation.map(([key, value]) => `${key}=${value}`).join('&')
+    const listOfPermuted = getPermutations(paramsArray).map(
+      (permutation: [string, string][]) =>
+        '?' + permutation.map(([key, value]) => `${key}=${value}`).join('&')
     );
 
     const normalizedPath = pathname.replace(/\/*$/gi, '');
-    return listOfPermuted.find((query) =>
+    return listOfPermuted.find((query: string) =>
       [
         regexParser(pattern).test(`${normalizedPath}${query}`),
         regexParser(pattern).test(`/${locale}${normalizedPath}${query}`),

--- a/packages/sitecore-jss/src/utils/index.ts
+++ b/packages/sitecore-jss/src/utils/index.ts
@@ -4,6 +4,7 @@ export {
   isAbsoluteUrl,
   isTimeoutError,
   enforceCors,
+  getPermutations,
   EnhancedOmit,
   getAllowedOriginsFromEnv,
 } from './utils';

--- a/packages/sitecore-jss/src/utils/utils.test.ts
+++ b/packages/sitecore-jss/src/utils/utils.test.ts
@@ -1,8 +1,14 @@
 /* eslint-disable no-unused-expressions */
 import { expect, spy } from 'chai';
-import { isServer, resolveUrl } from '.';
-import { enforceCors, getAllowedOriginsFromEnv, isAbsoluteUrl, isTimeoutError } from './utils';
 import { IncomingMessage, OutgoingMessage } from 'http';
+import { isServer, resolveUrl } from '.';
+import {
+  enforceCors,
+  getAllowedOriginsFromEnv,
+  getPermutations,
+  isAbsoluteUrl,
+  isTimeoutError,
+} from './utils';
 
 // must make TypeScript happy with `global` variable modification
 interface CustomWindow {
@@ -201,6 +207,38 @@ describe('utils', () => {
         'https://alsoallowed.com',
       ]);
       delete process.env.JSS_ALLOWED_ORIGINS;
+    });
+  });
+
+  describe('getPermutations', () => {
+    it('should return all permutations of an array with one pair', () => {
+      const input: [string, string][] = [['key1', 'value1']];
+      const expectedOutput = [[['key1', 'value1']]];
+      expect(getPermutations(input)).to.deep.equal(expectedOutput);
+    });
+
+    it('should return all permutations of an array with two pairs', () => {
+      const input: [string, string][] = [
+        ['key1', 'value1'],
+        ['key2', 'value2'],
+      ];
+      const expectedOutput = [
+        [
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ],
+        [
+          ['key2', 'value2'],
+          ['key1', 'value1'],
+        ],
+      ];
+      expect(getPermutations(input)).to.deep.equal(expectedOutput);
+    });
+
+    it('should return an empty array when input is empty', () => {
+      const input: [string, string][] = [];
+      const expectedOutput = [[]];
+      expect(getPermutations(input)).to.deep.equal(expectedOutput);
     });
   });
 });

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -153,3 +153,18 @@ export const enforceCors = (
   }
   return false;
 };
+
+  /**
+   * Generates all possible permutations of an array of key-value pairs.
+   * This is used to create every possible combination of URL query parameters.
+   * @param {Array<[string, string]>} array - The array of key-value pairs to permute.
+   * @returns {Array<Array<[string, string]>>} - A 2D array where each inner array is a unique permutation of the input.
+   */
+ export const getPermutations = (array: [string, string][]): [string, string][][] =>{
+  if (array.length <= 1) return [array];
+
+  return array.flatMap((current, i) => {
+    const remaining = array.filter((_, idx) => idx !== i);
+    return getPermutations(remaining).map((permutation) => [current, ...permutation]);
+  });
+};

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -1,8 +1,8 @@
-import isServer from './is-server';
-import { ParsedUrlQueryInput } from 'querystring';
 import { AxiosError } from 'axios';
-import { ResponseError } from '../data-fetcher';
 import { IncomingMessage, OutgoingMessage } from 'http';
+import { ParsedUrlQueryInput } from 'querystring';
+import { ResponseError } from '../data-fetcher';
+import isServer from './is-server';
 
 /**
  * Omit properties from T that are in K. This is a simplified version of TypeScript's built-in `Omit` utility type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
This PR includes a fix for an issue with Netlify, where URL parameters are being sorted by alphabet.
This causes redirects with two or more query parameters to not match the expected patterns. 
To resolve this, a new method has been added that generates all possible permutations of the query parameters based on their arrangement. This ensures that the redirect logic can correctly handle unordered query strings, allowing for proper matching with URL patterns, regardless of how parameters are ordered in the incoming requests.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
