### PR TITLE
[sitecore-jss-angular] Fix Editing Scripts component rendered twice in pages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Our versioning strategy is as follows:
    - `scRichTextEmptyFieldEditingTemplate` for _scRichText_
    - `scRouterLinkEmptyFieldEditingTemplate` for _scRouterLink_
    - `scTextEmptyFieldEditingTemplate` for _scText_
-* `[sitecore-jss-angular]` `[templates/angular-xmcloud]` Render clientScripts / clientData. The new `sc-editing-scripts` component is exposed from `sitecore-jss-angular` package and required to be rendered on the page to enable Metadata Edit mode. ([#1924](https://github.com/Sitecore/jss/pull/1924))
+* `[sitecore-jss-angular]` `[templates/angular-xmcloud]` Render clientScripts / clientData. The new `sc-editing-scripts` component is exposed from `sitecore-jss-angular` package and required to be rendered on the page to enable Metadata Edit mode. ([#1924](https://github.com/Sitecore/jss/pull/1924))([#1948](https://github.com/Sitecore/jss/pull/1948))
 * `[sitecore-jss]` GenericFieldValue model is updated to accept Date type ([#1916](https://github.com/Sitecore/jss/pull/1916))
 * `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/healthz endpoint ([#1928](https://github.com/Sitecore/jss/pull/1928))
 * `[sitecore-jss]` `[sitecore-jss-angular]` Render field metdata chromes in editMode metadata - in edit mode metadata in Pages, angular package field directives will render wrapping `code` elements with field metadata required for editing; ([#1926](https://github.com/Sitecore/jss/pull/1926))

--- a/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
@@ -6,6 +6,7 @@ import { PAGES_EDITING_MARKER } from '@sitecore-jss/sitecore-jss/editing';
 import { inject } from '@angular/core/testing';
 import { JssStateService } from '../services/jss-state.service';
 import { EditingScriptsComponent } from './editing-scripts.component';
+import * as utils from '@sitecore-jss/sitecore-jss/utils';
 
 @Component({
   selector: 'test-component',
@@ -61,6 +62,8 @@ describe('<EditingScripts />', () => {
         },
       });
 
+      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
+
       fixture.detectChanges();
 
       expect(_document.body.querySelector(`#${PAGES_EDITING_MARKER}`)).toBeNull();
@@ -93,6 +96,42 @@ describe('<EditingScripts />', () => {
         },
       });
 
+      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
+
+      fixture.detectChanges();
+
+      expect(_document.body.querySelector(`#${PAGES_EDITING_MARKER}`)).toBeNull();
+      expect(_document.body.querySelector('#hrz-canvas-state')).toBeNull();
+      expect(_document.body.querySelector('#hrz-canvas-verification-token')).toBeNull();
+      expect(
+        _document.body.querySelector(
+          'script[src="https://test.com/packages/page-extension/latest/page.js"]'
+        )
+      ).toBeNull();
+      expect(
+        _document.body.querySelector(
+          'script[src="https://test.com/horizon/canvas/horizon.canvas.js"]'
+        )
+      ).toBeNull();
+    }
+  ));
+
+  it('should not add editing scripts and client data when edit mode is Metadata and not serverside rendering', inject(
+    [JssStateService, DOCUMENT],
+    (stateService: JssStateService, _document: Document) => {
+      stateService.setState({
+        sitecore: {
+          context: {
+            editMode: EditMode.Metadata,
+            pageState: LayoutServicePageState.Edit,
+            ...sharedData,
+          },
+          route: null,
+        },
+      });
+
+      spyOnProperty(utils, 'isServer').and.returnValue(() => false);
+
       fixture.detectChanges();
 
       expect(_document.body.querySelector(`#${PAGES_EDITING_MARKER}`)).toBeNull();
@@ -124,6 +163,8 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
+
+      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 
@@ -160,6 +201,8 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
+
+      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 

--- a/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
@@ -116,7 +116,7 @@ describe('<EditingScripts />', () => {
     }
   ));
 
-  it('should not add editing scripts and client data when edit mode is Metadata and not serverside rendering', inject(
+  it('should not add editing scripts and client data when edit mode is Metadata and rendering is not server side', inject(
     [JssStateService, DOCUMENT],
     (stateService: JssStateService, _document: Document) => {
       stateService.setState({

--- a/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
+++ b/packages/sitecore-jss-angular/src/components/editing-scripts.component.spec.ts
@@ -36,6 +36,14 @@ describe('<EditingScripts />', () => {
     },
   };
 
+  beforeAll(() => {
+    jasmine.getEnv().allowRespy(true);
+  });
+
+  afterAll(() => {
+    jasmine.getEnv().allowRespy(false);
+  });
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, EditingScriptsComponent],
@@ -45,6 +53,7 @@ describe('<EditingScripts />', () => {
         { provide: DOCUMENT, useValue: document.implementation.createHTMLDocument() },
       ],
     }).compileComponents();
+    spyOnProperty(utils, 'isServer').and.returnValue(() => true);
     fixture = TestBed.createComponent(TestComponent);
   });
 
@@ -61,8 +70,6 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
-
-      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 
@@ -95,8 +102,6 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
-
-      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 
@@ -133,6 +138,8 @@ describe('<EditingScripts />', () => {
       spyOnProperty(utils, 'isServer').and.returnValue(() => false);
 
       fixture.detectChanges();
+      // reset spy state
+      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       expect(_document.body.querySelector(`#${PAGES_EDITING_MARKER}`)).toBeNull();
       expect(_document.body.querySelector('#hrz-canvas-state')).toBeNull();
@@ -163,8 +170,6 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
-
-      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 
@@ -201,8 +206,6 @@ describe('<EditingScripts />', () => {
           route: null,
         },
       });
-
-      spyOnProperty(utils, 'isServer').and.returnValue(() => true);
 
       fixture.detectChanges();
 

--- a/packages/sitecore-jss-angular/src/components/editing-scripts.component.ts
+++ b/packages/sitecore-jss-angular/src/components/editing-scripts.component.ts
@@ -3,6 +3,7 @@ import { getJssPagesClientData } from '@sitecore-jss/sitecore-jss/editing';
 import { JssStateService } from '../services/jss-state.service';
 import { DOCUMENT } from '@angular/common';
 import { EditMode, LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
+import { isServer } from '@sitecore-jss/sitecore-jss/utils';
 
 /**
  * Component that renders editing scripts and client data for the current page in Sitecore Editor.
@@ -23,10 +24,11 @@ export class EditingScriptsComponent implements OnInit {
     const state = this.stateService.stateValue;
     const { pageState, editMode, clientData, clientScripts } = state.sitecore?.context || {};
 
-    // Don't render anything if not in editing mode
+    // Don't render anything if not in editing mode or not server side
     if (
       pageState === LayoutServicePageState.Normal ||
-      pageState === LayoutServicePageState.Preview
+      pageState === LayoutServicePageState.Preview ||
+      !isServer()
     ) {
       return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes issue where editing scripts are rendered twice (for server and client) in pages edit mode metadata - by rendering the scripts only on the server.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - setup local app as rendering host for pages, and make sure client editing scripts are rendered only once in the markup and there is no 'duplicate modules' error in the browser console

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
