### PR TITLE
[templates/angular] Apply webpack resolve alias for angular, only in our monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Our versioning strategy is as follows:
 * `[templates/vue]``[sitecore-jss-vue]` Vue version has been updated to 3.5
 * `[templates/angular]` Update dependencies and proxy build path value to be unix style path to support xmcloud deployment and monorepo starter kit in xmcloud foundation head ([#1977](https://github.com/Sitecore/jss/pull/1977))
 * `[templates/angular]``[templates/angular-sxp]``[templates/angular-xmcloud]` Updates for Angular XMC sample to work well with local containers and spa-starters monorepo in xmcloud-foundation ([#1983](https://github.com/Sitecore/jss/pull/1983))
-* `[sitecore-jss-angular]``[templates/angular]` Integrate CloudSDK events firing ([#1984](https://github.com/Sitecore/jss/pull/1984))
+* `[sitecore-jss-angular]``[templates/angular]` Integrate CloudSDK events firing ([#1984](https://github.com/Sitecore/jss/pull/1984))([#1990](https://github.com/Sitecore/jss/pull/1990))
 
 ### 🛠 Breaking Change
 

--- a/packages/create-sitecore-jss/src/templates/angular/webpack.config.js
+++ b/packages/create-sitecore-jss/src/templates/angular/webpack.config.js
@@ -3,9 +3,11 @@ const path = require('path');
 
 module.exports = {
   plugins: [new Dotenv()],
-  resolve: {
-    alias: {
-      '@sitecore-cloudsdk': path.resolve(__dirname, 'node_modules/@sitecore-cloudsdk'),
+  <% if (helper.isDev) { %>
+    resolve: {
+      alias: {
+        '@sitecore-cloudsdk': path.resolve(__dirname, 'node_modules/@sitecore-cloudsdk'),
+      },
     },
-  },
+    <% } %>
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR to apply the webpack resolve alias setting in angular template only when scaffolding sample in monorepo.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
