### PR TITLE
Fix layout response for non-existent pages in RAV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
 ### 🛠 Breaking Change
 
 * `[all packages]` `[all samples]` Remove Axios ([#2006](https://github.com/Sitecore/jss/pull/2006)) ([#2008](https://github.com/Sitecore/jss/pull/2008)) ([#2011](https://github.com/Sitecore/jss/pull/2011))([#2013](https://github.com/Sitecore/jss/pull/2013))([#2015](https://github.com/Sitecore/jss/pull/2015))
+([#2016](https://github.com/Sitecore/jss/pull/2016))
     * `AxiosDataFetcher` is replaced by the `NativeDataFetcher`.
     * `AxiosDataFetcherConfig` is replaced by `NativeDataFetcherConfig`.
     * `AxiosResponse` is replaced by `NativeDataFetcherResponse`.

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -183,7 +183,6 @@ export class NativeDataFetcher {
       init.method = init.body ? 'POST' : 'GET';
     }
 
-    headers.set('Content-Type', 'application/json');
     init.headers = headers;
 
     return init;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The native fetch API was identifying the layout request as a complex request due to the explicitly set Content-Type header, which caused it to send an additional OPTIONS preflight request. This preflight request led to a CORS error, preventing the subsequent GET request from completing successfully. By removing the Content-Type header, the default headers for the HTTP request now satisfy the criteria for a [simple request](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests). This avoids triggering the preflight OPTIONS request and allows the GET request to complete as intended.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
