### PR TITLE
[sitecore-jss-nextjs]: Update Link.tsx to support next/link's prefetch property

### DIFF
--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import NextLink from 'next/link';
+import { LinkProps as NextLinkProps } from 'next/link';
 import {
   Link as ReactLink,
   LinkFieldValue,
@@ -15,6 +16,11 @@ export type LinkProps = ReactLinkProps & {
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
+  
+  /**
+   * Support next/link's prefetch prop.
+   */
+  prefetch?: NextLinkProps['prefetch'];
 };
 
 /**
@@ -68,6 +74,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             title={value.title}
             target={value.target}
             className={value.class}
+            prefetch={props.prefetch}
             {...htmlLinkProps}
             ref={ref}
           >
@@ -78,9 +85,10 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       }
     }
 
-    // prevent passing internalLinkMatcher as it is an invalid DOM element prop
+    // prevent passing internalLinkMatcher or prefetch as it is an invalid DOM element prop
     const reactLinkProps = { ...props };
     delete reactLinkProps.internalLinkMatcher;
+    delete reactLinkProps.prefetch;
 
     return <ReactLink {...reactLinkProps} ref={ref} />;
   }

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -16,7 +16,7 @@ export type LinkProps = ReactLinkProps & {
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
-  
+
   /**
    * Support next/link's prefetch prop.
    */


### PR DESCRIPTION
The `Link` component in the `sitecore-jss-nextjs` package does not currently support the prefetch prop from Next.js's `<Link/>` component. This limitation prevents developers from conditionally utilizing Next.js's prefetching capabilities for internal links. Prefetching can improve page load performance by preloading linked pages in the background; however, this can increase hosting costs.

See https://nextjs.org/docs/pages/api-reference/components/link#prefetch

<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without the prefetch property, Next.js defaults to prefetching being enabled. This change exposes the property to allow it to be enabled or disabled as needed. Some applications may prefer to disable it on some links to reduce overall hosting usage. According to the [Vercel documentation on optimizing edge requests](https://vercel.com/docs/pricing/networking#optimizing-edge-requests), reducing the amount of prefetching can decrease the number of requests made to your site, which can help manage hosting costs.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
