### PR TITLE
[sitecore-jss-nextjs] Fix Chromes mode for NativeFetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextj]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud
+
+
 ## 22.4.0
 
 ### 🐛 Bug Fixes

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -597,6 +597,29 @@ describe('EditingRenderMiddleware', () => {
       expect(fetcher.get).to.have.been.calledWithMatch('https://vercel.com');
     });
 
+    it('resolveServerUrl should return https address when authorization header present', async () => {
+      const html = '<html><body>Something amazing</body></html>';
+      const fetcher = mockFetcher(html);
+      const dataService = mockDataService();
+      const query = {} as Query;
+      query[QUERY_PARAM_EDITING_SECRET] = secret;
+      const req = mockRequest(EE_BODY, query, undefined, {
+        authorization: '123',
+        host: 'testhostheader.com',
+      });
+      const res = mockResponse();
+
+      const middleware = new EditingRenderMiddleware({
+        dataFetcher: fetcher,
+        editingDataService: dataService,
+      });
+      const handler = middleware.getHandler();
+
+      await handler(req, res);
+
+      expect(fetcher.get).to.have.been.calledWithMatch('https://testhostheader.com');
+    });
+
     it('should use custom resolveServerUrl', async () => {
       const html = '<html><body>Something amazing</body></html>';
       const fetcher = mockFetcher(html);
@@ -731,7 +754,7 @@ describe('EditingRenderMiddleware', () => {
 
       expect(fetcher.get).to.have.been.calledOnce;
       expect(fetcher.get).to.have.been.calledWith(
-        match('http://localhost:3000/test/path?timestamp'),
+        match('https://localhost:3000/test/path?timestamp'),
         {
           headers: {
             authorization: mockAuthValue,

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -77,7 +77,7 @@ export class ChromesHandler extends RenderMiddlewareBase {
   private editingDataService: EditingDataService;
   private dataFetcher: NativeDataFetcher;
   private resolvePageUrl: (args: { serverUrl: string; itemPath: string }) => string;
-  private resolveServerUrl: (req: NextApiRequest) => string;
+  private resolveServerUrl: (req: NextApiRequest, secure?: boolean) => string;
 
   constructor(public config?: EditingRenderMiddlewareChromesConfig) {
     super();
@@ -96,9 +96,10 @@ export class ChromesHandler extends RenderMiddlewareBase {
     try {
       // Extract data from EE payload
       const editingData = this.extractEditingData(req);
-
+      // use https for requests with auth but also support unsecured http rendering hosts
+      const secure = req.headers.authorization || process.env.VERCEL ? true : false;
       // Resolve server URL
-      const serverUrl = this.resolveServerUrl(req);
+      const serverUrl = this.resolveServerUrl(req, secure);
 
       // Get query string parameters to propagate on subsequent requests (e.g. for deployment protection bypass)
       const params = this.getQueryParamsForPropagation(query);
@@ -216,8 +217,8 @@ export class ChromesHandler extends RenderMiddlewareBase {
    * https://vercel.com/docs/environment-variables#system-environment-variables
    * @param {NextApiRequest} req
    */
-  private defaultResolveServerUrl = (req: NextApiRequest) => {
-    return `${process.env.VERCEL ? 'https' : 'http'}://${req.headers.host}`;
+  private defaultResolveServerUrl = (req: NextApiRequest, secure?: boolean) => {
+    return `${secure ? 'https' : 'http'}://${req.headers.host}`;
   };
 
   private extractEditingData(req: NextApiRequest): EditingData {

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -77,7 +77,7 @@ export class ChromesHandler extends RenderMiddlewareBase {
   private editingDataService: EditingDataService;
   private dataFetcher: NativeDataFetcher;
   private resolvePageUrl: (args: { serverUrl: string; itemPath: string }) => string;
-  private resolveServerUrl: (req: NextApiRequest, secure?: boolean) => string;
+  private resolveServerUrl: (req: NextApiRequest) => string;
 
   constructor(public config?: EditingRenderMiddlewareChromesConfig) {
     super();
@@ -96,10 +96,9 @@ export class ChromesHandler extends RenderMiddlewareBase {
     try {
       // Extract data from EE payload
       const editingData = this.extractEditingData(req);
-      // use https for requests with auth but also support unsecured http rendering hosts
-      const secure = req.headers.authorization || process.env.VERCEL ? true : false;
+
       // Resolve server URL
-      const serverUrl = this.resolveServerUrl(req, secure);
+      const serverUrl = this.resolveServerUrl(req);
 
       // Get query string parameters to propagate on subsequent requests (e.g. for deployment protection bypass)
       const params = this.getQueryParamsForPropagation(query);
@@ -217,8 +216,11 @@ export class ChromesHandler extends RenderMiddlewareBase {
    * https://vercel.com/docs/environment-variables#system-environment-variables
    * @param {NextApiRequest} req
    */
-  private defaultResolveServerUrl = (req: NextApiRequest, secure?: boolean) => {
-    return `${secure ? 'https' : 'http'}://${req.headers.host}`;
+  private defaultResolveServerUrl = (req: NextApiRequest) => {
+    // use https for requests with auth but also support unsecured http rendering hosts
+    return `${req.headers.authorization || process.env.VERCEL ? 'https' : 'http'}://${
+      req.headers.host
+    }`;
   };
 
   private extractEditingData(req: NextApiRequest): EditingData {


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fetch cannot pass `authorization` headers when request schema changes - and that's what is happening with XMCloud preview and edit in Chromes mode.
This PR makes rendering host requests be `https` OOB when authorization header is present.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
