### PR TITLE
[sitecore-jss][template/nextjs-sxa] Fix `/api/sitemap` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Our versioning strategy is as follows:
   * `SitecoreContext` now supports an `api` property for passing XM Cloud Edge endpoint settings, enabling the `Form` component to access the configured endpoint.
   * Added shared `Form` functionality via the `sitecore-jss/form` submodule.
 
+  ### 🐛 Bug Fixes
+* `[sitecore-jss]``[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058))
+
 ## 22.5.4
 
 ### 🐛 Bug Fixes

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -1,10 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { NativeDataFetcher, GraphQLSitemapXmlService } from '@sitecore-jss/sitecore-jss-nextjs';
 import { siteResolver } from 'lib/site-resolver';
-import config from 'temp/config';
 import clientFactory from 'lib/graphql-client-factory';
-
-const ABSOLUTE_URL_REGEXP = '^(?:[a-z]+:)?//';
 
 const sitemapApi = async (
   req: NextApiRequest,
@@ -30,13 +27,9 @@ const sitemapApi = async (
 
   // regular sitemap
   if (sitemapPath) {
-    const isAbsoluteUrl = sitemapPath.match(ABSOLUTE_URL_REGEXP);
-    const sitemapUrl = isAbsoluteUrl ? sitemapPath : `${config.sitecoreApiHost}${sitemapPath}`;
-    res.setHeader('Content-Type', 'text/xml;charset=utf-8');
-
     try {
       const fetcher = new NativeDataFetcher();
-      const xmlResponse = await fetcher.fetch<string>(sitemapUrl);
+      const xmlResponse = await fetcher.fetch<string>(sitemapPath);
 
       return res.send(xmlResponse.data);
     } catch (error) {
@@ -51,22 +44,23 @@ const sitemapApi = async (
     return res.redirect('/404');
   }
 
-  const reqtHost = req.headers.host;
+  const reqHost = req.headers.host;
   const reqProtocol = req.headers['x-forwarded-proto'] || 'https';
   const SitemapLinks = sitemaps
     .map((item: string) => {
       const parseUrl = item.split('/');
       const lastSegment = parseUrl[parseUrl.length - 1];
+      const escapedUrl = `${reqProtocol}://${reqHost}/${lastSegment}`.replace(/&/g, '&amp;');
 
       return `<sitemap>
-        <loc>${reqProtocol}://${reqtHost}/${lastSegment}</loc>
+        <loc>${escapedUrl}</loc>
       </sitemap>`;
     })
     .join('');
 
   res.setHeader('Content-Type', 'text/xml;charset=utf-8');
 
-  return res.send(`
+  return res.send(`<?xml version="1.0" encoding="UTF-8"?>
   <sitemapindex xmlns="http://sitemaps.org/schemas/sitemap/0.9" encoding="UTF-8">${SitemapLinks}</sitemapindex>
   `);
 };

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
@@ -108,5 +108,17 @@ describe('GraphQLSitemapXmlService', () => {
 
       return expect(nock.isDone()).to.be.true;
     });
+
+    it('should fetch default sitemap when no id is provided', async () => {
+      const defaultSitemap = 'sitemap.xml';
+      const mockSitemapsWithDefault = [...mockSitemaps, defaultSitemap];
+      mockSitemapRequest(mockSitemapsWithDefault);
+
+      const service = new GraphQLSitemapXmlService({ clientFactory, siteName });
+      const sitemaps = await service.getSitemap('');
+
+      expect(sitemaps).to.deep.equal(defaultSitemap);
+      return expect(nock.isDone()).to.be.true;
+    });
   });
 });

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
@@ -84,18 +84,6 @@ describe('GraphQLSitemapXmlService', () => {
       return expect(nock.isDone()).to.be.true;
     });
 
-    it('should get exists sitemap', async () => {
-      const mockIdSitemap = '-3';
-      mockSitemapRequest(mockSitemaps);
-
-      const service = new GraphQLSitemapXmlService({ clientFactory, siteName });
-      const sitemap = await service.getSitemap(mockIdSitemap);
-
-      expect(sitemap).to.deep.equal(mockSitemaps[2]);
-
-      return expect(nock.isDone()).to.be.true;
-    });
-
     it('should get null if sitemap not exists', async () => {
       const mockIdSitemap = '-5';
       mockSitemapRequest(mockSitemaps);
@@ -105,6 +93,18 @@ describe('GraphQLSitemapXmlService', () => {
 
       // eslint-disable-next-line no-unused-expressions
       expect(sitemap).to.be.undefined;
+
+      return expect(nock.isDone()).to.be.true;
+    });
+
+    it('should fetch specific sitemap when id is provided', async () => {
+      const mockIdSitemap = '3';
+      mockSitemapRequest(mockSitemaps);
+
+      const service = new GraphQLSitemapXmlService({ clientFactory, siteName });
+      const sitemaps = await service.getSitemap(mockIdSitemap);
+
+      expect(sitemaps).to.deep.equal(mockSitemaps[2]);
 
       return expect(nock.isDone()).to.be.true;
     });

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.test.ts
@@ -120,5 +120,26 @@ describe('GraphQLSitemapXmlService', () => {
       expect(sitemaps).to.deep.equal(defaultSitemap);
       return expect(nock.isDone()).to.be.true;
     });
+
+    it('should normalize IDs with leading hyphens (e.g., "-1" → "1")', async () => {
+      const mockSitemapsWithHyphenId = [...mockSitemaps, 'sitemap-1.xml'];
+      mockSitemapRequest(mockSitemapsWithHyphenId);
+
+      const service = new GraphQLSitemapXmlService({ clientFactory, siteName });
+      const result = await service.getSitemap('-1');
+
+      expect(result).to.deep.equal('sitemap-1.xml');
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it('should return undefined if sitemap does not exist', async () => {
+      mockSitemapRequest(mockSitemaps);
+
+      const service = new GraphQLSitemapXmlService({ clientFactory, siteName });
+      const result = await service.getSitemap('999');
+
+      expect(result).to.be.undefined;
+      expect(nock.isDone()).to.be.true;
+    });
   });
 });

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
@@ -79,7 +79,7 @@ export class GraphQLSitemapXmlService {
    * @returns {string | undefined} the sitemap file path or undefined if one doesn't exist
    */
   async getSitemap(id: string): Promise<string | undefined> {
-    const searchSitemap = `${PREFIX_NAME_SITEMAP}-${id}.xml`;
+    const searchSitemap = `${PREFIX_NAME_SITEMAP}${id ? `-${id}` : ''}.xml`;
     const sitemaps = await this.fetchSitemaps();
 
     return sitemaps.find((sitemap: string) => sitemap.includes(searchSitemap));

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
@@ -79,7 +79,8 @@ export class GraphQLSitemapXmlService {
    * @returns {string | undefined} the sitemap file path or undefined if one doesn't exist
    */
   async getSitemap(id: string): Promise<string | undefined> {
-    const searchSitemap = `${PREFIX_NAME_SITEMAP}${id ? `-${id}` : ''}.xml`;
+    const normalizedId = id?.startsWith('-') ? id.slice(1) : id || '';
+    const searchSitemap = `${PREFIX_NAME_SITEMAP}${normalizedId ? `-${normalizedId}` : ''}.xml`;
     const sitemaps = await this.fetchSitemaps();
 
     return sitemaps.find((sitemap: string) => sitemap.includes(searchSitemap));

--- a/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
+++ b/packages/sitecore-jss/src/site/graphql-sitemap-service.ts
@@ -79,7 +79,7 @@ export class GraphQLSitemapXmlService {
    * @returns {string | undefined} the sitemap file path or undefined if one doesn't exist
    */
   async getSitemap(id: string): Promise<string | undefined> {
-    const searchSitemap = `${PREFIX_NAME_SITEMAP}${id}.xml`;
+    const searchSitemap = `${PREFIX_NAME_SITEMAP}-${id}.xml`;
     const sitemaps = await this.fetchSitemaps();
 
     return sitemaps.find((sitemap: string) => sitemap.includes(searchSitemap));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
- Fix sitemap parsing issue and how query strings are handled.
- Remove dependency on `apiHost` since the the sitemap urls are absolute.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
