### PR TITLE
[templates/angular] Update angular template to support deployment to xmcloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Our versioning strategy is as follows:
   * `[angular-xmcloud]` Add CloudSDK initialization on client side ([#1952](https://github.com/Sitecore/jss/pull/1952))([#1957](https://github.com/Sitecore/jss/pull/1957))([#1961](https://github.com/Sitecore/jss/pull/1961))
   * `[angular-xmcloud]``[sitecore-jss-angular]` Add CDP Page View component to Angular XM Cloud add-on ([#1957](https://github.com/Sitecore/jss/pull/1957))
 * `[templates/vue]``[sitecore-jss-vue]` Vue version has been updated to 3.5
+* `[templates/angular]` Update dependencies and proxy build path value to be unix style path to support xmcloud deployment and spa monorepo in xmcloud foundation head ([#1977](https://github.com/Sitecore/jss/pull/1977))
 
 
 ### 🛠 Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Our versioning strategy is as follows:
   * `[angular-xmcloud]` Add CloudSDK initialization on client side ([#1952](https://github.com/Sitecore/jss/pull/1952))([#1957](https://github.com/Sitecore/jss/pull/1957))([#1961](https://github.com/Sitecore/jss/pull/1961))
   * `[angular-xmcloud]``[sitecore-jss-angular]` Add CDP Page View component to Angular XM Cloud add-on ([#1957](https://github.com/Sitecore/jss/pull/1957))
 * `[templates/vue]``[sitecore-jss-vue]` Vue version has been updated to 3.5
-* `[templates/angular]` Update dependencies and proxy build path value to be unix style path to support xmcloud deployment and spa monorepo in xmcloud foundation head ([#1977](https://github.com/Sitecore/jss/pull/1977))
+* `[templates/angular]` Update dependencies and proxy build path value to be unix style path to support xmcloud deployment and monorepo starter kit in xmcloud foundation head ([#1977](https://github.com/Sitecore/jss/pull/1977))
 
 
 ### 🛠 Breaking Change

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
@@ -11,4 +11,5 @@ SITECORE_EDGE_CONTEXT_ID=
 PROXY_HOST=http://localhost:3000
 
 # Your XM Cloud Proxy server path is needed to build the app. The build output will be copied to the proxy server path.
-PROXY_BUILD_PATH=<%- locals.relativeProxyAppDestination.replace(/\\/g, '\\\\') %>dist
+# Use a relative unix style path to ensure compatibility when deployment runs on Windows or Unix based systems. 
+PROXY_BUILD_PATH=<%- locals.relativeProxyAppDestination.replace(/\\/g, '\/') %>dist

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -65,7 +65,8 @@
     "graphql-tag": "~2.11.0",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
-    "zone.js": "~0.14.7"
+    "zone.js": "~0.14.7",
+    "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^17.0.2",
@@ -107,7 +108,7 @@
     "karma-jasmine": "~4.0.1",
     "karma-jasmine-html-reporter": "~1.5.4",
     "move-cli": "^2.0.0",
-    "npm-run-all": "~4.1.5",
+    "npm-run-all2": "^6.0.0",
     "protractor": "^7.0.0",
     "ts-node": "~10.9.2",
     "typescript": "~5.2.2"

--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -108,7 +108,7 @@
     "karma-jasmine": "~4.0.1",
     "karma-jasmine-html-reporter": "~1.5.4",
     "move-cli": "^2.0.0",
-    "npm-run-all2": "^6.0.0",
+    "npm-run-all2": "^7.0.1",
     "protractor": "^7.0.0",
     "ts-node": "~10.9.2",
     "typescript": "~5.2.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The updates in this PR are done to allow deployment of angular spa starter plus proxy apps to xmcloud:
- adds reflect-metadata dependency
- updates `npm-run-all` dependency to `npm-run-all2`
- ensure PROXY_BUILD_PATH value is a unix style path (with forward slashes); this allows compatibility with both windows and unix style sysetems

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
