### PR TITLE
[sitecore-jss-proxy] Ensure page variants can be switched in Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Our versioning strategy is as follows:
   * `proxyAppDestination` arg can be passed into `create-sitecore-jss` command to define path for proxy to be installed in
 * `[templates/angular]` `[templates/angular-xmcloud]` `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/editing/config endpoint ([#1903](https://github.com/Sitecore/jss/pull/1903))
 * `[templates/angular]` `[templates/angular-xmcloud]` `[template/node-xmcloud-proxy]` `[sitecore-jss-proxy]` Introduced /api/editing/render endpoint ([#1908](https://github.com/Sitecore/jss/pull/1908))
-* `[templates/angular-xmcloud]` `[template/node-xmcloud-proxy]` Personalization support ([#1964](https://github.com/Sitecore/jss/pull/1964))
+* `[templates/angular-xmcloud]` `[template/node-xmcloud-proxy]` Personalization support ([#1964](https://github.com/Sitecore/jss/pull/1964)[#1971](https://github.com/Sitecore/jss/pull/1971))
 * `[create-sitecore-jss]``[sitecore-jss-angular]``[template/angular-xmcloud]` Angular SXA components
   * Angular placeholder now supports SXA components ([#1870](https://github.com/Sitecore/jss/pull/1870))
   * Component styles ([#1917](https://github.com/Sitecore/jss/pull/1917))

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
@@ -12,10 +12,3 @@ PROXY_HOST=http://localhost:3000
 
 # Your XM Cloud Proxy server path is needed to build the app. The build output will be copied to the proxy server path.
 PROXY_BUILD_PATH=<%- locals.relativeProxyAppDestination.replace(/\\/g, '\\\\') %>dist
-
-# ==============================================
-
-# An optional Sitecore Personalize scope identifier.
-# This can be used to isolate personalization data when multiple XM Cloud Environments share a Personalize tenant.
-# This should match the PAGES_PERSONALIZE_SCOPE environment variable for your connected XM Cloud Environment.
-PERSONALIZE_SCOPE=

--- a/packages/sitecore-jss-proxy/src/middleware/editing/render.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/render.ts
@@ -7,6 +7,12 @@ import {
   EDITING_ALLOWED_ORIGINS,
   RenderMetadataQueryParams,
 } from '@sitecore-jss/sitecore-jss/editing';
+import { PersonalizeHelper } from '../../personalize';
+import {
+  DEFAULT_VARIANT,
+  getGroomedVariantIds,
+  personalizeLayout,
+} from '@sitecore-jss/sitecore-jss/personalize';
 
 /**
  * Configuration for the editing render endpoint
@@ -26,6 +32,10 @@ export type EditingRenderEndpointOptions = {
    * The appRenderer will produce the requested route's html
    */
   renderView: AppRenderer;
+  /**
+   * Personalize helper instance passed from proxy app
+   */
+  personalizeHelper?: PersonalizeHelper;
 };
 
 type MetadataRequest = Request & { query: RenderMetadataQueryParams };
@@ -79,6 +89,14 @@ export const editingRenderMiddleware = (config: EditingRenderEndpointOptions) =>
     if (!data || !data.layoutData || !data.dictionary) {
       throw new Error(`Unable to fetch editing data for ${JSON.stringify(query)}`);
     }
+
+    const variantIds = query.sc_variant?.split(',') || [DEFAULT_VARIANT];
+    const personalizeData = getGroomedVariantIds(variantIds);
+    personalizeLayout(
+      data.layoutData,
+      personalizeData.variantId,
+      personalizeData.componentVariantIds
+    );
 
     const viewBag = { dictionary: data.dictionary };
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow-up to https://github.com/Sitecore/jss/pull/1964 - adds variant switching in editing.
Also a small adjusment to main app's env file.

## Testing Details
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
