### PR TITLE
Ios16 lookbehind fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-nextjs]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
+
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))
 * `[sitecore-jss]` Handle trailing slash in sitecoreEdgeUrl to prevent request failures ([#2062](https://github.com/Sitecore/jss/pull/2062))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
-* `[sitecore-jss-nextjs]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
+* `[sitecore-jss]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
 
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -202,7 +202,7 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
  * @returns {string} - The modified string or regex with non-special "?" characters escaped.
  */
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
-  const regexPattern = /(?<!\\)\?/g; // Match unescaped "?" characters
+  const regexPattern = /((?:^|[^\\])\?)/g; // Match unescaped "?" characters
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
   const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
 

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -204,7 +204,7 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
   const regexPattern = /(\\)?\?/g; // Match "?" that may or may not be preceded by a backslash
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
-  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?" 
+  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
 
   let result = '';
   let lastIndex = 0;

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -202,9 +202,9 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
  * @returns {string} - The modified string or regex with non-special "?" characters escaped.
  */
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
-  const regexPattern = /((?:^|[^\\])\?)/g; // Match unescaped "?" characters
+  const regexPattern = /(\\)?\?/g; // Match "?" that may or may not be preceded by a backslash
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
-  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
+  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?" 
 
   let result = '';
   let lastIndex = 0;
@@ -214,14 +214,17 @@ export const escapeNonSpecialQuestionMarks = (input: string): string => {
     const index = match.index; // Position of the "?" in the string
     const before = input.slice(lastIndex, index); // Context before the "?"
 
+    // Check if "?" is preceded by a backslash (escaped)
+    const isEscaped = match[1] !== undefined; // match[1] is the backslash group
+
     // Check if "?" is part of a Negative Lookahead
     const isNegativeLookahead = negativeLookaheadPattern.test(before.slice(-3));
 
     // Check if "?" follows a special regex symbol
     const isSpecialRegexSymbol = specialRegexSymbols.test(before.slice(-1));
 
-    if (isNegativeLookahead || isSpecialRegexSymbol) {
-      // If it's a special case, keep the "?" as is
+    if (isEscaped || isNegativeLookahead || isSpecialRegexSymbol) {
+      // If it's escaped, part of a Negative Lookahead, or follows a special regex symbol, keep the "?" as is
       result += input.slice(lastIndex, index + 1);
     } else {
       // Otherwise, escape the "?"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
changed regex in sitecore-jss-nextjs utils.ts (line 205)
<!--- Why is this change required? What problem does it solve? -->
ios 16 doesn't support lookbehind regexes. This change fixes compatibility for that ios version with the latest JSS changes
<!--- If it fixes an open issue, please link to the issue here. -->
[#2057 ](https://github.com/Sitecore/jss/issues/2057)

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
