### PR TITLE
[angular][xmcloud] Init CloudSDK on browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Our versioning strategy is as follows:
 * `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/healthz endpoint ([#1928](https://github.com/Sitecore/jss/pull/1928))
 * `[sitecore-jss]` `[sitecore-jss-angular]` Render field metdata chromes in editMode metadata - in edit mode metadata in Pages, angular package field directives will render wrapping `code` elements with field metadata required for editing; ([#1926](https://github.com/Sitecore/jss/pull/1926))
 * `[sitecore-jss-nextjs]` Expose MiddlewareBase class and MiddlewareBaseConfig type ([#1941](https://github.com/Sitecore/jss/pull/1941))
+* `[angular-xmcloud]``[sitecore-jss-angular]` Analytics and CloudSDK integration
+  * `[angular-xmcloud]` Add CloudSDK initialization on client side ([#1952](https://github.com/Sitecore/jss/pull/1952))
 
 ### 🛠 Breaking Change
 

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/package.json
@@ -8,6 +8,8 @@
     "prepare:proxy-build": "ts-node --project src/tsconfig.webpack-server.json ./scripts/proxy-build.ts"
   },
   "dependencies": {
+    "@sitecore-cloudsdk/core": "^0.4.0-rc.0",
+    "@sitecore-cloudsdk/events": "^0.4.0-rc.0",
     "font-awesome": "^4.7.0",
     "sass": "^1.52.3",
     "sass-alias": "^1.0.5"

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
+import { environment } from '../../../environments/environment';
+import { isServer } from '@sitecore-jss/sitecore-jss/utils';
+
+/**
+ * Component that renders editing scripts and client data for the current page in Sitecore Editor.
+ * Only renders scripts when Metadata mode is used.
+ */
+@Component({
+  selector: 'app-cloudsdk-init',
+  template: '',
+})
+export class CloudSdkInitComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {
+    if (!isServer) {
+      CloudSDK({
+        siteName: environment.sitecoreSiteName,
+        sitecoreEdgeUrl: environment.sitecoreEdgeUrl,
+        sitecoreEdgeContextId: environment.sitecoreEdgeContextId,
+        // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
+        cookieDomain: window.location.hostname.replace(/^www\./, ''),
+        // Cookie may be created in personalize middleware (server), but if not we should create it here
+        enableBrowserCookie: true,
+      }).initialize();
+    }
+  }
+}

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
+import '@sitecore-cloudsdk/events/browser';
 import { environment } from '../../../environments/environment';
-import { isServer } from '@sitecore-jss/sitecore-jss/utils';
+import { isServer } from '@sitecore-jss/sitecore-jss-angular';
 
 /**
  * Component to init CloudSDK logic - to allow events throughout the site
@@ -23,7 +24,9 @@ export class CloudSdkInitComponent implements OnInit {
         cookieDomain: window.location.hostname.replace(/^www\./, ''),
         // Cookie may be created in personalize middleware (server), but if not we should create it here
         enableBrowserCookie: true,
-      }).initialize();
+      })
+      .addEvents()
+      .initialize();
     }
   }
 }

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
@@ -4,11 +4,10 @@ import { environment } from '../../../environments/environment';
 import { isServer } from '@sitecore-jss/sitecore-jss/utils';
 
 /**
- * Component that renders editing scripts and client data for the current page in Sitecore Editor.
- * Only renders scripts when Metadata mode is used.
+ * Component to init CloudSDK logic - to allow events throughout the site
  */
 @Component({
-  selector: 'app-cloudsdk-init',
+  selector: 'app-cloud-sdk-init',
   template: '',
 })
 export class CloudSdkInitComponent implements OnInit {

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.component.html
@@ -1,4 +1,4 @@
 <ng-container>
   <sc-editing-scripts></sc-editing-scripts>
-  <app-cloudsdk-init></app-cloudsdk-init>
+  <app-cloud-sdk-init></app-cloud-sdk-init>
 </ng-container>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.component.html
@@ -1,3 +1,4 @@
 <ng-container>
   <sc-editing-scripts></sc-editing-scripts>
+  <app-cloudsdk-init></app-cloudsdk-init>
 </ng-container>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.module.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/scripts.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { ScriptsComponent } from './scripts.component';
 import { JssModule } from '@sitecore-jss/sitecore-jss-angular';
+import { CloudSdkInitComponent } from './cloud-sdk-init.component';
 
 @NgModule({
   exports: [ScriptsComponent],
   imports: [JssModule],
-  declarations: [ScriptsComponent],
+  declarations: [ScriptsComponent, CloudSdkInitComponent],
 })
 export class ScriptsModule {}

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@sitecore/components": "^1.1.10",
-    "@sitecore-cloudsdk/core": "^0.3.1",
+    "@sitecore-cloudsdk/events": "^0.3.1",
     "@sitecore-feaas/clientside": "^0.5.17"
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
     "@sitecore/components": "^1.1.10",
-    "@sitecore-cloudsdk/core": "^0.4.0-rc.0",
-    "@sitecore-cloudsdk/events": "^0.4.0-rc.0",
+    "@sitecore-cloudsdk/core": "^0.3.1",
     "@sitecore-feaas/clientside": "^0.5.17"
   }
 }

--- a/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
+++ b/packages/create-sitecore-jss/src/templates/nextjs-xmcloud/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
     "@sitecore/components": "^1.1.10",
-    "@sitecore-cloudsdk/events": "^0.3.1",
+    "@sitecore-cloudsdk/core": "^0.4.0-rc.0",
+    "@sitecore-cloudsdk/events": "^0.4.0-rc.0",
     "@sitecore-feaas/clientside": "^0.5.17"
   }
 }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Initializes CloudSDK on browser for Angular app
- Allows for other parts of app to use events etc

Note: adding events init TBD

## Testing Details
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
