### PR TITLE
[sitecore-jss-nextjs] Remove variantId from query in Comp Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000)[#2002](https://github.com/Sitecore/jss/pull/2002))
+* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000)[#2002](https://github.com/Sitecore/jss/pull/2002)[#2005](https://github.com/Sitecore/jss/pull/2005))
 
 ### 🐛 Bug Fixes
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -235,7 +235,6 @@ describe('EditingRenderMiddleware', () => {
           pageState: 'normal',
           mode: 'library',
           dataSourceId: query.sc_datasourceId,
-          variant: query.sc_variant,
           version: query.sc_version,
         });
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -388,7 +388,6 @@ export class MetadataHandler {
           pageState: LayoutServicePageState.Normal,
           mode: 'library',
           dataSourceId: query.sc_datasourceId,
-          variant: query.sc_variant || DEFAULT_VARIANT,
           version: query.sc_version,
         } as ComponentLibraryRenderPreviewData,
         {

--- a/packages/sitecore-jss/src/editing/rest-component-layout-service.test.ts
+++ b/packages/sitecore-jss/src/editing/rest-component-layout-service.test.ts
@@ -466,7 +466,6 @@ describe('RestComponentLayoutService', () => {
         sc_site: testParams.siteName,
         sc_lang: testParams.language,
         sc_mode: testParams.editMode,
-        sc_variant: testParams.variant,
       };
 
       // eslint-disable-next-line dot-notation
@@ -498,7 +497,6 @@ describe('RestComponentLayoutService', () => {
         renderingItemId: testParams.renderingId,
         sc_lang: testParams.language,
         sc_mode: testParams.editMode,
-        sc_variant: testParams.variant,
       };
 
       // eslint-disable-next-line dot-notation

--- a/packages/sitecore-jss/src/editing/rest-component-layout-service.ts
+++ b/packages/sitecore-jss/src/editing/rest-component-layout-service.ts
@@ -40,10 +40,6 @@ export interface ComponentLayoutRequestParams {
    * site name to be used as context for rendering the component
    */
   siteName?: string;
-  /**
-   * variant to be rendered for component if set (works with rendering existing component)
-   */
-  variant?: string;
 }
 
 /**
@@ -96,7 +92,6 @@ export class RestComponentLayoutService extends RestLayoutService {
         sc_site: params.siteName,
         sc_lang: params.language || 'en',
         sc_mode: params.editMode,
-        sc_variant: params.variant,
       })
     );
   }


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
variantID is no longer required to come from JSS side by Component Library.

## Testing Details
- [x] Unit Test Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
