### PR TITLE
[sitecore-jss] NativeDataFetcher doesn't return stream response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+## 22.4.1
+
 ### 🐛 Bug Fixes
 
-* `[sitecore-jss-nextj]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud [#2019](https://github.com/Sitecore/jss/pull/2019)
-
+* `[sitecore-jss-nextjs]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud ([#2019](https://github.com/Sitecore/jss/pull/2019))
+* `[sitecore-jss]` NativeDataFetcher doesn't return stream response ([#2020](https://github.com/Sitecore/jss/pull/2020))
 
 ## 22.4.0
 

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -12,7 +12,7 @@ let fetchInit: RequestInit | undefined;
 
 const mockFetch = (
   status: number,
-  response: unknown = {},
+  response: { [key: string]: unknown } = {},
   {
     jsonError,
     textError,
@@ -55,6 +55,7 @@ const mockFetch = (
           ? Promise.reject(new Error(textError))
           : Promise.resolve(JSON.stringify(response));
       },
+      body: response.body,
     } as Response);
   };
 };
@@ -65,7 +66,7 @@ const mockHeaders = () => {
   });
 };
 
-describe('NativeDataFetcher', () => {
+describe.only('NativeDataFetcher', () => {
   let debugNamespaces: string;
 
   before(() => {
@@ -130,6 +131,30 @@ describe('NativeDataFetcher', () => {
 
       const response = await fetcher.fetch('http://test.com/api');
       expect(response.status).to.equal(200);
+      expect(fetchInput).to.equal('http://test.com/api');
+      expect(fetchInit?.method).to.equal('GET');
+      expect(fetchInit?.body).to.be.undefined;
+    });
+
+    it.only('should execute request with stream response type', async () => {
+      const fetcher = new NativeDataFetcher();
+
+      const fakeRes = { body: new ReadableStream() };
+
+      spy.on(
+        global,
+        'fetch',
+        mockFetch(200, fakeRes, {
+          customHeaders: {
+            'Content-Type': 'text/xml',
+          },
+        })
+      );
+
+      const response = await fetcher.fetch('http://test.com/api');
+
+      expect(response.status).to.equal(200);
+      expect(response.data instanceof ReadableStream).to.be.true;
       expect(fetchInput).to.equal('http://test.com/api');
       expect(fetchInit?.method).to.equal('GET');
       expect(fetchInit?.body).to.be.undefined;

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -66,7 +66,7 @@ const mockHeaders = () => {
   });
 };
 
-describe.only('NativeDataFetcher', () => {
+describe('NativeDataFetcher', () => {
   let debugNamespaces: string;
 
   before(() => {
@@ -136,7 +136,7 @@ describe.only('NativeDataFetcher', () => {
       expect(fetchInit?.body).to.be.undefined;
     });
 
-    it.only('should execute request with stream response type', async () => {
+    it('should execute request with stream response type', async () => {
       const fetcher = new NativeDataFetcher();
 
       const fakeRes = { body: new ReadableStream() };

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -220,6 +220,11 @@ export class NativeDataFetcher {
       if (contentType.includes('application/json')) {
         return await response.json();
       }
+
+      if (response.body instanceof ReadableStream) {
+        return response.body;
+      }
+
       return await response.text();
     } catch (error) {
       debug('Response parsing error: %o', error);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
`NativeDataFetcher` now returns body in case of stream response type
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
