### PR TITLE
[sitecore-jss-nextjs]: Link component emptyFieldEditingComponent prop shouldn't pass to NextLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Our versioning strategy is as follows:
   * The `Form` component must be registered in the app to enable non-BYOC Forms support.
   * `SitecoreContext` now supports an `api` property for passing XM Cloud Edge endpoint settings, enabling the `Form` component to access the configured endpoint.
   * Added shared `Form` functionality via the `sitecore-jss/form` submodule.
+* `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061)):
 
 ## 22.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ Our versioning strategy is as follows:
   * The `Form` component must be registered in the app to enable non-BYOC Forms support.
   * `SitecoreContext` now supports an `api` property for passing XM Cloud Edge endpoint settings, enabling the `Form` component to access the configured endpoint.
   * Added shared `Form` functionality via the `sitecore-jss/form` submodule.
-* `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061)):
+
+### 🐛 Bug Fixes
+
+- `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061)):
 
 ## 22.5.4
 

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -1,7 +1,11 @@
 import React, { createRef, ReactNode } from 'react';
 import { NextRouter } from 'next/router';
 import NextLink from 'next/link';
-import { Link as ReactLink, LinkField } from '@sitecore-jss/sitecore-jss-react';
+import {
+  Link as ReactLink,
+  LinkField,
+  DefaultEmptyFieldEditingComponentText,
+} from '@sitecore-jss/sitecore-jss-react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
@@ -341,6 +345,39 @@ describe('<Link />', () => {
 
     const link = rendered.find('a');
     expect(link.html()).not.to.contain('internallinkmatcher');
+  });
+
+  it('should prevent passing emptyFieldEditingComponent to NextLink', () => {
+    const field = {
+      value: {
+        href: '/lorem',
+        text: 'ipsum',
+        class: 'my-link',
+        title: 'My Link',
+        target: '_blank',
+      },
+    };
+    const customEmptyFieldEditingComponentText = DefaultEmptyFieldEditingComponentText;
+    // Spy on console.warn
+    const consoleErrorSpy = spy(console, 'error');
+
+    const rendered = mount(
+      <Page>
+        <Link field={field} emptyFieldEditingComponent={customEmptyFieldEditingComponentText}>
+          <p>Hello world...</p>
+        </Link>
+      </Page>
+    );
+
+    expect(rendered.find(NextLink).length).to.equal(1);
+    expect(rendered.find(ReactLink).length).to.equal(0);
+
+    // Assert that the specific warning was not logged
+    expect(consoleErrorSpy.calledWithMatch(/React does not recognize the .* prop on a DOM element/))
+      .to.be.false;
+
+    // Restore the original console.error
+    consoleErrorSpy.restore();
   });
 
   it('should render ReactLink if href not exists', () => {

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -66,6 +66,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 
       // determine if a link is a route or not. File extensions are not routes and should not be pre-fetched.
       if (isMatching && !isFileUrl) {
+        delete htmlLinkProps.emptyFieldEditingComponent;
         return (
           <NextLink
             href={{ pathname: href, query: querystring, hash: anchor }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
To support Tailwind in Pages field helpers, we are using passing a custom `emptyFieldEditingComponent` function that adds our component classes to the output: 
```
<span classNames={classNames}>[No text in field]</span>
```

Overall, this approach works, but it does throw an error when used in the Link component from `@sitecore-jss/sitecore-jss-nextjs` which is:

> Warning: React does not recognize the `emptyFieldEditingComponent` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `emptyfieldeditingcomponent` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

This is because the `emptyFieldEditingComponent` is not being removed from the `htmlLinkProps` object before being added to `NextLink` from `next/link`. 

This PR removes the `emptyFieldEditingComponent` props before it is passed to `NextLink`. Also added a unit test to detect that this warning no longer appears when the `emptyFieldEditingComponent` prop is used on a link that results in `NextLink` usage.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
