### PR TITLE
[sitecore-jss-nextjs][Component Lib] Remove 'datasourceId' from required params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987))
+* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000))
 
 ### 🐛 Bug Fixes
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -355,7 +355,6 @@ export class MetadataHandler {
       'sc_site',
       'sc_itemid',
       'sc_renderingId',
-      'sc_datasourceId',
       'sc_uid',
       'sc_lang',
       'mode',


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Remove `sc_datasourceId` from the required params in Library Component flow.

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
