### PR TITLE
[create-sitecore-jss] Fix nextjs(xmcloud) app initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))
 * `[sitecore-jss]` Handle trailing slash in sitecoreEdgeUrl to prevent request failures ([#2062](https://github.com/Sitecore/jss/pull/2062))
+* `[create-sitecore-jss]` Fix nextjs(xmcloud) app initialization ([#2070](https://github.com/Sitecore/jss/pull/2070))
 
 ### 🛠 Breaking Changes
 

--- a/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
@@ -1,26 +1,22 @@
-﻿import path, { sep } from 'path';
+﻿import { NextjsArgs } from './../nextjs/args';
+import path, { sep } from 'path';
 import {
   Initializer,
   openJsonFile,
   transform,
   isDevEnvironment,
   DEFAULT_APPNAME,
-  ClientAppArgs,
   incompatibleAddonsMsg,
 } from '../../common';
 import { removeDevDependencies } from './remove-dev-dependencies';
-import { sharedPrerender, Prerender } from '../nextjs/prompts';
-
-type ExtendedClientAppArgs = ClientAppArgs & {
-  prerender?: Prerender;
-};
+import { sharedPrerender } from '../nextjs/prompts';
 
 export default class NextjsXMCloudInitializer implements Initializer {
   get isBase(): boolean {
     return false;
   }
 
-  async init(args: ExtendedClientAppArgs) {
+  async init(args: NextjsArgs) {
     const pkg = openJsonFile(`${args.destination}${sep}package.json`);
 
     const mergedArgs = {

--- a/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs-xmcloud/index.ts
@@ -9,19 +9,25 @@ import {
   incompatibleAddonsMsg,
 } from '../../common';
 import { removeDevDependencies } from './remove-dev-dependencies';
+import { sharedPrerender, Prerender } from '../nextjs/prompts';
+
+type ExtendedClientAppArgs = ClientAppArgs & {
+  prerender?: Prerender;
+};
 
 export default class NextjsXMCloudInitializer implements Initializer {
   get isBase(): boolean {
     return false;
   }
 
-  async init(args: ClientAppArgs) {
+  async init(args: ExtendedClientAppArgs) {
     const pkg = openJsonFile(`${args.destination}${sep}package.json`);
 
     const mergedArgs = {
       ...args,
       appName: args.appName || pkg?.config?.appName || DEFAULT_APPNAME,
       appPrefix: args.appPrefix || pkg?.config?.prefix || false,
+      prerender: sharedPrerender.prerender,
     };
 
     const templatePath = path.resolve(__dirname, '../../templates/nextjs-xmcloud');

--- a/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/index.ts
@@ -11,6 +11,7 @@ import {
 } from '../../common';
 import { removeDevDependencies } from './remove-dev-dependencies';
 import { NextjsArgs } from './args';
+import { sharedPrerender } from './prompts';
 
 inquirer.registerPrompt('nextjs-checkbox', NextjsCheckbox);
 
@@ -51,6 +52,7 @@ export default class NextjsInitializer implements Initializer {
 
   async init(args: NextjsArgs) {
     const answers = await inquirer.prompt<NextjsAnswer>(prompts, args);
+    sharedPrerender.prerender = answers.prerender;
 
     const pkgPath = path.resolve(`${answers.destination}${sep}package.json`);
     const templatePath = path.resolve(__dirname, '../../templates/nextjs');

--- a/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
+++ b/packages/create-sitecore-jss/src/initializers/nextjs/prompts.ts
@@ -16,6 +16,17 @@ export type NextjsAnswer = ClientAppAnswer & {
 
 const DEFAULT_PRERENDER = Prerender.SSG;
 
+/*
+ * Shared prerender configuration for the selected prerendering strategy (SSG or SSR).
+ *
+ * This object is initialized with a default prerender value (`SSG`) and is updated
+ * dynamically after the primary Next.js initializer's initialization process based on
+ * user input collected via prompts without having to re-prompt or duplicate logic.
+ */
+export const sharedPrerender = {
+  prerender: DEFAULT_PRERENDER,
+};
+
 // still need sxp prompts here until sitecore/config is no longer added to xmc app
 export const prompts: QuestionCollection<NextjsAnswer> = [
   ...clientAppPrompts,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
`prerender` is not available in the `nextjs-xmcloud` add-on which leads to an error during app initialization.
Creating a shared prerender state which gets updated dynamically after the primary Next.js initializer's initialization process fixes it.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
