### PR TITLE
[sitecore-jss-react] Extend withDatasourceCheck logic to handle empty datasource in DesignLibrary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987)[#2000](https://github.com/Sitecore/jss/pull/2000)[#2002](https://github.com/Sitecore/jss/pull/2002)[#2005](https://github.com/Sitecore/jss/pull/2005)[#2024](https://github.com/Sitecore/jss/pull/2024)[#2053](https://github.com/Sitecore/jss/pull/2053)[#2059](https://github.com/Sitecore/jss/pull/2059))
+* `[nextjs][sitecore-jss-nextjs]` Support for Component Library feature in XMCloud ([#1987](https://github.com/Sitecore/jss/pull/1987))([#2000](https://github.com/Sitecore/jss/pull/2000))([#2002](https://github.com/Sitecore/jss/pull/2002))([#2005](https://github.com/Sitecore/jss/pull/2005))([#2024](https://github.com/Sitecore/jss/pull/2024))([#2053](https://github.com/Sitecore/jss/pull/2053))([#2059](https://github.com/Sitecore/jss/pull/2059))([#2064](https://github.com/Sitecore/jss/pull/2064))
 * `[create-sitecore-jss]` Create apps with exact jss dependency versions for canary and beta releases; all apps are now created with v0.1.0 instead of the version of JSS ([#2032](https://github.com/Sitecore/jss/pull/2032))
 
 ### 🐛 Bug Fixes

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
@@ -10,10 +10,11 @@ import {
   DefaultEditingError,
 } from '../enhancers/withDatasourceCheck';
 import { SitecoreContextReactContext } from '../components/SitecoreContext';
+import { RenderingType } from '@sitecore-jss/sitecore-jss/layout';
 
-const mockContext = (editing: boolean) => {
+const mockContext = (editing: boolean, renderingType?: RenderingType) => {
   return {
-    context: { pageEditing: editing },
+    context: { pageEditing: editing, renderingType },
     setContext: spy(),
   };
 };
@@ -99,6 +100,26 @@ describe('withDatasourceCheck', () => {
 
     expect(wrapper.find(CustomEditingError)).to.have.length(1);
     expect(wrapper.html()).to.contain('Better than yours');
+  });
+
+  it('should return wrapped component if rendered in DesignLibrary', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '',
+      },
+    };
+
+    const wrapper = mount(
+      <SitecoreContextReactContext.Provider value={mockContext(false, RenderingType.Component)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.find(TestComponent)).to.have.length(1);
+    expect(wrapper.html()).to.contain(props.rendering.componentName);
+    expect(wrapper.html()).to.contain(props.rendering.dataSource);
   });
 
   it('should return wrapped component if datasource present in normal mode', () => {

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentRendering } from '@sitecore-jss/sitecore-jss/layout';
+import { ComponentRendering, RenderingType } from '@sitecore-jss/sitecore-jss/layout';
 import { useSitecoreContext } from './withSitecoreContext';
 
 export const DefaultEditingError = (): JSX.Element => (
@@ -35,7 +35,10 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
       const { sitecoreContext } = useSitecoreContext();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
-      return props.rendering?.dataSource ? (
+      // If the component is rendered in DesignLibrary, we don't need to check for datasource
+      const isDesignLibrary = sitecoreContext?.renderingType === RenderingType.Component;
+
+      return isDesignLibrary || props.rendering?.dataSource ? (
         <Component {...props} />
       ) : sitecoreContext.pageEditing ? (
         <EditingError />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Components rendered within the Design Library don’t require a datasource and are initialized with an empty one by default. We need to handle this case explicitly to avoid unnecessary validation errors.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
