### PR TITLE
[sitecore-jss-angular] Fix default empty image styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))
 * `[template/angular]` Prevent client-side dictionary API call when SSR data is available ([#1930](https://github.com/Sitecore/jss/pull/1930)) ([#1932](https://github.com/Sitecore/jss/pull/1932))
-* `[sitecore-jss-angular]` Fix default empty field components to not render the unwanted wrapping tags ([#1937](https://github.com/Sitecore/jss/pull/1937))
+* `[sitecore-jss-angular]` Fix default empty field components to not render the unwanted wrapping tags ([#1937](https://github.com/Sitecore/jss/pull/1937)) ([#1940](https://github.com/Sitecore/jss/pull/1940))
 
 ### 🎉 New Features & Improvements
 

--- a/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
+++ b/packages/sitecore-jss-angular/src/components/default-empty-image-field-editing-placeholder.component.ts
@@ -12,7 +12,16 @@ import { Component } from '@angular/core';
       class="scEmptyImage"
     />
   `,
-  styles:
-    'img { min-width:48px; min-height:48px; max-width:400px; max-height:400px; cursor:pointer }',
+  styles: [
+    `
+      :host {
+        min-width: 48px;
+        min-height: 48px;
+        max-width: 400px;
+        max-height: 400px;
+        cursor: pointer;
+      }
+    `,
+  ],
 })
 export class DefaultEmptyImageFieldEditingComponent {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes the issue when Image component is selected Edit frame is expanded to all the area

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
