### PR TITLE
[Component Library] accept dataSourceId query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000)[#2002](https://github.com/Sitecore/jss/pull/2002)[#2005](https://github.com/Sitecore/jss/pull/2005))
+* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000)[#2002](https://github.com/Sitecore/jss/pull/2002)[#2005](https://github.com/Sitecore/jss/pull/2005)[#2024](https://github.com/Sitecore/jss/pull/2024))
 
 ### 🐛 Bug Fixes
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.test.ts
@@ -216,7 +216,7 @@ describe('EditingRenderMiddleware', () => {
         sc_version: 'latest',
         secret: secret,
         sc_renderingId: '123',
-        sc_datasourceId: '456',
+        dataSourceId: '456',
         sc_uid: '789',
       };
 
@@ -237,7 +237,7 @@ describe('EditingRenderMiddleware', () => {
           site: query.sc_site,
           pageState: 'normal',
           mode: 'library',
-          dataSourceId: query.sc_datasourceId,
+          dataSourceId: query.dataSourceId,
           version: query.sc_version,
         });
 

--- a/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-render-middleware.ts
@@ -392,7 +392,7 @@ export class MetadataHandler {
           site: query.sc_site,
           pageState: LayoutServicePageState.Normal,
           mode: 'library',
-          dataSourceId: query.sc_datasourceId,
+          dataSourceId: query.dataSourceId,
           version: query.sc_version,
         } as ComponentLibraryRenderPreviewData,
         {

--- a/packages/sitecore-jss/src/editing/rest-component-layout-service.ts
+++ b/packages/sitecore-jss/src/editing/rest-component-layout-service.ts
@@ -60,11 +60,12 @@ export class RestComponentLayoutService extends RestLayoutService {
     params.siteName = params.siteName || this.config.siteName;
     const querystringParams = this.getComponentFetchParams(params);
     debug.layout(
-      'fetching component with uid %s for %s %s %s',
+      'fetching component with uid %s for %s %s %s %s',
       params.componentUid,
       params.itemId,
       params.language,
-      params.siteName
+      params.siteName,
+      params.dataSourceId
     );
     const fetcher = this.getFetcher(req, res);
 


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Replaces `sc_datasourceId` expected by render middleware before by `dataSourceId` query string parameter.
Also logs datasource ID by component layout service, when present.

## Testing Details
- [x] Unit Test Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [?] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
