### PR TITLE
[XM Cloud][Angular] Navigation component link forces full page reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[templates/angular-xmcloud]` Navigation component link forces full page reload ([#1958](https://github.com/Sitecore/jss/pull/1958))
 * `[sitecore-jss-nextjs]` Link component prefetches files ([#1956](https://github.com/Sitecore/jss/pull/1956))
 * `[templates/nextjs]` `[templates/react]` `[templates/angular]` `[templates/vue]` Fixed an issue when environment variable is undefined (not present in .env), that produced an "undefined" value in generated config file ([#1875](https://github.com/Sitecore/jss/pull/1875))
 * `[templates/nextjs]` Fix embedded personalization not rendering correctly after navigation through router links. ([#1911](https://github.com/Sitecore/jss/pull/1911))

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/image/image.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/image/image.component.html
@@ -22,7 +22,7 @@
 </ng-template>
 
 <ng-template #withLink>
-  <a *scLink="rendering.fields.TargetUrl">
+  <a *scGenericLink="rendering.fields.TargetUrl">
     <img *scImage="rendering.fields.Image" />
   </a>
 </ng-template>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/link-list/link-list.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/link-list/link-list.component.html
@@ -5,7 +5,7 @@
   <ul>
     <li *ngFor="let fieldLink of fieldLinks; index as i" [ngClass]="getFieldLinkClass(i)">
       <div class="field-link">
-        <a *scLink="fieldLink"></a>
+        <a *scGenericLink="fieldLink"></a>
       </div>
     </li>
   </ul>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.html
@@ -1,6 +1,6 @@
 <li [class]="cssClasses" [ngClass]="{ active: isActive }" tabIndex="0">
   <div [ngClass]="{ 'navigation-title': true, child: hasChildren }" (click)="isActive = !isActive">
-    <a *scLink="linkField" (click)="onClick($event)">
+    <a *scRouterLink="linkField" (click)="onClick($event)">
       <ng-container *ngIf="navItemFields.NavigationTitle"
         ><span *scText="navItemFields.NavigationTitle"></span
       ></ng-container>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/promo/promo.component.html
@@ -10,7 +10,7 @@
         </div>
       </div>
       <div class="field-promolink">
-        <a *scLink="rendering.fields.PromoLink"></a>
+        <a *scGenericLink="rendering.fields.PromoLink"></a>
       </div>
     </div>
   </ng-container>

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/title/title.component.html
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/title/title.component.html
@@ -1,7 +1,7 @@
 <div clas="component-content">
   <div class="field-title">
     <ng-container *ngIf="!pageEditing; else textOnly">
-      <a *scLink="link"></a>
+      <a *scGenericLink="link"></a>
     </ng-container>
   </div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
In order to perform the client side routing without the full page refresh we need to use "scRouterLink" in Navigation component instead of regular "scLink"
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
