### PR TITLE
 [templates/nextjs-sxa]: The background image in Container component has been fixed #SXA-7647

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Our versioning strategy is as follows:
 
 * `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987))
 
+### 🐛 Bug Fixes
+
+* `[templates/nextjs-sxa]` Fixed an issue in the `Container` component where `background-image` was not rendering correctly in `pageState === 'edit'` ([#1997](https://github.com/Sitecore/jss/pull/1997))
+
 ## 22.3.0 / 22.3.1
 
 ### 🐛 Bug Fixes

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
@@ -2,6 +2,7 @@ import {
   ComponentParams,
   ComponentRendering,
   Placeholder,
+  useSitecoreContext,
 } from '@sitecore-jss/sitecore-jss-nextjs';
 import React from 'react';
 
@@ -10,44 +11,67 @@ interface ComponentProps {
   params: ComponentParams;
 }
 
-const DefaultContainer = (props: ComponentProps): JSX.Element => {
-  const containerStyles = props.params && props.params.Styles ? props.params.Styles : '';
-  const styles = `${props.params.GridParameters} ${containerStyles}`.trimEnd();
-  const phKey = `container-${props.params.DynamicPlaceholderId}`;
-  const id = props.params.RenderingIdentifier;
-  const mediaUrlPattern = new RegExp(/mediaurl=\"([^"]*)\"/, 'i');
-  let backgroundImage = props.params.BackgroundImage as string;
-  let backgroundStyle: { [key: string]: string } = {};
+const BACKGROUND_REG_EXP = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+const MEDIA_URL_PATTERN = /mediaurl="([^"]*)"/i;
+const SITECORE_MEDIA_PREFIX = '/sitecore/shell/-/media/';
 
-  if (backgroundImage && backgroundImage.match(mediaUrlPattern)) {
-    const mediaUrl = backgroundImage.match(mediaUrlPattern)?.[1] || '';
+const getBackgroundStyle = (
+  backgroundImage: string,
+  isEditMode: boolean
+): { [key: string]: string } => {
+  if (!backgroundImage) return {};
 
-    backgroundStyle = {
-      backgroundImage: `url('${mediaUrl}')`,
-    };
+  if (isEditMode) {
+    const processedImage = backgroundImage
+      .match(BACKGROUND_REG_EXP)
+      ?.pop()
+      ?.replace(/-/gi, '');
+    return processedImage
+      ? { backgroundImage: `url('${SITECORE_MEDIA_PREFIX}${processedImage}')` }
+      : {};
   }
 
+  const mediaUrl = backgroundImage.match(MEDIA_URL_PATTERN)?.[1] || '';
+  return mediaUrl ? { backgroundImage: `url('${mediaUrl}')` } : {};
+};
+
+const DefaultContainer: React.FC<ComponentProps> = ({ params, rendering }): JSX.Element => {
+  const { sitecoreContext } = useSitecoreContext();
+  const {
+    Styles: containerStyles = '',
+    GridParameters = '',
+    DynamicPlaceholderId,
+    RenderingIdentifier,
+    BackgroundImage,
+  } = params;
+
+  const styles = `${GridParameters} ${containerStyles}`.trimEnd();
+  const placeholderKey = `container-${DynamicPlaceholderId}`;
+  const backgroundStyle = getBackgroundStyle(
+    BackgroundImage as string,
+    sitecoreContext.pageState === 'edit'
+  );
+
   return (
-    <div className={`component container-default ${styles}`} id={id ? id : undefined}>
+    <div className={`component container-default ${styles}`} id={RenderingIdentifier || undefined}>
       <div className="component-content" style={backgroundStyle}>
         <div className="row">
-          <Placeholder name={phKey} rendering={props.rendering} />
+          <Placeholder name={placeholderKey} rendering={rendering} />
         </div>
       </div>
     </div>
   );
 };
 
-export const Default = (props: ComponentProps): JSX.Element => {
-  const splitStyles = props.params?.Styles?.split(' ');
+export const Default: React.FC<ComponentProps> = (props): JSX.Element => {
+  const { Styles = '' } = props.params;
+  const hasContainerStyle = Styles.split(' ').includes('container');
 
-  if (splitStyles && splitStyles.includes('container')) {
-    return (
-      <div className="container-wrapper">
-        <DefaultContainer {...props} />
-      </div>
-    );
-  }
-
-  return <DefaultContainer {...props} />;
+  return hasContainerStyle ? (
+    <div className="container-wrapper">
+      <DefaultContainer {...props} />
+    </div>
+  ) : (
+    <DefaultContainer {...props} />
+  );
 };

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Container.tsx
@@ -4,74 +4,54 @@ import {
   Placeholder,
   useSitecoreContext,
 } from '@sitecore-jss/sitecore-jss-nextjs';
-import React from 'react';
+import config from 'temp/config';
+
+const MEDIA_URL_PATTERN = /mediaurl="([^"]*)"/i;
 
 interface ComponentProps {
   rendering: ComponentRendering & { params: ComponentParams };
   params: ComponentParams;
 }
 
-const BACKGROUND_REG_EXP = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
-const MEDIA_URL_PATTERN = /mediaurl="([^"]*)"/i;
-const SITECORE_MEDIA_PREFIX = '/sitecore/shell/-/media/';
+const DefaultContainer = (props: ComponentProps): JSX.Element => {
+  const { sitecoreContext } = useSitecoreContext();
+  const isEditMode = sitecoreContext.pageState === 'edit';
+  const containerStyles = props.params && props.params.Styles ? props.params.Styles : '';
+  const styles = `${props.params.GridParameters} ${containerStyles}`.trimEnd();
+  const phKey = `container-${props.params.DynamicPlaceholderId}`;
+  const id = props.params.RenderingIdentifier;
+  const backgroundImage = props.params.BackgroundImage as string;
+  let backgroundStyle: { [key: string]: string } = {};
 
-const getBackgroundStyle = (
-  backgroundImage: string,
-  isEditMode: boolean
-): { [key: string]: string } => {
-  if (!backgroundImage) return {};
+  if (backgroundImage && backgroundImage.match(MEDIA_URL_PATTERN)) {
+    const mediaUrl = backgroundImage.match(MEDIA_URL_PATTERN)?.[1] || '';
 
-  if (isEditMode) {
-    const processedImage = backgroundImage
-      .match(BACKGROUND_REG_EXP)
-      ?.pop()
-      ?.replace(/-/gi, '');
-    return processedImage
-      ? { backgroundImage: `url('${SITECORE_MEDIA_PREFIX}${processedImage}')` }
-      : {};
+    backgroundStyle = {
+      backgroundImage: `url('${isEditMode ? config.sitecoreApiHost : ''}${mediaUrl}')`,
+    };
   }
 
-  const mediaUrl = backgroundImage.match(MEDIA_URL_PATTERN)?.[1] || '';
-  return mediaUrl ? { backgroundImage: `url('${mediaUrl}')` } : {};
-};
-
-const DefaultContainer: React.FC<ComponentProps> = ({ params, rendering }): JSX.Element => {
-  const { sitecoreContext } = useSitecoreContext();
-  const {
-    Styles: containerStyles = '',
-    GridParameters = '',
-    DynamicPlaceholderId,
-    RenderingIdentifier,
-    BackgroundImage,
-  } = params;
-
-  const styles = `${GridParameters} ${containerStyles}`.trimEnd();
-  const placeholderKey = `container-${DynamicPlaceholderId}`;
-  const backgroundStyle = getBackgroundStyle(
-    BackgroundImage as string,
-    sitecoreContext.pageState === 'edit'
-  );
-
   return (
-    <div className={`component container-default ${styles}`} id={RenderingIdentifier || undefined}>
+    <div className={`component container-default ${styles}`} id={id ? id : undefined}>
       <div className="component-content" style={backgroundStyle}>
         <div className="row">
-          <Placeholder name={placeholderKey} rendering={rendering} />
+          <Placeholder name={phKey} rendering={props.rendering} />
         </div>
       </div>
     </div>
   );
 };
 
-export const Default: React.FC<ComponentProps> = (props): JSX.Element => {
-  const { Styles = '' } = props.params;
-  const hasContainerStyle = Styles.split(' ').includes('container');
+export const Default = (props: ComponentProps): JSX.Element => {
+  const splitStyles = props.params?.Styles?.split(' ');
 
-  return hasContainerStyle ? (
-    <div className="container-wrapper">
-      <DefaultContainer {...props} />
-    </div>
-  ) : (
-    <DefaultContainer {...props} />
-  );
+  if (splitStyles && splitStyles.includes('container')) {
+    return (
+      <div className="container-wrapper">
+        <DefaultContainer {...props} />
+      </div>
+    );
+  }
+
+  return <DefaultContainer {...props} />;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
Fixed the background-image issue in the Container component for the pageState === 'edit' scenario.

Implemented correct parsing and formatting of the BackgroundImage parameter to ensure proper rendering during the edit mode.

Replaced UUID dashes with an empty string and prefixed the image path with `/sitecore/shell/-/media/`.

Extracted the background image processing logic into a reusable function _getBackgroundStyle_ for better code organization and clarity.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
