### PR TITLE
 [templates/nextjs-sxa]: The imports of font-awesome has been fixed #SXA-7659

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Our versioning strategy is as follows:
 
 * `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987))
 
+### 🐛 Bug Fixes
+
+* `[templates/nextjs-sxa]` Fixed font-awesome import issue in custom workspace configuration ([#1998](https://github.com/Sitecore/jss/pull/1998))
+
 ## 22.3.0 / 22.3.1
 
 ### 🐛 Bug Fixes

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/base/richtext/_richtext-files-icons.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/base/richtext/_richtext-files-icons.scss
@@ -1,5 +1,5 @@
-@import '@fontawesome/scss/mixins';
-@import '@fontawesome/scss/variables';
+@import '~font-awesome/scss/mixins';
+@import '~font-awesome/scss/variables';
 @import "@sass/abstracts/mixins";
 
 //files icons

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/link-list/_component-link-list.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/link-list/_component-link-list.scss
@@ -1,7 +1,7 @@
 @import "@sass/abstracts/mixins";
 @import "@sass/abstracts/vars";
-@import '@fontawesome/scss/mixins';
-@import "@fontawesome/scss/variables";
+@import '~font-awesome/scss/mixins';
+@import "~font-awesome/scss/variables";
 
 .link-list {
     background: $link-list-bg;

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-fat.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-fat.scss
@@ -1,7 +1,7 @@
 @import '@sass/abstracts/vars';
 @import '@sass/abstracts/mixins';
-@import '@fontawesome/scss/mixins';
-@import '@fontawesome/scss/variables';
+@import '~font-awesome/scss/mixins';
+@import '~font-awesome/scss/variables';
 
 .navigation.navigation-fat {
   background: $bg-basic-color;

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-main-horizontal-vertical.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-main-horizontal-vertical.scss
@@ -1,7 +1,7 @@
 @import '@sass/abstracts/vars';
 @import '@sass/abstracts/mixins';
-@import '@fontawesome/scss/mixins';
-@import '@fontawesome/scss/variables';
+@import '~font-awesome/scss/mixins';
+@import '~font-awesome/scss/variables';
 
 $borderSize: 2px;
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-mobile.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_navigation-mobile.scss
@@ -1,7 +1,7 @@
 @import '@sass/abstracts/vars';
 @import '@sass/abstracts/mixins';
-@import '@fontawesome/scss/mixins';
-@import '@fontawesome/scss/variables';
+@import '~font-awesome/scss/mixins';
+@import '~font-awesome/scss/variables';
 
 .navigation.navigation-mobile {
   nav > ul {

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_sitemap-navigation.scss
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/assets/sass/components/navigation/_sitemap-navigation.scss
@@ -1,7 +1,7 @@
 @import '@sass/abstracts/vars';
 @import '@sass/abstracts/mixins';
-@import '@fontawesome/scss/mixins';
-@import '@fontawesome/scss/variables';
+@import '~font-awesome/scss/mixins';
+@import '~font-awesome/scss/variables';
 
 .navigation.sitemap-navigation {
   .level2 a {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
The font-awesome package imports (e.g., @fontawesome/) were failing in the custom workspace due to incorrect paths or missing dependencies.

Corrected SCSS imports by explicitly specifying the proper path (~font-awesome/scss/...) in SCSS files.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
