### PR TITLE
[sitecore-jss-react] ErrorBoundary now does not render Suspense when it is wrapping BYOCWrapper, to prevent hydration errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))
 * `[sitecore-jss]` Handle trailing slash in sitecoreEdgeUrl to prevent request failures ([#2062](https://github.com/Sitecore/jss/pull/2062))
+* `[sitecore-jss-react]` Suspense in ErrorBoundary component is not rendered when it is wrapping a BYOCWrapper to prevent client side hydration errors ([#](https://github.com/Sitecore/jss/pull/))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -11,7 +11,6 @@ import { stub } from 'sinon';
 import { convertedData as eeData, emptyPlaceholderData } from '../test-data/ee-data';
 import {
   byocWrapperData,
-  byocWrapperOnlyData,
   feaasWrapperData,
   convertedDevData as nonEeDevData,
   convertedLayoutServiceData as nonEeLsData,
@@ -442,7 +441,7 @@ describe('<Placeholder />', () => {
     });
 
     it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
-      const component = byocWrapperOnlyData.sitecore.route as RouteData;
+      const component = byocWrapperData.sitecore.route as RouteData;
       const phKey = 'main';
 
       byocComponentStub = stub(BYOCComponent, 'BYOCComponent').callsFake(() => (
@@ -461,8 +460,8 @@ describe('<Placeholder />', () => {
         </SitecoreContext>
       );
 
-      expect(renderedComponent.find('ErrorBoundary').length).to.equal(1);
-      expect(renderedComponent.find('Suspense').length).to.equal(0);
+      expect(renderedComponent.find('ErrorBoundary').length).to.equal(2);
+      expect(renderedComponent.find('Suspense').length).to.equal(1);
 
       byocComponentStub.restore();
       byocWrapperStub.restore();

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -11,6 +11,7 @@ import { stub } from 'sinon';
 import { convertedData as eeData, emptyPlaceholderData } from '../test-data/ee-data';
 import {
   byocWrapperData,
+  byocWrapperOnlyData,
   feaasWrapperData,
   convertedDevData as nonEeDevData,
   convertedLayoutServiceData as nonEeLsData,
@@ -29,11 +30,7 @@ import * as FEAASWrapper from './FEaaSWrapper';
 import { HiddenRendering } from './HiddenRendering';
 import { MissingComponent, MissingComponentProps } from './MissingComponent';
 import { Placeholder } from './Placeholder';
-import {
-  ComponentProps,
-  getDynamicPlaceholderPattern,
-  isDynamicPlaceholder,
-} from './PlaceholderCommon';
+import { ComponentProps } from './PlaceholderCommon';
 import { SitecoreContext } from './SitecoreContext';
 import { ComponentFactory } from './sharedTypes';
 import { PlaceholderMetadata } from './PlaceholderMetadata';
@@ -437,8 +434,39 @@ describe('<Placeholder />', () => {
         </SitecoreContext>
       );
 
+      console.log('renderedComponent');
+      console.log(renderedComponent.find('ErrorBoundary').length);
+      console.log(renderedComponent.find('Suspense').length);
+
       expect(renderedComponent.find('.byoc-component').length).to.equal(2);
       expect(renderedComponent.find('.byoc-wrapper').length).to.equal(1);
+
+      byocComponentStub.restore();
+      byocWrapperStub.restore();
+    });
+
+    it('should not render ErrorBoundary without Suspense for byoc wrapper', () => {
+      const component = byocWrapperOnlyData.sitecore.route as RouteData;
+      const phKey = 'main';
+
+      byocComponentStub = stub(BYOCComponent, 'BYOCComponent').callsFake(() => (
+        <p className="byoc-component">Foo</p>
+      ));
+
+      byocWrapperStub = stub(BYOCWrapper, 'BYOCWrapper').callsFake(() => (
+        <div className="byoc-wrapper">
+          <BYOCComponent.BYOCComponent />
+        </div>
+      ));
+
+      const renderedComponent = mount(
+        <SitecoreContext componentFactory={componentFactory}>
+          <Placeholder name={phKey} rendering={component} />
+        </SitecoreContext>
+      );
+
+      expect(renderedComponent.find('ErrorBoundary').length).to.equal(1);
+      expect(renderedComponent.find('Suspense').length).to.equal(0);
 
       byocComponentStub.restore();
       byocWrapperStub.restore();

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -434,10 +434,6 @@ describe('<Placeholder />', () => {
         </SitecoreContext>
       );
 
-      console.log('renderedComponent');
-      console.log(renderedComponent.find('ErrorBoundary').length);
-      console.log(renderedComponent.find('Suspense').length);
-
       expect(renderedComponent.find('.byoc-component').length).to.equal(2);
       expect(renderedComponent.find('.byoc-wrapper').length).to.equal(1);
 
@@ -445,7 +441,7 @@ describe('<Placeholder />', () => {
       byocWrapperStub.restore();
     });
 
-    it('should not render ErrorBoundary without Suspense for byoc wrapper', () => {
+    it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
       const component = byocWrapperOnlyData.sitecore.route as RouteData;
       const phKey = 'main';
 

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -287,6 +287,13 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
         if (!isEmpty) {
           // assign type based on passed element - type='text/sitecore' should be ignored when renderEach Placeholder prop function is being used
           const type = rendered.props.type === 'text/sitecore' ? rendered.props.type : '';
+
+          // the registered BYOC components are imported using dynamic(), so we need to account for that when passing the isDynamic prop to ErrorBoundary
+          const isByocWrapper = componentRendering.componentName === BYOC_WRAPPER_RENDERING_NAME;
+
+          // all dynamic elements will have a separate render prop
+          const isDynamicComponent = !!(component as JssComponentType).render?.preload;
+
           // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
           // that's why we need to expose element's props here
           rendered = (
@@ -295,7 +302,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
               errorComponent={this.props.errorComponent}
               componentLoadingMessage={this.props.componentLoadingMessage}
               type={type}
-              isDynamic={(component as JssComponentType).render?.preload ? true : false}
+              isDynamic={isDynamicComponent || isByocWrapper}
               {...rendered.props}
             >
               {rendered}

--- a/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
@@ -410,6 +410,39 @@ export const byocWrapperData = {
   },
 };
 
+export const byocWrapperOnlyData = {
+  sitecore: {
+    context: {
+      pageEditing: false,
+    },
+    route: {
+      name: 'Home',
+      displayName: 'Home',
+      fields: {
+        key: {
+          value: 'This is a some sample &lt;p&gt;field data&lt;/p&gt; o&#39;boy! &quot;wow&quot;',
+        },
+      },
+      placeholders: {
+        main: [
+          {
+            uid: '278b99a7-8d73-4362-ac05-53e7c35154d5',
+            componentName: 'BYOCWrapper',
+            dataSource: '',
+            params: {
+              ComponentName: 'Foo',
+              ComponentProps: '{ "columns": 7 }',
+              GridParameters: 'col-12',
+              DynamicPlaceholderId: '1',
+              FieldNames: 'Default',
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
 export const feaasWrapperData = {
   sitecore: {
     context: {

--- a/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
@@ -410,39 +410,6 @@ export const byocWrapperData = {
   },
 };
 
-export const byocWrapperOnlyData = {
-  sitecore: {
-    context: {
-      pageEditing: false,
-    },
-    route: {
-      name: 'Home',
-      displayName: 'Home',
-      fields: {
-        key: {
-          value: 'This is a some sample &lt;p&gt;field data&lt;/p&gt; o&#39;boy! &quot;wow&quot;',
-        },
-      },
-      placeholders: {
-        main: [
-          {
-            uid: '278b99a7-8d73-4362-ac05-53e7c35154d5',
-            componentName: 'BYOCWrapper',
-            dataSource: '',
-            params: {
-              ComponentName: 'Foo',
-              ComponentProps: '{ "columns": 7 }',
-              GridParameters: 'col-12',
-              DynamicPlaceholderId: '1',
-              FieldNames: 'Default',
-            },
-          },
-        ],
-      },
-    },
-  },
-};
-
 export const feaasWrapperData = {
   sitecore: {
     context: {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Rendering dynamic client side components do not work well with Suspense and cause hydration errors (e.g. BYOC form component).To prevent this kind of errors the ErrorBoundary component will not render Suspense if it is wrapping a BYOCWrapper since all BYOC's are registered as dynamic imports.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - BYOC form should render without errors in connected mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
