### PR TITLE
[sitecore-jss-nextjs] Fix redirects when matching URLs and search params present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+* `[sitecore-jss-nextjs]` When redirect rule was not using regex and was only matching a path (without query string), incoming matching URLs were ignored when query string is present. This has been fixed ([#2050](https://github.com/Sitecore/jss/pull/2050))
+* `[sitecore-jss-nextjs]` Fixed redirect header from previous middleware execution not being cleaned up correctly.
+
 ## 22.5.1
 
 ### 🎉 New Features & Improvements

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
@@ -3,7 +3,7 @@ import chai, { use } from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import chaiString from 'chai-string';
-import { MiddlewareBase } from './middleware';
+import { MiddlewareBase, REWRITE_HEADER_NAME } from './middleware';
 import { NextRequest, NextResponse } from 'next/server';
 import { SiteResolver } from '@sitecore-jss/sitecore-jss/site';
 
@@ -280,5 +280,59 @@ describe('MiddlewareBase', () => {
 
     expect(middleware['getSite'](req, res).hostName).to.equal('yyy.net');
     expect(siteResolver.getByHost).to.be.calledWith('yyy.net');
+  });
+  xdescribe('rewrite', () => {
+    let rewriteStub = sinon.stub();
+    before(() => {
+      rewriteStub = sinon.stub(NextResponse, 'rewrite').callsFake((rewritePath) => {
+        return createRes({
+          url: typeof rewritePath === 'string' ? rewritePath : rewritePath.pathname,
+          headers: new Map<string, unknown>(),
+        });
+      });
+    });
+
+    after(() => {
+      rewriteStub.restore();
+    });
+
+    it('should rewrite path and add header by default', () => {
+      const middleware = new SampleMiddleware({ siteResolver: new MockSiteResolver([]) });
+      const cloneUrl = () => Object.assign({}, req.nextUrl);
+      const url = {
+        clone: cloneUrl,
+        href: 'http://localhost:3000/not-found',
+        locale: 'en',
+        pathname: 'http://localhost:3000/found',
+      };
+      const req = createReq({
+        nextUrl: url,
+      });
+      const res = createRes();
+
+      const response = middleware['rewrite']('/new', req, res);
+
+      expect(response.headers.get(REWRITE_HEADER_NAME)).to.equal('/new');
+      expect(response.url).to.endWith('/new');
+    });
+
+    it('should rewrite path and not rewrite header when skipHeader is true', () => {
+      const middleware = new SampleMiddleware({ siteResolver: new MockSiteResolver([]) });
+      const cloneUrl = () => Object.assign({}, req.nextUrl);
+      const url = {
+        clone: cloneUrl,
+        href: 'http://localhost:3000/not-found',
+        locale: 'en',
+        pathname: 'http://localhost:3000/found',
+      };
+      const req = createReq({
+        nextUrl: url,
+      });
+      const res = createRes();
+
+      const response = middleware['rewrite']('/new', req, res, true);
+      expect(response.headers.get(REWRITE_HEADER_NAME)).to.be.undefined;
+      expect(response.url).to.endWith('/new');
+    });
   });
 });

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
@@ -1,6 +1,8 @@
 import { SiteInfo, SiteResolver } from '@sitecore-jss/sitecore-jss/site';
 import { NextRequest, NextResponse } from 'next/server';
 
+export const REWRITE_HEADER_NAME = 'x-sc-rewrite';
+
 export type MiddlewareBaseConfig = {
   /**
    * function, determines if middleware should be turned off, based on cookie, header, or other considerations
@@ -29,7 +31,6 @@ export type MiddlewareBaseConfig = {
 
 export abstract class MiddlewareBase {
   protected SITE_SYMBOL = 'sc_site';
-  protected REWRITE_HEADER_NAME = 'x-sc-rewrite';
   protected defaultHostname: string;
 
   constructor(protected config: MiddlewareBaseConfig) {
@@ -129,7 +130,7 @@ export abstract class MiddlewareBase {
     const response = NextResponse.rewrite(rewriteUrl, res);
 
     // Share rewrite path with following executed middlewares
-    response.headers.set(this.REWRITE_HEADER_NAME, rewritePath);
+    response.headers.set(REWRITE_HEADER_NAME, rewritePath);
 
     return response;
   }

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
@@ -121,16 +121,23 @@ export abstract class MiddlewareBase {
    * @param {string} rewritePath the destionation path
    * @param {NextRequest} req the current request
    * @param {NextResponse} res the current response
+   * @param {boolean} [skipHeader] don't write 'x-sc-rewrite' header
    */
-  protected rewrite(rewritePath: string, req: NextRequest, res: NextResponse): NextResponse {
+  protected rewrite(
+    rewritePath: string,
+    req: NextRequest,
+    res: NextResponse,
+    skipHeader?: boolean
+  ): NextResponse {
     // Note an absolute URL is required: https://nextjs.org/docs/messages/middleware-relative-urls
     const rewriteUrl = req.nextUrl.clone();
     rewriteUrl.pathname = rewritePath;
-
     const response = NextResponse.rewrite(rewriteUrl, res);
 
     // Share rewrite path with following executed middlewares
-    response.headers.set(REWRITE_HEADER_NAME, rewritePath);
+    if (!skipHeader) {
+      response.headers.set(REWRITE_HEADER_NAME, rewritePath);
+    }
 
     return response;
   }

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_VARIANT,
 } from '@sitecore-jss/sitecore-jss/personalize';
 import { debug } from '@sitecore-jss/sitecore-jss';
-import { MiddlewareBase, MiddlewareBaseConfig } from './middleware';
+import { MiddlewareBase, MiddlewareBaseConfig, REWRITE_HEADER_NAME } from './middleware';
 import { CloudSDK } from '@sitecore-cloudsdk/core/server';
 import { personalize } from '@sitecore-cloudsdk/personalize/server';
 
@@ -347,7 +347,7 @@ export class PersonalizeMiddleware extends MiddlewareBase {
     }
 
     // Path can be rewritten by previously executed middleware
-    const basePath = res?.headers.get('x-sc-rewrite') || pathname;
+    const basePath = res?.headers.get(REWRITE_HEADER_NAME) || pathname;
 
     // Rewrite to persononalized path
     const rewritePath = getPersonalizedRewrite(basePath, identifiedVariantIds);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -498,9 +498,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {
-            'x-sc-rewrite': 'http://localhost:3000/found',
-          },
+          headers: {},
           redirected: undefined,
           status: 200,
           url,
@@ -551,9 +549,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {
-            'x-sc-rewrite': 'http://localhost:3000/found?abc=def',
-          },
+          headers: {},
           redirected: undefined,
           status: 200,
           url,
@@ -995,9 +991,7 @@ describe('RedirectsMiddleware', () => {
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {
-            'x-sc-rewrite': 'http://localhost:3000/found',
-          },
+          headers: {},
           redirected: undefined,
           status: 200,
           url,

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -14,6 +14,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import sinon, { spy } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { RedirectsMiddleware } from './redirects-middleware';
+import { REWRITE_HEADER_NAME } from './middleware';
 
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
@@ -705,6 +706,57 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
+      it('should redirect without QS, when url has query string, pattern doesnt and query string not preserved', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/found',
+          pathname: '/found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+        setupRedirectStub(301);
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/not-found',
+              search: '?abc=def',
+              href: 'http://localhost:3000/not-found?abc=def',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: 'not-found',
+            target: '/found',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req
+        );
+
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
+        });
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes).to.deep.equal(res);
+        expect(finalRes.status).to.equal(res.status);
+      });
+
       it('should redirect uses token in target', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
@@ -1306,7 +1358,7 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
-      it('should remove x-middleware-next/x-middleware-rewrite headers and redirect 301', async () => {
+      it('should remove rewrite headers and redirect 301', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
           clone: cloneUrl,
@@ -1332,6 +1384,7 @@ describe('RedirectsMiddleware', () => {
         setupRedirectStub(301);
         res.headers.set('x-middleware-next', '1');
         res.headers.set('x-middleware-rewrite', '1');
+        res.headers.set(REWRITE_HEADER_NAME, 1);
 
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
@@ -1354,6 +1407,7 @@ describe('RedirectsMiddleware', () => {
         // Check that the headers were not removed
         expect(finalRes.headers.has('x-middleware-next')).to.equal(false);
         expect(finalRes.headers.has('x-middleware-rewrite')).to.equal(false);
+        expect(finalRes.headers.has(REWRITE_HEADER_NAME)).to.equal(false);
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
@@ -1566,7 +1620,7 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
-      it('should return a 302 redirect', async () => {
+      it('should clean redirect headers and return a 302 redirect', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
           clone: cloneUrl,
@@ -1592,6 +1646,9 @@ describe('RedirectsMiddleware', () => {
           status: 302,
         });
         setupRedirectStub(302);
+        res.headers.set('x-middleware-next', '1');
+        res.headers.set('x-middleware-rewrite', '1');
+        res.headers.set(REWRITE_HEADER_NAME, 1);
 
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
@@ -1610,6 +1667,11 @@ describe('RedirectsMiddleware', () => {
           status: 302,
           url,
         });
+
+        // Check that the headers were not removed
+        expect(finalRes.headers.has('x-middleware-next')).to.equal(false);
+        expect(finalRes.headers.has('x-middleware-rewrite')).to.equal(false);
+        expect(finalRes.headers.has(REWRITE_HEADER_NAME)).to.equal(false);
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -17,7 +17,7 @@ import {
 import { NextURL } from 'next/dist/server/web/next-url';
 import { NextRequest, NextResponse } from 'next/server';
 import regexParser from 'regex-parser';
-import { MiddlewareBase, MiddlewareBaseConfig } from './middleware';
+import { MiddlewareBase, MiddlewareBaseConfig, REWRITE_HEADER_NAME } from './middleware';
 
 const REGEXP_CONTEXT_SITE_LANG = new RegExp(/\$siteLang/, 'i');
 const REGEXP_ABSOLUTE_URL = new RegExp('^(?:[a-z]+:)?//', 'i');
@@ -94,17 +94,16 @@ export class RedirectsMiddleware extends MiddlewareBase {
     return modifyRedirects.length
       ? modifyRedirects.find((redirect: RedirectResult) => {
           if (isRegexOrUrl(redirect.pattern) === 'url') {
-            const parseUrlPattern = redirect.pattern.endsWith('/')
+            const [patternPath, patternQS] = redirect.pattern.endsWith('/')
               ? redirect.pattern.slice(0, -1).split('?')
               : redirect.pattern.split('?');
-
             return (
-              (parseUrlPattern[0] === normalizedPath ||
-                parseUrlPattern[0] === `/${locale}${normalizedPath}`) &&
-              areURLSearchParamsEqual(
-                new URLSearchParams(parseUrlPattern[1] ?? ''),
-                new URLSearchParams(targetQS)
-              )
+              (patternPath === normalizedPath || patternPath === `/${locale}${normalizedPath}`) &&
+              (!patternQS ||
+                areURLSearchParamsEqual(
+                  new URLSearchParams(patternQS),
+                  new URLSearchParams(targetQS)
+                ))
             );
           }
 
@@ -121,6 +120,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
             .replace(/^\^|\$$/g, '') // Further cleans up anchors
             .replace(/\$\/gi$/g, '')}[\/]?$/i`; // Ensures the pattern allows an optional trailing slash
 
+          // Redirect pattern matches the full incoming URL with query string present
           matchedQueryString = [
             regexParser(redirect.pattern).test(`${normalizedPath}${targetQS}`),
             regexParser(redirect.pattern).test(`/${locale}${normalizedPath}${targetQS}`),
@@ -130,7 +130,12 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
           // Save the matched query string (if found) into the redirect object
           redirect.matchedQueryString = matchedQueryString || '';
-
+          debug.redirects('All info: %o', {
+            matchedQueryString,
+            patern: redirect.pattern,
+            targetURL,
+            targetQS,
+          });
           return (
             !!(
               regexParser(redirect.pattern).test(targetURL) ||
@@ -189,6 +194,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
 
       // Find the redirect from result of RedirectService
       const existsRedirect = await this.getExistsRedirect(req, site.name);
+      debug.redirects('Existing redirect: %o', { existsRedirect });
 
       if (!existsRedirect) {
         debug.redirects('skipped (redirect does not exist)');
@@ -350,6 +356,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
     if (res?.headers) {
       redirect.headers.delete('x-middleware-next');
       redirect.headers.delete('x-middleware-rewrite');
+      redirect.headers.delete(REWRITE_HEADER_NAME);
     }
     return redirect;
   }

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -269,7 +269,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
           return this.createRedirectResponse(url, response, 302, 'Found');
         }
         case REDIRECT_TYPE_SERVER_TRANSFER: {
-          return this.rewrite(url.href, req, response);
+          return this.rewrite(url.href, req, response, true);
         }
         default:
           return response;


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixes two main issues:
- Cleans up `x-sc-rewrite` header correctly
- Ensures redirect works with simple urls (`/page-1` -> `/page-2`) when incoming URL has query string.

## Testing Details
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
