### PR TITLE
bugfix/Test ios fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-nextjs]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
+
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))
 * `[sitecore-jss]` Handle trailing slash in sitecoreEdgeUrl to prevent request failures ([#2062](https://github.com/Sitecore/jss/pull/2062))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
-* `[sitecore-jss-nextjs]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
+* `[sitecore-jss]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
 
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -202,7 +202,7 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
  * @returns {string} - The modified string or regex with non-special "?" characters escaped.
  */
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
-  const regexPattern = /(?<!\\)\?/g; // Match unescaped "?" characters
+  const regexPattern = /((?:^|[^\\])\?)/g; // Match unescaped "?" characters
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
   const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
 

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -204,7 +204,7 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
   const regexPattern = /(\\)?\?/g; // Match "?" that may or may not be preceded by a backslash
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
-  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?" 
+  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
 
   let result = '';
   let lastIndex = 0;

--- a/packages/sitecore-jss/src/utils/utils.ts
+++ b/packages/sitecore-jss/src/utils/utils.ts
@@ -202,9 +202,9 @@ export const areURLSearchParamsEqual = (params1: URLSearchParams, params2: URLSe
  * @returns {string} - The modified string or regex with non-special "?" characters escaped.
  */
 export const escapeNonSpecialQuestionMarks = (input: string): string => {
-  const regexPattern = /((?:^|[^\\])\?)/g; // Match unescaped "?" characters
+  const regexPattern = /(\\)?\?/g; // Match "?" that may or may not be preceded by a backslash
   const negativeLookaheadPattern = /\(\?!$/; // Detect the start of a Negative Lookahead pattern
-  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?"
+  const specialRegexSymbols = /[.*+)\[\]|\(]$/; // Check for special regex symbols before "?" 
 
   let result = '';
   let lastIndex = 0;
@@ -214,14 +214,17 @@ export const escapeNonSpecialQuestionMarks = (input: string): string => {
     const index = match.index; // Position of the "?" in the string
     const before = input.slice(lastIndex, index); // Context before the "?"
 
+    // Check if "?" is preceded by a backslash (escaped)
+    const isEscaped = match[1] !== undefined; // match[1] is the backslash group
+
     // Check if "?" is part of a Negative Lookahead
     const isNegativeLookahead = negativeLookaheadPattern.test(before.slice(-3));
 
     // Check if "?" follows a special regex symbol
     const isSpecialRegexSymbol = specialRegexSymbols.test(before.slice(-1));
 
-    if (isNegativeLookahead || isSpecialRegexSymbol) {
-      // If it's a special case, keep the "?" as is
+    if (isEscaped || isNegativeLookahead || isSpecialRegexSymbol) {
+      // If it's escaped, part of a Negative Lookahead, or follows a special regex symbol, keep the "?" as is
       result += input.slice(lastIndex, index + 1);
     } else {
       // Otherwise, escape the "?"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR fixes [Negative lookbehind not supported in iOS16.3](https://github.com/Sitecore/jss/issues/2057) originally submitted in a fix PR [#2065](https://github.com/Sitecore/jss/issues/2057) by a community contributor.
I've tested the fix locally and it resolves the issue as expected.

## Testing Details
Needs to be tested on BrowerStack for iOS devices in a version of 16.3 or lower. In order to complete testing setup and proceed with testing you can follow this [documentation](https://sitecore.atlassian.net/wiki/spaces/JSS/pages/5954797677/Testing+iOS+Devices+on+BrowserStack)
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
