### PR TITLE
[sitecore-jss-nextjs] Ensure locales are compared case-insensitively in redirects middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Our versioning strategy is as follows:
 ## Unreleased
 
 ### 🐛 Bug Fixes
-* `[sitecore-jss-nextjs]` Fixes an issue where a more specific redirect rule with locale is not activating when a less specific rule is present. ([#2054](https://github.com/Sitecore/jss/pull/2054))
+* `[sitecore-jss-nextjs]` Fixes an issue where a more specific redirect rule with locale is not activating when a less specific rule is present. ([#2054](https://github.com/Sitecore/jss/pull/2054)[#2056](https://github.com/Sitecore/jss/pull/2056))
 
 * `[sitecore-jss-nextjs]` Fix an endless redirect issue with [/default/(.*) -> /en/$1] redirect rule when nextjs default locale is set to default. ([#2055](https://github.com/Sitecore/jss/pull/2055))
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -775,7 +775,7 @@ describe('RedirectsMiddleware', () => {
           request: {
             nextUrl: {
               pathname: '/not-found',
-              href: 'http://localhost:3000/pl-pl/not-found',
+              href: 'http://localhost:3000/pl-PL/not-found',
               locale: 'pl-PL',
               origin: 'http://localhost:3000',
               clone: cloneUrl,
@@ -788,6 +788,7 @@ describe('RedirectsMiddleware', () => {
           {
             redirectMaps: [
               {
+                // note: lowercase locale in pattern should still match
                 pattern: '/pl-pl/not-found',
                 target: '/found',
                 redirectType: REDIRECT_TYPE_301,

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -144,7 +144,7 @@ describe('RedirectsMiddleware', () => {
       siteResolver,
       ...props,
       clientFactory,
-      locales: ['en', 'ua'],
+      locales: ['en', 'ua', 'pl-PL'],
     });
     const redirectMaps = props.redirectMaps || [];
     if (props.pattern && props.target) {
@@ -775,7 +775,7 @@ describe('RedirectsMiddleware', () => {
           request: {
             nextUrl: {
               pathname: '/not-found',
-              href: 'http://localhost:3000/pl-PL/not-found',
+              href: 'http://localhost:3000/pl-pl/not-found',
               locale: 'pl-PL',
               origin: 'http://localhost:3000',
               clone: cloneUrl,
@@ -788,7 +788,7 @@ describe('RedirectsMiddleware', () => {
           {
             redirectMaps: [
               {
-                pattern: '/pl-PL/not-found',
+                pattern: '/pl-pl/not-found',
                 target: '/found',
                 redirectType: REDIRECT_TYPE_301,
                 isQueryStringPreserved: false,

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -91,18 +91,24 @@ export class RedirectsMiddleware extends MiddlewareBase {
     const language = this.getLanguage(req);
     const modifyRedirects = structuredClone(redirects);
     let matchedQueryString: string | undefined;
-    const localePath = `/${locale}${normalizedPath}`.toLowerCase();
+    const localePath = `/${locale.toLowerCase()}${normalizedPath}`;
 
     return modifyRedirects.length
       ? modifyRedirects.find((redirect: RedirectResult) => {
           // process static URL (non-regex) rules
           if (isRegexOrUrl(redirect.pattern) === 'url') {
-            const [patternPath, patternQS] = redirect.pattern.endsWith('/')
-              ? redirect.pattern
-                  .toLowerCase()
-                  .slice(0, -1)
-                  .split('?')
-              : redirect.pattern.toLowerCase().split('?');
+            const urlArray = redirect.pattern.endsWith('/')
+              ? redirect.pattern.slice(0, -1).split('?')
+              : redirect.pattern.split('?');
+            const patternQS = urlArray[1];
+            let patternPath = urlArray[0];
+            // nextjs routes are case-sensitive, but locales should be compared case-insensitively
+            const patternParts = patternPath.split('/');
+            const maybeLocale = patternParts[1].toLowerCase();
+            // case insensitive lookup of locales
+            if (new RegExp(this.locales.join('|'), 'i').test(maybeLocale)) {
+              patternPath = patternPath.replace(`/${patternParts[1]}`, `/${maybeLocale}`);
+            }
             return (
               (patternPath === localePath || patternPath === normalizedPath) &&
               (!patternQS ||


### PR DESCRIPTION
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
We must ensure redirect rules specified like 'pl-pl/mypath' would still activate if matching 'pl-PL' locale, despite difference in case.

## Testing Details
- [x] Unit Test Adjusted
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
