### PR TITLE
[Angular] Remove unnecessary PROXY_HOST setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-angular]` Support `CanActivate` `RedirectCommand` API ([#2029](https://github.com/Sitecore/jss/pull/2029))
 * `[sitecore-jss-angular]` `CanActivate` and `CanResolve` now additionally accept `router` as a parameter ([#2029](https://github.com/Sitecore/jss/pull/2029))
-* `[templates/angular]` Remove unnecessary PROXY_HOST setting ([#2036](https://github.com/Sitecore/jss/pull/2036))
+* `[templates/angular]` Remove unnecessary PROXY_HOST setting ([#2036](https://github.com/Sitecore/jss/pull/2036)):
+  * The environment variable `PROXY_HOST` is no longer required and can be fully removed from the application.
 
 ### 🛠 Breaking Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-angular]` Support `CanActivate` `RedirectCommand` API ([#2029](https://github.com/Sitecore/jss/pull/2029))
 * `[sitecore-jss-angular]` `CanActivate` and `CanResolve` now additionally accept `router` as a parameter ([#2029](https://github.com/Sitecore/jss/pull/2029))
+* `[templates/angular]` Remove unnecessary PROXY_HOST setting ([#2036](https://github.com/Sitecore/jss/pull/2036))
 
 ### 🛠 Breaking Change
 

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/.env
@@ -7,9 +7,6 @@ SITECORE_EDGE_CONTEXT_ID=
 
 # ========== XM Cloud Proxy ===========
 
-# Your XM Cloud Proxy hostname is needed to build the app and execute the client-side requests against the proxy server.
-PROXY_HOST=http://localhost:3000
-
 # Your XM Cloud Proxy server path is needed to build the app. The build output will be copied to the proxy server path.
 # Use a relative unix style path to ensure compatibility when deployment runs on Windows or Unix based systems. 
 PROXY_BUILD_PATH=<%- locals.relativeProxyAppDestination.replace(/\\/g, '\/') %>dist

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/README.md
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/README.md
@@ -77,7 +77,6 @@ The following environment variables can be used to configure the angular app. Yo
 
 | Parameter                              | Description                                                                                                                                |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `PROXY_HOST`                        | Your XM Cloud Proxy hostname is needed to build the app and execute the client-side requests against the proxy server. Default value `http://localhost:3000`                                                                                                                  |
 | `PROXY_BUILD_PATH`                              | Your XM Cloud Proxy server path is needed to build the app. The build output will be copied to the XM Cloud Proxy application path. Default value `<xmcloud_proxy_path>\dist`.
 | `SITECORE_EDGE_CONTEXT_ID`                              | The Context ID, which covers many system configurations, is required for connecting to the XM Cloud back end. This is an XM Cloud system environment variable. When the application runs on the XM Cloud editing host, this value is always set to the preview Context ID.                   |
 | `SITECORE_API_KEY`                              | The API key for GRAPH_QL_ENDPOINT authentication. It should be used in combination with SITECORE_API_HOST for local development when connecting to a local XM Cloud instance

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/scripts/config/plugins/xmcloud.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/scripts/config/plugins/xmcloud.ts
@@ -12,7 +12,6 @@ class XMCloudPlugin implements ConfigPlugin {
 
   async exec(config: JssConfig) {
     const proxyBuildPath = process.env[`${constantCase('proxyBuildPath')}`]?.replace(/\/$/, '');
-    const proxyHost = process.env[`${constantCase('proxyHost')}`];
 
     const sitecoreEdgeUrl =
       process.env[`${constantCase('sitecoreEdgeUrl')}`]?.replace(/\/$/, '') ||
@@ -30,7 +29,6 @@ class XMCloudPlugin implements ConfigPlugin {
 
     return Object.assign({}, config, {
       proxyBuildPath,
-      proxyHost,
       sitecoreEdgeUrl,
       sitecoreEdgeContextId,
       personalizeScope,

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/lib/config.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/lib/config.ts
@@ -11,7 +11,6 @@ export interface JssConfig extends Record<string, string | boolean | undefined> 
   graphQLEndpointPath?: string;
   defaultServerRoute?: string;
   proxyBuildPath?: string;
-  proxyHost?: string;
   sitecoreEdgeUrl?: string;
   sitecoreEdgeContextId?: string;
 }

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/lib/graphql-client-factory/config.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/lib/graphql-client-factory/config.ts
@@ -17,15 +17,11 @@ export const getGraphQLClientFactoryConfig = () => {
   const isProduction = env.production === 'true';
 
   if (isProduction) {
-    if (!env.proxyHost) {
-      throw new Error('Please configure your proxyHost.');
-    }
-
     if (env.sitecoreEdgeContextId) {
       clientConfig = {
         endpoint: isServer
           ? getEdgeProxyContentUrl(env.sitecoreEdgeContextId, env.sitecoreEdgeUrl)
-          : getEdgeProxyContentUrl(env.sitecoreEdgeContextId, env.proxyHost),
+          : getEdgeProxyContentUrl(env.sitecoreEdgeContextId, ''),
       };
     } else if (env.graphQLEndpoint && env.sitecoreApiKey) {
       // we ignore ssr-proxy and query CM directly in case apiKey is used (i.e. in dev docker deployments)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The `PROXY_HOST` setting was initially introduced to construct the target request URL, as all requests are routed through a proxy during client-side navigation. However, further investigation has shown that this setting is no longer needed. The request URL can be built without the base URL, by automatically resolving to the current hostname (which serves as the proxy URL). Removing `PROXY_HOST` will simplify the configuration without impacting functionality.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
