### PR TITLE
[Angular] [Next.js] Support Editing Host protection by handling OPTIONS preflight requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-angular]` Fix nested dynamic placeholders not being displayed in Pages ([#1947](https://github.com/Sitecore/jss/pull/1947))
 * `[sitecore-jss-dev-tools]` getMetadata() now uses `npm query` command to get the list and exact versions of packages. this solution works for monorepo setups ([#1949](https://github.com/Sitecore/jss/pull/1949))
 * `[templates/nextjs-sxa]` Fix an alignment issue where components using both `me-auto` and `ms-md-auto` classes resulted in inconsistent alignment of elements. ([#1946](https://github.com/Sitecore/jss/pull/1946)) ([#1950](https://github.com/Sitecore/jss/pull/1950)) ([#1955](https://github.com/Sitecore/jss/pull/1955))
+* `[sitecore-jss-proxy]` Support Editing Host protection by handling OPTIONS preflight requests ([#1976](https://github.com/Sitecore/jss/pull/1976))
 
 ### 🎉 New Features & Improvements
 
@@ -92,6 +93,12 @@ Our versioning strategy is as follows:
 * `[templates/angular]``[templates/node-xmcloud-proxy]``[templates/node-headless-ssr-proxy]``[templates/node-headless-ssr-experience-edge]` Adjust out of box .gitignore rules
 * New Angular add-on's are not scaffolded within build pipeline ([#1962](https://github.com/Sitecore/jss/pull/1962))
 * `[template/angular-xmcloud]``[template/xmcloud-proxy]` Add README.md ([#1965](https://github.com/Sitecore/jss/pull/1965))
+
+## 22.2.2
+
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextjs]` Support Editing Host protection by handling OPTIONS preflight requests (#[TBD](TBD))
 
 ## 22.2.1
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-config-middleware.ts
@@ -62,6 +62,14 @@ export class EditingConfigMiddleware {
       return res.status(401).json({ message: 'Missing or invalid editing secret' });
     }
 
+    // Handle preflight request
+    if (_req.method === 'OPTIONS') {
+      debug.editing('preflight request');
+
+      // CORS headers are set by enforceCors
+      return res.status(204).send(null);
+    }
+
     const components = Array.isArray(this.config.components)
       ? this.config.components
       : Array.from(this.config.components.keys());

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -59,6 +59,9 @@ const mockResponse = () => {
   res.status = spy(() => {
     return res;
   });
+  res.send = spy(() => {
+    return res;
+  });
   res.json = spy(() => {
     return res;
   });
@@ -107,7 +110,7 @@ describe('EditingRenderMiddleware', () => {
     delete process.env.JSS_ALLOWED_ORIGINS;
   });
 
-  it('should respondWith 405 for unsupported method', async () => {
+  it('should respond with 405 for unsupported method', async () => {
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
     const req = mockRequest(EE_BODY, query, 'PUT');
@@ -122,6 +125,33 @@ describe('EditingRenderMiddleware', () => {
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(405);
     expect(res.json).to.have.been.calledOnce;
+  });
+
+  it('should respond with 204 for OPTIONS method', async () => {
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+    const req = mockRequest(EE_BODY, query, 'OPTIONS');
+    const res = mockResponse();
+
+    const middleware = new EditingRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.status).to.have.been.calledOnceWith(204);
+    expect(res.setHeader.getCall(0).args).to.deep.equal([
+      'Access-Control-Allow-Origin',
+      allowedOrigin,
+    ]);
+    expect(res.setHeader.getCall(1).args).to.deep.equal([
+      'Access-Control-Allow-Methods',
+      'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+    ]);
+    expect(res.setHeader.getCall(2).args).to.deep.equal([
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization',
+    ]);
+    expect(res.send).to.have.been.calledOnceWith(null);
   });
 
   it('should respond with 401 for invalid secret', async () => {

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -476,6 +476,12 @@ export class EditingRenderMiddleware extends RenderMiddlewareBase {
         await handler.render(req, res);
         break;
       }
+      case 'OPTIONS': {
+        debug.editing('preflight request');
+
+        // CORS headers are set by enforceCors
+        return res.status(204).send(null);
+      }
       default:
         debug.editing('invalid method - sent %s expected GET/POST', req.method);
         res.setHeader('Allow', 'GET, POST');

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.test.ts
@@ -108,6 +108,34 @@ describe('FEAASRenderMiddleware', () => {
     );
   });
 
+  it('should respond with 204 for preflight OPTIONS request', async () => {
+    const query = {} as Query;
+    query[QUERY_PARAM_EDITING_SECRET] = secret;
+
+    const req = mockRequest(query, 'OPTIONS');
+    const res = mockResponse();
+
+    const middleware = new FEAASRenderMiddleware();
+    const handler = middleware.getHandler();
+
+    await handler(req, res);
+
+    expect(res.setHeader.getCall(0).args).to.deep.equal([
+      'Access-Control-Allow-Origin',
+      allowedOrigin,
+    ]);
+    expect(res.setHeader.getCall(1).args).to.deep.equal([
+      'Access-Control-Allow-Methods',
+      'GET, POST, OPTIONS, DELETE, PUT, PATCH',
+    ]);
+    expect(res.setHeader.getCall(2).args).to.deep.equal([
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization',
+    ]);
+    expect(res.status).to.have.been.calledOnceWith(204);
+    expect(res.send).to.have.been.calledOnceWith(null);
+  });
+
   it('should throw error', async () => {
     const query = {} as Query;
     query[QUERY_PARAM_EDITING_SECRET] = secret;
@@ -140,7 +168,7 @@ describe('FEAASRenderMiddleware', () => {
 
     await handler(req, res);
 
-    expect(res.setHeader).to.have.been.calledWithExactly('Allow', 'GET');
+    expect(res.setHeader).to.have.been.calledWithExactly('Allow', 'GET, OPTIONS');
     expect(res.status).to.have.been.calledOnce;
     expect(res.status).to.have.been.calledWith(405);
     expect(res.send).to.have.been.calledOnce;

--- a/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/feaas-render-middleware.ts
@@ -67,9 +67,9 @@ export class FEAASRenderMiddleware extends RenderMiddlewareBase {
         );
     }
 
-    if (method !== 'GET') {
-      debug.editing('invalid method - sent %s expected GET', method);
-      res.setHeader('Allow', 'GET');
+    if (!method || !['GET', 'OPTIONS'].includes(method)) {
+      debug.editing('invalid method - sent %s expected GET,OPTIONS', method);
+      res.setHeader('Allow', 'GET, OPTIONS');
       return res.status(405).send(`<html><body>Invalid request method '${method}'</body></html>`);
     }
 
@@ -82,6 +82,14 @@ export class FEAASRenderMiddleware extends RenderMiddlewareBase {
         getJssEditingSecret()
       );
       return res.status(401).send('<html><body>Missing or invalid secret</body></html>');
+    }
+
+    // Handle preflight request
+    if (method === 'OPTIONS') {
+      debug.editing('preflight request');
+
+      // CORS headers are set by enforceCors
+      return res.status(204).send(null);
     }
 
     try {

--- a/packages/sitecore-jss-proxy/src/middleware/editing/index.test.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/index.test.ts
@@ -37,6 +37,7 @@ describe('editingRouter', () => {
     app = express();
 
     process.env.JSS_EDITING_SECRET = 'correct';
+    process.env.JSS_ALLOWED_ORIGINS = 'http://allowed.com';
   });
 
   afterEach(() => {
@@ -91,5 +92,18 @@ describe('editingRouter', () => {
         'Invalid request method or path GET /api/editing/fake-config?secret=correct',
         done
       );
+  });
+
+  it('should response 204 when preflight OPTIONS request is sent', (done) => {
+    app.use('/api/editing', editingRouter(defaultOptions));
+
+    request(app)
+      .options('/api/editing/config')
+      .query({ secret: 'correct' })
+      .set('origin', 'http://allowed.com')
+      .expect(204, '', done)
+      .expect('Access-Control-Allow-Origin', 'http://allowed.com')
+      .expect('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE, PUT, PATCH')
+      .expect('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   });
 });

--- a/packages/sitecore-jss-proxy/src/middleware/editing/index.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/index.ts
@@ -72,6 +72,13 @@ export const editingMiddleware = async (
     return res.status(401).send('Missing or invalid secret');
   }
 
+  if (req.method === 'OPTIONS') {
+    debug.editing('preflight request');
+
+    // CORS headers are set by enforceCors
+    return res.status(204).send();
+  }
+
   return next();
 };
 

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -114,6 +114,7 @@ export const getAllowedOriginsFromEnv = () =>
  * set in JSS's JSS_ALLOWED_ORIGINS env variable, passed via allowedOrigins param and/or
  * be already set in Access-Control-Allow-Origin by other logic.
  * Applies Access-Control-Allow-Origin and Access-Control-Allow-Methods on match
+ * Also applies Access-Control-Allow-Headers for preflight requests
  * @param {IncomingMessage} req incoming request
  * @param {OutgoingMessage} res response to set CORS headers for
  * @param {string[]} [allowedOrigins] additional list of origins to test against
@@ -149,6 +150,12 @@ export const enforceCors = (
   ) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, DELETE, PUT, PATCH');
+
+    // set the allowed headers for preflight requests
+    if (req.method === 'OPTIONS') {
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    }
+
     return true;
   }
   return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Enabling Rendering Host protection can cause requests to be rejected by the rendering host. To address this, we have introduced support for preflight requests.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
