### PR TITLE
[Chore] Use 'feature' tag instead of 'beta'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ steps:
   # * Only run for 'dev' and 'release' branches
   #
 - script: |
-    npm exec -- lerna version prerelease --exact --preid beta --force-publish --message "version %s [skip ci]" --yes
+    npm exec -- lerna version prerelease --exact --preid feature --force-publish --message "version %s [skip ci]" --yes
   displayName: 'pre-release version update'
   condition: and(succeeded(), eq(variables.shouldPublish, true))
   env:
@@ -133,7 +133,7 @@ steps:
   #
 - script: |
     echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-    npm exec -- lerna publish from-git --canary --pre-dist-tag beta --preid beta --no-verify-access --yes
+    npm exec -- lerna publish from-git --canary --pre-dist-tag feature --preid feature --no-verify-access --yes
   displayName: 'pre-release canary publish'
   condition: and(succeeded(), eq(variables.shouldPublish, true))
   env:

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "3.22.1",
   "packages": ["packages/*", "samples/*"],
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/create-sitecore-jss/package.json
+++ b/packages/create-sitecore-jss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-sitecore-jss",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "Sitecore JSS initializer",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/sitecore-jss-angular-schematics/package.json
+++ b/packages/sitecore-jss-angular-schematics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-angular-schematics",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "Scaffolding schematics for Sitecore JSS Angular apps",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/sitecore-jss-angular/package.json
+++ b/packages/sitecore-jss-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-angular",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "",
   "scripts": {
     "build": "ng-packagr -p ng-package.json",
@@ -60,7 +60,7 @@
     "rxjs": "~7.8.1"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2"
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0"
   },
   "main": "dist/esm2022/sitecore-jss-sitecore-jss-angular.mjs",
   "module": "dist/esm2022/sitecore-jss-sitecore-jss-angular.js",

--- a/packages/sitecore-jss-cli/package.json
+++ b/packages/sitecore-jss-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-cli",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "Sitecore JSS command-line",
   "main": "dist/cjs/cli.js",
   "module": "dist/esm/cli.js",
@@ -32,7 +32,7 @@
     "url": "https://github.com/sitecore/jss/issues"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss-dev-tools": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss-dev-tools": "22.5.0-feature.0",
     "chalk": "^4.1.2",
     "cross-spawn": "^7.0.3",
     "dotenv": "^16.0.3",

--- a/packages/sitecore-jss-dev-tools/package.json
+++ b/packages/sitecore-jss-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-dev-tools",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "Utilities to assist in the development and deployment of Sitecore JSS apps.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.24.0",
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.6.0",
     "del": "^6.0.0",

--- a/packages/sitecore-jss-forms/package.json
+++ b/packages/sitecore-jss-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-forms",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -42,7 +42,7 @@
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2"
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0"
   },
   "description": "",
   "types": "types/index.d.ts",

--- a/packages/sitecore-jss-nextjs/package.json
+++ b/packages/sitecore-jss-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-nextjs",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -73,9 +73,9 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2",
-    "@sitecore-jss/sitecore-jss-dev-tools": "22.5.0-beta.2",
-    "@sitecore-jss/sitecore-jss-react": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0",
+    "@sitecore-jss/sitecore-jss-dev-tools": "22.5.0-feature.0",
+    "@sitecore-jss/sitecore-jss-react": "22.5.0-feature.0",
     "@vercel/kv": "^0.2.1",
     "prop-types": "^15.8.1",
     "regex-parser": "^2.2.11",

--- a/packages/sitecore-jss-proxy/package.json
+++ b/packages/sitecore-jss-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-proxy",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "Middlewares, utilities to work in a headless mode",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@sitecore-cloudsdk/core": "^0.4.2",
     "@sitecore-cloudsdk/personalize": "^0.4.2",
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0",
     "http-proxy-middleware": "^2.0.6",
     "http-status-codes": "^2.2.0",
     "set-cookie-parser": "^2.5.1"

--- a/packages/sitecore-jss-react-forms/package.json
+++ b/packages/sitecore-jss-react-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react-forms",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -54,7 +54,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss-forms": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss-forms": "22.5.0-feature.0",
     "prop-types": "^15.8.1"
   },
   "description": "",

--- a/packages/sitecore-jss-react-native/package.json
+++ b/packages/sitecore-jss-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react-native",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "url": "https://github.com/sitecore/jss/issues"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0",
     "prop-types": "^15.7.2",
     "react-native-htmlview": "^0.15.0",
     "react-native-svg": "^5.3.0",

--- a/packages/sitecore-jss-react/package.json
+++ b/packages/sitecore-jss-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-react",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,
@@ -61,7 +61,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2",
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0",
     "fast-deep-equal": "^3.1.3",
     "prop-types": "^15.8.1",
     "style-attr": "^1.3.0"

--- a/packages/sitecore-jss-rendering-host/package.json
+++ b/packages/sitecore-jss-rendering-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-rendering-host",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/sitecore-jss-vue/package.json
+++ b/packages/sitecore-jss-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss-vue",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "description": "A library for building Sitecore JSS apps using Vue.js",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -48,7 +48,7 @@
     "vue": "^3.5.12"
   },
   "dependencies": {
-    "@sitecore-jss/sitecore-jss": "22.5.0-beta.2"
+    "@sitecore-jss/sitecore-jss": "22.5.0-feature.0"
   },
   "types": "./types/index.d.ts",
   "gitHead": "2f4820efddf4454eeee58ed1b2cc251969efdf5b",

--- a/packages/sitecore-jss/package.json
+++ b/packages/sitecore-jss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitecore-jss/sitecore-jss",
-  "version": "22.5.0-beta.2",
+  "version": "22.5.0-feature.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5869,7 +5869,7 @@ __metadata:
     "@angular/platform-browser-dynamic": ~17.3.11
     "@angular/router": ~17.3.11
     "@sitecore-cloudsdk/events": ^0.4.2
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/jasmine": ^5.1.4
     "@types/node": ^22.9.0
     codelyzer: ^6.0.1
@@ -5900,7 +5900,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-cli@workspace:packages/sitecore-jss-cli"
   dependencies:
-    "@sitecore-jss/sitecore-jss-dev-tools": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss-dev-tools": 22.5.0-feature.0
     "@types/chai": ^4.2.4
     "@types/cross-spawn": ^6.0.2
     "@types/mocha": ^10.0.1
@@ -5932,14 +5932,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-dev-tools@22.5.0-beta.2, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
+"@sitecore-jss/sitecore-jss-dev-tools@22.5.0-feature.0, @sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-dev-tools@workspace:packages/sitecore-jss-dev-tools"
   dependencies:
     "@babel/core": ^7.24.4
     "@babel/parser": ^7.24.0
     "@babel/register": ^7.23.7
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/chokidar": ^2.1.3
     "@types/del": ^4.0.0
@@ -5990,11 +5990,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-forms@22.5.0-beta.2, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
+"@sitecore-jss/sitecore-jss-forms@22.5.0-feature.0, @sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-forms@workspace:packages/sitecore-jss-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/lodash.unescape": ^4.0.7
@@ -6018,9 +6018,9 @@ __metadata:
   dependencies:
     "@sitecore-cloudsdk/core": ^0.4.2
     "@sitecore-cloudsdk/personalize": ^0.4.2
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
-    "@sitecore-jss/sitecore-jss-dev-tools": 22.5.0-beta.2
-    "@sitecore-jss/sitecore-jss-react": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
+    "@sitecore-jss/sitecore-jss-dev-tools": 22.5.0-feature.0
+    "@sitecore-jss/sitecore-jss-react": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/chai-as-promised": ^7.1.5
     "@types/chai-string": ^1.4.2
@@ -6073,7 +6073,7 @@ __metadata:
   dependencies:
     "@sitecore-cloudsdk/core": ^0.4.2
     "@sitecore-cloudsdk/personalize": ^0.4.2
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/express": ^4.17.17
     "@types/mocha": ^10.0.1
@@ -6105,7 +6105,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react-forms@workspace:packages/sitecore-jss-react-forms"
   dependencies:
-    "@sitecore-jss/sitecore-jss-forms": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss-forms": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/enzyme": ^3.10.12
     "@types/mocha": ^10.0.1
@@ -6145,7 +6145,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": ^7.5.2
     "@babel/preset-env": ^7.6.2
     "@babel/preset-typescript": ^7.6.0
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/jest": ^24.0.18
     "@types/prop-types": ^15.7.3
     "@types/react": ^16.9.5
@@ -6175,12 +6175,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss-react@22.5.0-beta.2, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
+"@sitecore-jss/sitecore-jss-react@22.5.0-feature.0, @sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-react@workspace:packages/sitecore-jss-react"
   dependencies:
     "@sitecore-feaas/clientside": ^0.5.19
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/chai": ^4.3.4
     "@types/chai-string": ^1.4.2
     "@types/enzyme": ^3.10.12
@@ -6253,7 +6253,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss-vue@workspace:packages/sitecore-jss-vue"
   dependencies:
-    "@sitecore-jss/sitecore-jss": 22.5.0-beta.2
+    "@sitecore-jss/sitecore-jss": 22.5.0-feature.0
     "@types/jest": ^29.2.6
     "@types/node": ^22.9.0
     "@vue/compiler-dom": ^3.5.12
@@ -6275,7 +6275,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@sitecore-jss/sitecore-jss@22.5.0-beta.2, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
+"@sitecore-jss/sitecore-jss@22.5.0-feature.0, @sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss":
   version: 0.0.0-use.local
   resolution: "@sitecore-jss/sitecore-jss@workspace:packages/sitecore-jss"
   dependencies:


### PR DESCRIPTION
'beta' suffix resolves both `canary` and `beta` versions when used by npm:
https://semver.npmjs.com/

This leads to `22.5.0-beta` version to be resolved to `canary` instead.

If we use a unique suffix name we won't have this problem.