### PR TITLE
[angular][xmcloud] Do not initialize CloudSDK if we are in edit or preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Our versioning strategy is as follows:
 * `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/healthz endpoint ([#1928](https://github.com/Sitecore/jss/pull/1928))
 * `[sitecore-jss]` `[sitecore-jss-angular]` Render field metdata chromes in editMode metadata - in edit mode metadata in Pages, angular package field directives will render wrapping `code` elements with field metadata required for editing; ([#1926](https://github.com/Sitecore/jss/pull/1926))
 * `[angular-xmcloud]``[sitecore-jss-angular]` Analytics and CloudSDK integration
-  * `[angular-xmcloud]` Add CloudSDK initialization on client side ([#1952](https://github.com/Sitecore/jss/pull/1952))([#1957](https://github.com/Sitecore/jss/pull/1957))
+  * `[angular-xmcloud]` Add CloudSDK initialization on client side ([#1952](https://github.com/Sitecore/jss/pull/1952))([#1957](https://github.com/Sitecore/jss/pull/1957))([#1961](https://github.com/Sitecore/jss/pull/1961))
   * `[angular-xmcloud]``[sitecore-jss-angular]` Add CDP Page View component to Angular XM Cloud add-on ([#1957](https://github.com/Sitecore/jss/pull/1957))
 
 

--- a/docs/upgrades/unreleased.md
+++ b/docs/upgrades/unreleased.md
@@ -295,6 +295,7 @@ If you plan to use the Angular SDK with XMCloud, you will need to perform next s
 
 * In XMCloud client side event tracking is done via CloudSDK so you need to make sure that it is initialized before send any event. See the following example of a component that does that; note that it should be added to the scripts.component.html before any other scripts that uses it; for more details take a look at the OOTB cloud-sdk-init.component.ts: 
     ```ts
+        import { take } from 'rxjs/operators';
         import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
         import '@sitecore-cloudsdk/events/browser';
         import { environment } from '../../../environments/environment';
@@ -304,26 +305,27 @@ If you plan to use the Angular SDK with XMCloud, you will need to perform next s
         ...
         ngOnInit(): void {
             if (!isServer() && environment.production) {
-                this.contextSubscription = this.jssContext.state.subscribe((newState: JssState) => {
-                    const {
-                        route,
-                        context: { pageState },
-                    } = newState.sitecore;
+                // to ensure that CloudSDK initialization logic runs only once in the browser, take only the first emitted value of state
+                this.jssContext.state.pipe(take(1)).subscribe((newState: JssState) => {
+                const {
+                    route,
+                    context: { pageState },
+                } = newState.sitecore;
 
-                    // Do not initialize CloudSDK in editing or preview mode or if missing route data
-                    if (pageState !== LayoutServicePageState.Normal || !route?.itemId) {
-                        return;
-                    }
+                // Do not initialize CloudSDK in editing or preview mode or if missing route data
+                if (pageState !== LayoutServicePageState.Normal || !route?.itemId) {
+                    return;
+                }
 
-                    CloudSDK({
-                        siteName: environment.sitecoreSiteName,
-                        sitecoreEdgeUrl: environment.sitecoreEdgeUrl,
-                        sitecoreEdgeContextId: environment.sitecoreEdgeContextId,
-                        cookieDomain: window.location.hostname.replace(/^www\./, ''),
-                        enableBrowserCookie: true,
-                    })
-                    .addEvents()
-                    .initialize();
+                CloudSDK({
+                    siteName: environment.sitecoreSiteName,
+                    sitecoreEdgeUrl: environment.sitecoreEdgeUrl,
+                    sitecoreEdgeContextId: environment.sitecoreEdgeContextId,
+                    cookieDomain: window.location.hostname.replace(/^www\./, ''),
+                    enableBrowserCookie: true,
+                })
+                .addEvents()
+                .initialize();
                 });
             }
         }

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
@@ -1,8 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
 import '@sitecore-cloudsdk/events/browser';
+import { isServer, LayoutServicePageState } from '@sitecore-jss/sitecore-jss-angular';
 import { environment } from '../../../environments/environment';
-import { isServer } from '@sitecore-jss/sitecore-jss-angular';
+import { JssContextService } from '../../jss-context.service';
+import { JssState } from '../../JssState';
 
 /**
  * Component to init CloudSDK logic - to allow events throughout the site
@@ -11,22 +14,42 @@ import { isServer } from '@sitecore-jss/sitecore-jss-angular';
   selector: 'app-cloud-sdk-init',
   template: '',
 })
-export class CloudSdkInitComponent implements OnInit {
-  constructor() {}
+export class CloudSdkInitComponent implements OnInit, OnDestroy {
+  private contextSubscription: Subscription;
+
+  constructor(private jssContext: JssContextService) {}
 
   ngOnInit(): void {
     if (!isServer() && environment.production) {
-      CloudSDK({
-        siteName: environment.sitecoreSiteName,
-        sitecoreEdgeUrl: environment.sitecoreEdgeUrl,
-        sitecoreEdgeContextId: environment.sitecoreEdgeContextId,
-        // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
-        cookieDomain: window.location.hostname.replace(/^www\./, ''),
-        // Cookie may be created in personalize middleware (server), but if not we should create it here
-        enableBrowserCookie: true,
-      })
-        .addEvents()
-        .initialize();
+      this.contextSubscription = this.jssContext.state.subscribe((newState: JssState) => {
+        const {
+          route,
+          context: { pageState },
+        } = newState.sitecore;
+
+        // Do not initialize CloudSDK in editing or preview mode or if missing route data
+        if (pageState !== LayoutServicePageState.Normal || !route?.itemId) {
+          return;
+        }
+
+        CloudSDK({
+          siteName: environment.sitecoreSiteName,
+          sitecoreEdgeUrl: environment.sitecoreEdgeUrl,
+          sitecoreEdgeContextId: environment.sitecoreEdgeContextId,
+          // Replace with the top level cookie domain of the website that is being integrated e.g ".example.com" and not "www.example.com"
+          cookieDomain: window.location.hostname.replace(/^www\./, ''),
+          // Cookie may be created in personalize middleware (server), but if not we should create it here
+          enableBrowserCookie: true,
+        })
+          .addEvents()
+          .initialize();
+      });
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.contextSubscription) {
+      this.contextSubscription.unsubscribe();
     }
   }
 }

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/routing/scripts/cloud-sdk-init.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component, OnInit } from '@angular/core';
+import { take } from 'rxjs/operators';
 import { CloudSDK } from '@sitecore-cloudsdk/core/browser';
 import '@sitecore-cloudsdk/events/browser';
 import { isServer, LayoutServicePageState } from '@sitecore-jss/sitecore-jss-angular';
@@ -14,14 +14,13 @@ import { JssState } from '../../JssState';
   selector: 'app-cloud-sdk-init',
   template: '',
 })
-export class CloudSdkInitComponent implements OnInit, OnDestroy {
-  private contextSubscription: Subscription;
-
+export class CloudSdkInitComponent implements OnInit {
   constructor(private jssContext: JssContextService) {}
 
   ngOnInit(): void {
     if (!isServer() && environment.production) {
-      this.contextSubscription = this.jssContext.state.subscribe((newState: JssState) => {
+      // to ensure that CloudSDK initialization logic runs only once in the browser, take only the first emitted value of state
+      this.jssContext.state.pipe(take(1)).subscribe((newState: JssState) => {
         const {
           route,
           context: { pageState },
@@ -44,12 +43,6 @@ export class CloudSdkInitComponent implements OnInit, OnDestroy {
           .addEvents()
           .initialize();
       });
-    }
-  }
-
-  ngOnDestroy() {
-    if (this.contextSubscription) {
-      this.contextSubscription.unsubscribe();
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR modifies cloudsk init component to not initialize CloudSDK in the browser if we are in edit or preview mode or route data is missing.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
