### PR TITLE
[sitecore-jss] Handle trailing slash in sitecoreEdgeUrl to prevent request failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ Our versioning strategy is as follows:
   * `SitecoreContext` now supports an `api` property for passing XM Cloud Edge endpoint settings, enabling the `Form` component to access the configured endpoint.
   * Added shared `Form` functionality via the `sitecore-jss/form` submodule.
 
-  ### 🐛 Bug Fixes
-* `[sitecore-jss]``[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058))
+### 🐛 Bug Fixes
+
+* `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058))
+* `[sitecore-jss]` Handle trailing slash in sitecoreEdgeUrl to prevent request failures ([#2062](https://github.com/Sitecore/jss/pull/2062))
 
 ### 🛠 Breaking Changes
 
-* Upgrade cloudsdk to 0.5 ([#2060](https://github.com/Sitecore/jss/pull/2060)): 
+* Upgrade cloudsdk to 0.5 ([#2060](https://github.com/Sitecore/jss/pull/2060)):
   * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
 
 ## 22.5.4

--- a/packages/sitecore-jss/src/graphql/graphql-edge-proxy.test.ts
+++ b/packages/sitecore-jss/src/graphql/graphql-edge-proxy.test.ts
@@ -24,6 +24,16 @@ describe('graphql-edge-proxy', () => {
         'https://test.com/v1/content/api/graphql/v1?sitecoreContextId=0730fc5a-3333-5555-5555-08db6d7ddb49'
       );
     });
+
+    it('should return url when sitecoreEdgeUrl ends with /', () => {
+      const sitecoreEdgeUrl = 'https://test.com/';
+
+      const url = getEdgeProxyContentUrl(sitecoreEdgeContextId, sitecoreEdgeUrl);
+
+      expect(url).to.equal(
+        'https://test.com/v1/content/api/graphql/v1?sitecoreContextId=0730fc5a-3333-5555-5555-08db6d7ddb49'
+      );
+    });
   });
 
   describe('getEdgeProxyFormsUrl', () => {
@@ -39,6 +49,16 @@ describe('graphql-edge-proxy', () => {
 
     it('should return url when custom sitecoreEdgeUrl is provided', () => {
       const sitecoreEdgeUrl = 'https://test.com';
+
+      const url = getEdgeProxyFormsUrl(sitecoreEdgeContextId, formId, sitecoreEdgeUrl);
+
+      expect(url).to.equal(
+        `https://test.com/v1/forms/publisher/${formId}?sitecoreContextId=${sitecoreEdgeContextId}`
+      );
+    });
+
+    it('should return url when sitecoreEdgeUrl ends with /', () => {
+      const sitecoreEdgeUrl = 'https://test.com/';
 
       const url = getEdgeProxyFormsUrl(sitecoreEdgeContextId, formId, sitecoreEdgeUrl);
 

--- a/packages/sitecore-jss/src/graphql/graphql-edge-proxy.ts
+++ b/packages/sitecore-jss/src/graphql/graphql-edge-proxy.ts
@@ -1,5 +1,7 @@
 import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 
+const normalizeUrl = (url: string) => (url.endsWith('/') ? url.slice(0, -1) : url);
+
 /**
  * Generates a URL for accessing Sitecore Edge Platform Content using the provided endpoint and context ID.
  * @param {string} sitecoreEdgeContextId - The unique context id.
@@ -9,7 +11,10 @@ import { SITECORE_EDGE_URL_DEFAULT } from '../constants';
 export const getEdgeProxyContentUrl = (
   sitecoreEdgeContextId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
-) => `${sitecoreEdgeUrl}/v1/content/api/graphql/v1?sitecoreContextId=${sitecoreEdgeContextId}`;
+) =>
+  `${normalizeUrl(
+    sitecoreEdgeUrl
+  )}/v1/content/api/graphql/v1?sitecoreContextId=${sitecoreEdgeContextId}`;
 
 /**
  * Generates a URL for accessing Sitecore Edge Platform Forms using the provided form ID and context ID.
@@ -22,4 +27,7 @@ export const getEdgeProxyFormsUrl = (
   sitecoreEdgeContextId: string,
   formId: string,
   sitecoreEdgeUrl = SITECORE_EDGE_URL_DEFAULT
-) => `${sitecoreEdgeUrl}/v1/forms/publisher/${formId}?sitecoreContextId=${sitecoreEdgeContextId}`;
+) =>
+  `${normalizeUrl(
+    sitecoreEdgeUrl
+  )}/v1/forms/publisher/${formId}?sitecoreContextId=${sitecoreEdgeContextId}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
When passing the sitecoreEdgeUrl value to getEdgeProxyFormsUrl or getEdgeProxyContentUrl, we expect it to be provided without a trailing slash. However, it's possible for someone to mistakenly include one. We need to handle this case, as currently, any request using a URL with a trailing slash fails

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
