### PR TITLE
[Next.js] [RichText] Add support for the "prefetch on hover"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
+* `[sitecore-jss-nextjs]` [RichText] Add support for the "prefetch on hover" ([#2049](https://github.com/Sitecore/jss/pull/2049)):
+  * The `prefetchLinks` property now supports the `hover` value, that allows prefetching internal links on hover.
 * `[sitecore-jss-nextjs]` Refactor RedirectsMiddleware for better extensibility ([#2040](https://github.com/Sitecore/jss/pull/2040))([#2048](https://github.com/Sitecore/jss/pull/2048)):
   * Introduced `processRedirectRequest` that can be overridden in custom middleware.
 * `[sitecore-jss-nextjs]` Link component supports `prefetch` property ([#2039](https://github.com/Sitecore/jss/pull/2039))([#2046](https://github.com/Sitecore/jss/pull/2046))
@@ -21,7 +23,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[templates/nextjs-sxa]` Fixed unsafe property access by replacing direct calls with optional chaining ([#2035](https://github.com/Sitecore/jss/pull/2035))
-* `[sitecore-jss-react]` Extend `PlaceholderProps` to support `Item` type field [#2043](https://github.com/Sitecore/jss/pull/2043)
+* `[sitecore-jss-react]` Extend `PlaceholderProps` to support `Item` type field ([#2043](https://github.com/Sitecore/jss/pull/2043))
 
 ## 22.5.0
 

--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -5,7 +5,7 @@ import { RichText as ReactRichText } from '@sitecore-jss/sitecore-jss-react';
 import { NextRouter } from 'next/router';
 import { mount } from 'enzyme';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
-import { RichText } from './RichText';
+import { prefetched, RichText } from './RichText';
 import { SinonSpy, spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 
@@ -38,6 +38,14 @@ const Page = ({ children, value }: { children: ReactNode; value?: any }) => (
 );
 
 describe('RichText', () => {
+  beforeEach(() => {
+    // Clear prefetched links state
+    Object.keys(prefetched).forEach((key) => delete prefetched[key]);
+
+    // Clear the document body
+    document.body.innerHTML = '';
+  });
+
   it('should initialize links', () => {
     const app = document.createElement('main');
 
@@ -351,7 +359,7 @@ describe('RichText', () => {
     expect(c.find(ReactRichText).length).to.equal(1);
   });
 
-  it('Should not call prefetch when prefetchLinks is set to false', () => {
+  it('should not call prefetch when prefetchLinks is set to false', () => {
     const app = document.createElement('main');
 
     document.body.appendChild(app);
@@ -378,6 +386,43 @@ describe('RichText', () => {
     expect(c.html()).contains('<a href="/notprefetched2">2</a>');
 
     expect(router.prefetch).callCount(0);
+  });
+
+  it('should call prefetch when prefetchLinks is set to hover', () => {
+    const app = document.createElement('main');
+
+    document.body.appendChild(app);
+
+    const router = Router();
+
+    const props = {
+      field: {
+        value:
+          '<div id="test"><h1>Prefetch test!</h1><a href="/hoverprefetched1">1</a><a href="/hoverprefetched2">2</a></div>',
+      },
+    };
+
+    const c = mount(
+      <Page value={router}>
+        <RichText {...props} prefetchLinks="hover" />
+      </Page>,
+      { attachTo: app }
+    );
+
+    expect(c.html()).contains('<div id="test">');
+    expect(c.html()).contains('<h1>Prefetch test!</h1>');
+    expect(c.html()).contains('<a href="/hoverprefetched1">1</a>');
+    expect(c.html()).contains('<a href="/hoverprefetched2">2</a>');
+
+    const main = document.querySelector('main');
+    const links = main && main.querySelectorAll('a');
+    const link1 = links && links[0];
+    const link2 = links && links[1];
+
+    link1 && link1.dispatchEvent(new MouseEvent('mouseover'));
+    link2 && link2.dispatchEvent(new MouseEvent('mouseover'));
+
+    expect(router.prefetch).callCount(2);
   });
 
   describe('editMode metadata', () => {

--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -416,13 +416,19 @@ describe('RichText', () => {
 
     const main = document.querySelector('main');
     const links = main && main.querySelectorAll('a');
-    const link1 = links && links[0];
-    const link2 = links && links[1];
+    const link1 = (links && links[0])!;
+    const link2 = (links && links[1])!;
 
-    link1 && link1.dispatchEvent(new MouseEvent('mouseover'));
-    link2 && link2.dispatchEvent(new MouseEvent('mouseover'));
+    link1.dispatchEvent(new MouseEvent('mouseover'));
+    link2.dispatchEvent(new MouseEvent('mouseover'));
+
+    // Verify that prefetch called only once for each link
+    link1.dispatchEvent(new MouseEvent('mouseover'));
+    link2.dispatchEvent(new MouseEvent('mouseover'));
 
     expect(router.prefetch).callCount(2);
+    expect(prefetched['/hoverprefetched1']).to.equal(true);
+    expect(prefetched['/hoverprefetched2']).to.equal(true);
   });
 
   describe('editMode metadata', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
The `prefetchLinks` property now supports the `hover` value, that allows prefetching internal links on hover.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
