### PR TITLE
 [sitecore-jss]: The logic of method escapeNonSpecialQuestionMarks has been fixed #SXA-7975

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fixed handling of ? inside square brackets [] in regex patterns to prevent incorrect escaping ([#1999](https://github.com/Sitecore/jss/pull/1999))
 * `[sitecore-jss-nextjs]` Improve performance for redirect middleware ([#2003](https://github.com/Sitecore/jss/pull/2003))
 * `[templates/nextjs]` `[templates/nextjs-sxa]` Fixed condition of DISABLE_FETCH_SSG ([#2007](https://github.com/Sitecore/jss/pull/2007))
+* `[sitecore-jss]` Fixed incorrect escaping of question marks in negative lookahead patterns in `escapeNonSpecialQuestionMarks` function ([#2014](https://github.com/Sitecore/jss/pull/2014))
+
 
 ### 🛠 Breaking Change
 

--- a/packages/sitecore-jss/src/utils/utils.test.ts
+++ b/packages/sitecore-jss/src/utils/utils.test.ts
@@ -297,45 +297,57 @@ describe('utils', () => {
   });
 
   describe('escapeNonSpecialQuestionMarks', () => {
-    it('should escape non-special "?" in plain strings', () => {
-      const input = 'What? is this? really?';
-      const expected = 'What\\? is this\\? really\\?';
+    it('should escape simple unescaped question marks', () => {
+      const input = 'abc?def?ghi';
+      const expected = 'abc\\?def\\?ghi';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should not escape special regex "?" characters', () => {
-      const input = '(abc)? .*? [a-z]?';
-      const expected = '(abc)? .*? [a-z]?';
+    it('should not escape question marks in negative lookaheads', () => {
+      const input = 'abc(?!def)?ghi';
+      const expected = 'abc(?!def)?ghi';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should handle mixed cases with special and non-special "?"', () => {
-      const input = 'Is this (true)? or false?';
-      const expected = 'Is this (true)? or false\\?';
+    it('should not escape question marks following special regex symbols', () => {
+      const input = 'abc.*?def+?ghi';
+      const expected = 'abc.*?def+?ghi';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should escape "?" in a string with no special characters', () => {
-      const input = 'Just a plain string?';
-      const expected = 'Just a plain string\\?';
+    it('should escape mixed cases correctly', () => {
+      const input = 'abc?de(?!f)?g?hi.*?';
+      const expected = 'abc\\?de(?!f)?g\\?hi.*?';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should handle strings with escaped "?" already', () => {
-      const input = 'This \\? should stay escaped?';
-      const expected = 'This \\? should stay escaped\\?';
+    it('should handle strings without question marks', () => {
+      const input = 'abcdefghi';
+      const expected = 'abcdefghi';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should handle an empty string', () => {
+    it('should handle escaped question marks', () => {
+      const input = 'abc\\?def?ghi';
+      const expected = 'abc\\?def\\?ghi';
+      expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
+    });
+
+    it('should handle empty strings', () => {
       const input = '';
       const expected = '';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
 
-    it('should handle strings without any "?"', () => {
-      const input = 'No question marks here.';
-      const expected = 'No question marks here.';
+    it('should handle consecutive unescaped question marks', () => {
+      const input = 'abc??def';
+      const expected = 'abc\\?\\?def';
+      expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
+    });
+
+    it('should handle consecutive special symbols with question marks', () => {
+      const input = 'abc.*??ghi';
+      const expected = 'abc.*?\\?ghi';
       expect(escapeNonSpecialQuestionMarks(input)).to.equal(expected);
     });
   });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->

This fix for the `escapeNonSpecialQuestionMarks` function to correctly handle negative lookaheads. Previously, the function incorrectly escaped `?` within negative lookahead patterns like `(?!)`. Now, the logic ensures that `?` inside these constructs remains unescaped while still escaping other unescaped question marks outside special regex constructs.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
