### PR TITLE
[sitecore-jss] Introduce separate flow for fetching streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud ([#2019](https://github.com/Sitecore/jss/pull/2019))
-* `[sitecore-jss]` NativeDataFetcher doesn't return stream response ([#2020](https://github.com/Sitecore/jss/pull/2020))
+* `[sitecore-jss]` NativeDataFetcher doesn't return stream response ([#2020](https://github.com/Sitecore/jss/pull/2020)[#2022](https://github.com/Sitecore/jss/pull/2022))
 
 ## 22.4.0
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -36,7 +36,7 @@ const sitemapApi = async (
 
     try {
       const fetcher = new NativeDataFetcher();
-      const response = await fetcher.fetch<ReadableStream<Uint8Array>>(sitemapUrl);
+      const response = await fetcher.fetchStream<Uint8Array>(sitemapUrl);
 
       const reader = response.data.getReader();
       if (reader) {

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -145,6 +145,15 @@ describe('NativeDataFetcher', () => {
       expect(response.data).to.equal('response override');
     });
 
+    it('fetchStream should return response.body', async () => {
+      const fetcher = new NativeDataFetcher();
+
+      spy.on(global, 'fetch', mockFetch(200, { body: 'response body' }, { responseType: 'text' }));
+
+      const response = await fetcher.fetch('http://test.com/api');
+      expect(response.data).to.equal('response body');
+    });
+
     it('should execute request with stream response type', async () => {
       const fetcher = new NativeDataFetcher();
 

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -136,6 +136,15 @@ describe('NativeDataFetcher', () => {
       expect(fetchInit?.body).to.be.undefined;
     });
 
+    it('should execute request with custom response parser', async () => {
+      const fetcher = new NativeDataFetcher();
+
+      spy.on(global, 'fetch', mockFetch(200, {}, { responseType: 'text' }));
+
+      const response = await fetcher.fetch('http://test.com/api', {}, () => 'response override');
+      expect(response.data).to.equal('response override');
+    });
+
     it('should execute request with stream response type', async () => {
       const fetcher = new NativeDataFetcher();
 
@@ -151,7 +160,7 @@ describe('NativeDataFetcher', () => {
         })
       );
 
-      const response = await fetcher.fetch('http://test.com/api');
+      const response = await fetcher.fetchStream('http://test.com/api');
 
       expect(response.status).to.equal(200);
       expect(response.data instanceof ReadableStream).to.be.true;

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -150,7 +150,7 @@ describe('NativeDataFetcher', () => {
 
       spy.on(global, 'fetch', mockFetch(200, { body: 'response body' }, { responseType: 'text' }));
 
-      const response = await fetcher.fetch('http://test.com/api');
+      const response = await fetcher.fetchStream('http://test.com/api');
       expect(response.data).to.equal('response body');
     });
 

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -49,6 +49,11 @@ export type NativeDataFetcherFunction<T> = (
   data?: RequestInit
 ) => Promise<NativeDataFetcherResponse<T>>;
 
+export type ResponseParserFunc = (
+  response: Response,
+  debug: (message: string, ...optionalParams: any[]) => void
+) => Promise<unknown> | unknown;
+
 export type NativeDataFetcherConfig = NativeDataFetcherOptions & RequestInit;
 
 export class NativeDataFetcher {
@@ -60,14 +65,19 @@ export class NativeDataFetcher {
    * Implements a data fetcher.
    * @param {string} url The URL to request (may include query string)
    * @param {RequestInit} [options] Optional fetch options
+   * @param {ResponseParserFunc} [responseParser] Optionally specifies custom way to parse fetch response
    * @returns {Promise<NativeDataFetcherResponse<T>>} response
    */
-  async fetch<T>(url: string, options: RequestInit = {}): Promise<NativeDataFetcherResponse<T>> {
+  async fetch<T>(
+    url: string,
+    options: RequestInit = {},
+    responseParser?: ResponseParserFunc
+  ): Promise<NativeDataFetcherResponse<T>> {
     const { debugger: debugOverride, fetch: fetchOverride, ...init } = this.config;
     const startTimestamp = Date.now();
     const fetchImpl = fetchOverride || fetch;
     const debug = debugOverride || debuggers.http;
-
+    responseParser = responseParser || this.parseResponse;
     const requestInit = this.getRequestInit({ ...init, ...options });
 
     const fetchWithOptionalTimeout = [fetchImpl(url, requestInit)];
@@ -88,7 +98,7 @@ export class NativeDataFetcher {
         return res;
       });
 
-      const respData = await this.parseResponse(response, debug);
+      const respData = await responseParser(response, debug);
       if (!response.ok) {
         const error = this.createError(response, respData);
         debug('Response error: %o', error.response);
@@ -109,6 +119,16 @@ export class NativeDataFetcher {
       debug('Request failed: %o', error);
       throw error;
     }
+  }
+
+  async fetchStream<T>(
+    url: string,
+    options: RequestInit = {}
+  ): Promise<NativeDataFetcherResponse<ReadableStream<T>>> {
+    const parseStreamResponse = (response: Response) => {
+      return response.body;
+    };
+    return this.fetch<ReadableStream<T>>(url, options, parseStreamResponse);
   }
 
   /**
@@ -220,11 +240,6 @@ export class NativeDataFetcher {
       if (contentType.includes('application/json')) {
         return await response.json();
       }
-
-      if (response.body instanceof ReadableStream) {
-        return response.body;
-      }
-
       return await response.text();
     } catch (error) {
       debug('Response parsing error: %o', error);

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -49,6 +49,9 @@ export type NativeDataFetcherFunction<T> = (
   data?: RequestInit
 ) => Promise<NativeDataFetcherResponse<T>>;
 
+/**
+ * Type describing oprional response parser for fetch requests
+ */
 export type ResponseParserFunc = (
   response: Response,
   debug: (message: string, ...optionalParams: any[]) => void
@@ -121,6 +124,12 @@ export class NativeDataFetcher {
     }
   }
 
+  /**
+   * performs a fetch call with that returns fetch's response.body as a ReadableStream
+   * @param {string} url The URL to request (may include query string)
+   * @param {RequestInit} [options] Optional fetch options
+   * @returns {Promise<NativeDataFetcherResponse<ReadableStream<T>>>} response
+   */
   async fetchStream<T>(
     url: string,
     options: RequestInit = {}


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow up for https://github.com/Sitecore/jss/pull/2020

Previous approach introduced a bug where every fetch operation response was considered a stream - because `response.body` always has type `ReadableStream`. 
An alterative approach is to explicitly state an intent of getting a stream - so we optionally pass a resneponse handler into the `fetch` operation and get what we need.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
