### PR TITLE
[Next.js] sitemap.xml endpoint returns 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud ([#2019](https://github.com/Sitecore/jss/pull/2019))
-* `[templates/next.js]` Simplify sitemap.xml handling ([#2023](https://github.com/Sitecore/jss/pull/2023))
+* `[templates/next.js]` sitemap.xml endpoint returns 404 ([#2023](https://github.com/Sitecore/jss/pull/2023))
 
 ## 22.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Fix Chromes editing mode when rendering host URL is internally redirected in XMCloud ([#2019](https://github.com/Sitecore/jss/pull/2019))
-* `[sitecore-jss]` NativeDataFetcher doesn't return stream response ([#2020](https://github.com/Sitecore/jss/pull/2020))
+* `[templates/next.js]` Simplify sitemap.xml handling ([#2023](https://github.com/Sitecore/jss/pull/2023))
 
 ## 22.4.0
 

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -38,12 +38,10 @@ const sitemapApi = async (
       const fetcher = new NativeDataFetcher();
       const xmlResponse = await fetcher.fetch<string>(sitemapUrl);
 
-      res.send(xmlResponse.data);
+      return res.send(xmlResponse.data);
     } catch (error) {
       return res.redirect('/404');
     }
-
-    return;
   }
 
   // index /sitemap.xml that includes links to all sitemaps

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -36,19 +36,9 @@ const sitemapApi = async (
 
     try {
       const fetcher = new NativeDataFetcher();
-      const response = await fetcher.fetch<ReadableStream<Uint8Array>>(sitemapUrl);
+      const xmlResponse = await fetcher.fetch<string>(sitemapUrl);
 
-      const reader = response.data.getReader();
-      if (reader) {
-        while (true) {
-          const { done, value } = await reader.read();
-
-          if (done) break;
-          if (value) res.write(value);
-        }
-      }
-
-      res.end();
+      res.send(xmlResponse.data);
     } catch (error) {
       return res.redirect('/404');
     }

--- a/packages/sitecore-jss/src/native-fetcher.test.ts
+++ b/packages/sitecore-jss/src/native-fetcher.test.ts
@@ -136,30 +136,6 @@ describe('NativeDataFetcher', () => {
       expect(fetchInit?.body).to.be.undefined;
     });
 
-    it('should execute request with stream response type', async () => {
-      const fetcher = new NativeDataFetcher();
-
-      const fakeRes = { body: new ReadableStream() };
-
-      spy.on(
-        global,
-        'fetch',
-        mockFetch(200, fakeRes, {
-          customHeaders: {
-            'Content-Type': 'text/xml',
-          },
-        })
-      );
-
-      const response = await fetcher.fetch('http://test.com/api');
-
-      expect(response.status).to.equal(200);
-      expect(response.data instanceof ReadableStream).to.be.true;
-      expect(fetchInput).to.equal('http://test.com/api');
-      expect(fetchInit?.method).to.equal('GET');
-      expect(fetchInit?.body).to.be.undefined;
-    });
-
     it('should execute POST request with data', async () => {
       const fetcher = new NativeDataFetcher();
       const postData = { x: 'val1', y: 'val2' };

--- a/packages/sitecore-jss/src/native-fetcher.ts
+++ b/packages/sitecore-jss/src/native-fetcher.ts
@@ -216,13 +216,10 @@ export class NativeDataFetcher {
     debug: (message: string, ...optionalParams: any[]) => void
   ): Promise<unknown> {
     const contentType = response.headers.get('Content-Type') || '';
+
     try {
       if (contentType.includes('application/json')) {
         return await response.json();
-      }
-
-      if (response.body instanceof ReadableStream) {
-        return response.body;
       }
 
       return await response.text();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
Streamlined the implementation of the api/sitemap API route by replacing the use of the Streams API
Fixed the bug when api/sitemap API endpoint returned 404
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
