### PR TITLE
[nextjs] fix for casing issue in redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) [#2072](https://github.com/Sitecore/jss/pull/2072)
 * `[sitecore-jss]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))
 * `[sitecore-jss]` `[template/nextjs-sxa]` Fix `/api/sitemap` endpoint ([#2058](https://github.com/Sitecore/jss/pull/2058)) ([#2063](https://github.com/Sitecore/jss/pull/2063))

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1,4 +1,4 @@
-﻿/* eslint-disable no-unused-expressions */
+﻿﻿/* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable dot-notation */
 import { debug, GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
@@ -191,7 +191,7 @@ describe('RedirectsMiddleware', () => {
     const finalRes = await middleware.getHandler()(req);
 
     validateDebugLog('redirects middleware start: %o', {
-      hostname: typeof _hostname === 'string' ? _hostname : hostname, // Ensure it's a string to fix type issues
+      hostname: _hostname,
       language: middlewareOptions.locale || 'en',
       pathname: req.nextUrl.pathname,
     });
@@ -1369,7 +1369,6 @@ describe('RedirectsMiddleware', () => {
           href: 'http://localhost:3000/found/',
           locale: 'en',
           origin: 'http://localhost:3000',
-          search: '',
           pathname: '/not-found/',
         };
         const { res, req } = createTestRequestResponse({
@@ -1389,7 +1388,7 @@ describe('RedirectsMiddleware', () => {
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
             pattern: '/not-found/',
-            target: '/found/',
+            target: 'http://localhost:3000/found/',
             redirectType: REDIRECT_TYPE_301,
             isQueryStringPreserved: true,
             locale: 'en',
@@ -1684,207 +1683,69 @@ describe('RedirectsMiddleware', () => {
           pathname: '/found/',
         };
 
-        it('should return 301 redirect when trailingSlash is true', async () => {
-          const cloneUrl = () => Object.assign({}, req.nextUrl);
-          const url = {
-            clone: cloneUrl,
-            href: 'http://localhost:3000/found/',
-            locale: 'en',
-            origin: 'http://localhost:3000',
-            search: '',
-            pathname: '/found/',
-          };
-
-          const { res, req } = createTestRequestResponse({
-            response: { url },
-            request: {
-              nextUrl: {
-                pathname: '/not-found/',
-                href: 'http://localhost:3000/not-found/',
-                locale: 'en',
-                origin: 'http://localhost:3000',
-                clone: cloneUrl,
-              },
-            },
-          });
-          setupRedirectStub(301);
-
-          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-            {
-              pattern: '/not-found/',
-              target: '/found/',
-              redirectType: REDIRECT_TYPE_301,
-              isQueryStringPreserved: true,
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/not-found/',
+              search: '?path=not-found',
+              href: 'http://localhost:3000/not-found/?path=not-found',
               locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
             },
-            req
-          );
+          },
+        });
+        setupRedirectStub(301);
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/not-found/',
+            target: '/found/',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: true,
+            locale: 'en',
+          },
+          req
+        );
 
-          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-            headers: {},
-            redirected: undefined,
-            status: 301,
-            url,
-          });
-
-          expect(siteResolver.getByHost).to.be.calledWith(hostname);
-          expect(fetchRedirects.called).to.be.true;
-          expect(finalRes).to.deep.equal(res);
-          expect(finalRes.status).to.equal(res.status);
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
         });
 
-        it('should return 302 redirect when query string is not preserved and target has no parameters', async () => {
-          const cloneUrl = () => Object.assign({}, req.nextUrl);
-          const url = {
-            clone: cloneUrl,
-            href: 'http://localhost:3000/found',
-            locale: 'en',
-            origin: 'http://localhost:3000',
-            search: '',
-            pathname: '/found',
-          };
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes).to.deep.equal(res);
+        expect(finalRes.status).to.equal(res.status);
+      });
 
-          const { res, req } = createTestRequestResponse({
-            response: { url },
-            request: {
-              nextUrl: {
-                pathname: '/not-found',
-                search: '?path=not-found',
-                href: 'http://localhost:3000/not-found?path=not-found',
-                locale: 'en',
-                origin: 'http://localhost:3000',
-                clone: cloneUrl,
-              },
-            },
-            status: 302,
-          });
-          setupRedirectStub(302);
+      it('should clean redirect headers and return a 302 redirect', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          clone: cloneUrl,
+          href: 'http://localhost:3000/found',
+          locale: 'en',
+          origin: 'http://localhost:3000',
+          search: '',
+          pathname: '/found',
+        };
 
-          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-            {
-              pattern: '/not-found',
-              target: '/found',
-              redirectType: REDIRECT_TYPE_302,
-              isQueryStringPreserved: false,
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/not-found',
+              search: '?path=not-found&abc=edf',
+              href: 'http://localhost:3000/not-found?path=not-found&abc=edf',
               locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
             },
-            req
-          );
-
-          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-            headers: {},
-            redirected: undefined,
-            status: 302,
-            url,
-          });
-
-          expect(siteResolver.getByHost).to.be.calledWith(hostname);
-          // eslint-disable-next-line no-unused-expressions
-          expect(fetchRedirects.called).to.be.true;
-          expect(finalRes).to.deep.equal(res);
-          expect(finalRes.status).to.equal(res.status);
-        });
-
-        it('should return 301 redirect when pattern and target have mixed case', async () => {
-          const cloneUrl = () => Object.assign({}, req.nextUrl);
-          const url = {
-            clone: cloneUrl,
-            href: 'http://localhost:3000/FoUnD',
-            locale: 'en',
-            origin: 'http://localhost:3000',
-            search: '',
-            pathname: '/FoUnD',
-          };
-
-          const { res, req } = createTestRequestResponse({
-            response: { url },
-            request: {
-              nextUrl: {
-                pathname: '/NoT-FoUnD',
-                search: '',
-                href: 'http://localhost:3000/NoT-FoUnD',
-                locale: 'en',
-                origin: 'http://localhost:3000',
-                clone: cloneUrl,
-              },
-            },
-          });
-          setupRedirectStub(301);
-
-          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-            {
-              pattern: '/NoT-FoUnD',
-              target: '/FoUnD',
-              redirectType: REDIRECT_TYPE_301,
-              isQueryStringPreserved: false,
-              locale: 'en',
-            },
-            req
-          );
-
-          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-            headers: {},
-            redirected: undefined,
-            status: 301,
-            url,
-          });
-
-          expect(siteResolver.getByHost).to.be.calledWith(hostname);
-          // eslint-disable-next-line no-unused-expressions
-          expect(fetchRedirects.called).to.be.true;
-          expect(finalRes).to.deep.equal(res);
-          expect(finalRes.status).to.equal(res.status);
-        });
-
-        it('should return 301 redirect when pattern includes regex and query string is preserved', async () => {
-          const cloneUrl = () => Object.assign({}, req.nextUrl);
-          const url = {
-            clone: cloneUrl,
-            href: 'http://localhost:3000/found?abc=123',
-            locale: 'en',
-            origin: 'http://localhost:3000',
-            search: '?abc=123',
-            pathname: '/found',
-          };
-
-          const { res, req } = createTestRequestResponse({
-            response: { url },
-            request: {
-              nextUrl: {
-                pathname: '/not-found',
-                search: '?abc=123',
-                href: 'http://localhost:3000/not-found?abc=123',
-                locale: 'en',
-                origin: 'http://localhost:3000',
-                clone: cloneUrl,
-              },
-            },
-          });
-          setupRedirectStub(301);
-
-          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-            {
-              pattern: '/not-found\\?abc=123',
-              target: '/found',
-              redirectType: REDIRECT_TYPE_301,
-              isQueryStringPreserved: true,
-              locale: 'en',
-            },
-            req
-          );
-
-          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-            headers: {},
-            redirected: undefined,
-            status: 301,
-            url,
-          });
-
-          expect(siteResolver.getByHost).to.be.calledWith(hostname);
-          // eslint-disable-next-line no-unused-expressions
-          expect(fetchRedirects.called).to.be.true;
-          expect(finalRes).to.deep.equal(res);
-          expect(finalRes.status).to.equal(res.status);
+          },
+          status: 302,
         });
         setupRedirectStub(302);
         res.headers.set('x-middleware-next', '1');
@@ -1916,58 +1777,6 @@ describe('RedirectsMiddleware', () => {
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
         // eslint-disable-next-line no-unused-expressions
-        expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
-      });
-
-      // Test cases for case-insensitive redirects
-      it('should redirect regardless of case in pattern and target', async () => {
-        const cloneUrl = () => Object.assign({}, req.nextUrl);
-        const url = {
-          href: 'http://localhost:3000/found',
-          pathname: '/found',
-          origin: 'http://localhost:3000',
-          locale: 'en',
-          search: '',
-          clone: cloneUrl,
-        };
-        setupRedirectStub(301);
-
-        const { res, req } = createTestRequestResponse({
-          response: { url },
-          request: {
-            nextUrl: {
-              pathname: '/About', // Mixed case
-              href: 'http://localhost:3000/About',
-              locale: 'en',
-              origin: 'http://localhost:3000',
-              clone: cloneUrl,
-            },
-          },
-          status: 301,
-        });
-
-        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-          {
-            pattern: '/about', // Lowercase pattern
-            target: '/Found', // Mixed case target
-            redirectType: REDIRECT_TYPE_301,
-            isQueryStringPreserved: false,
-            locale: 'en',
-          },
-          req,
-          hostname // Ensure hostname is passed as a string
-        );
-
-        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
-          redirected: undefined,
-          status: 301,
-          url,
-        });
-
-        expect(siteResolver.getByHost).to.be.calledWith(hostname);
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1782,6 +1782,60 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
+      it('should redirect regardless of case in pattern and target', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+
+        const url = {
+          href: 'http://localhost:3000/Found',
+          pathname: '/Found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        setupRedirectStub(301);
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/About',
+              href: 'http://localhost:3000/About',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/about',
+            target: '/Found',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        // Skip the annoying part — only validate the end log
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
+        });
+
+        // Only care about what's relevant
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(301);
+        expect(finalRes.headers.get('location')).to.equal('http://localhost:3000/Found');
+      });
+
       // TODO: This test is failing because of this bug https://sitecore.atlassian.net/browse/JSS-3955
       xit('should return rewrite', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -191,7 +191,7 @@ describe('RedirectsMiddleware', () => {
     const finalRes = await middleware.getHandler()(req);
 
     validateDebugLog('redirects middleware start: %o', {
-      hostname: _hostname,
+      hostname: typeof _hostname === 'string' ? _hostname : hostname, // Ensure it's a string to fix type issues
       language: middlewareOptions.locale || 'en',
       pathname: req.nextUrl.pathname,
     });
@@ -1683,24 +1683,23 @@ describe('RedirectsMiddleware', () => {
           pathname: '/found/',
         };
 
-        it('should return 301 redirect when query string is preserved and target has additional parameters', async () => {
+        it('should return 301 redirect when trailingSlash is true', async () => {
           const cloneUrl = () => Object.assign({}, req.nextUrl);
           const url = {
             clone: cloneUrl,
-            href: 'http://localhost:3000/found?path=not-found&extra=1',
+            href: 'http://localhost:3000/found/',
             locale: 'en',
             origin: 'http://localhost:3000',
-            search: '?path=not-found&extra=1',
-            pathname: '/found',
+            search: '',
+            pathname: '/found/',
           };
 
           const { res, req } = createTestRequestResponse({
             response: { url },
             request: {
               nextUrl: {
-                pathname: '/not-found',
-                search: '?path=not-found',
-                href: 'http://localhost:3000/not-found?path=not-found',
+                pathname: '/not-found/',
+                href: 'http://localhost:3000/not-found/',
                 locale: 'en',
                 origin: 'http://localhost:3000',
                 clone: cloneUrl,
@@ -1711,8 +1710,8 @@ describe('RedirectsMiddleware', () => {
 
           const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
             {
-              pattern: '/not-found',
-              target: '/found?extra=1',
+              pattern: '/not-found/',
+              target: '/found/',
               redirectType: REDIRECT_TYPE_301,
               isQueryStringPreserved: true,
               locale: 'en',
@@ -1728,7 +1727,6 @@ describe('RedirectsMiddleware', () => {
           });
 
           expect(siteResolver.getByHost).to.be.calledWith(hostname);
-          // eslint-disable-next-line no-unused-expressions
           expect(fetchRedirects.called).to.be.true;
           expect(finalRes).to.deep.equal(res);
           expect(finalRes.status).to.equal(res.status);
@@ -1958,7 +1956,7 @@ describe('RedirectsMiddleware', () => {
             locale: 'en',
           },
           req,
-          res
+          hostname // Ensure hostname is passed as a string
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
@@ -1969,7 +1967,6 @@ describe('RedirectsMiddleware', () => {
         });
 
         expect(siteResolver.getByHost).to.be.calledWith(hostname);
-        // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes).to.deep.equal(res);
         expect(finalRes.status).to.equal(res.status);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1782,6 +1782,59 @@ describe('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
+      // Test cases for case-insensitive redirects
+      it('should redirect regardless of case in pattern and target', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/found',
+          pathname: '/found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+        setupRedirectStub(301);
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/About', // Mixed case
+              href: 'http://localhost:3000/About',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/about', // Lowercase pattern
+            target: '/Found', // Mixed case target
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
+        });
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes).to.deep.equal(res);
+        expect(finalRes.status).to.equal(res.status);
+      });
+
       // TODO: This test is failing because of this bug https://sitecore.atlassian.net/browse/JSS-3955
       xit('should return rewrite', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1683,69 +1683,209 @@ describe('RedirectsMiddleware', () => {
           pathname: '/found/',
         };
 
-        const { res, req } = createTestRequestResponse({
-          response: { url },
-          request: {
-            nextUrl: {
-              pathname: '/not-found/',
-              search: '?path=not-found',
-              href: 'http://localhost:3000/not-found/?path=not-found',
-              locale: 'en',
-              origin: 'http://localhost:3000',
-              clone: cloneUrl,
-            },
-          },
-        });
-        setupRedirectStub(301);
-        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
-          {
-            pattern: '/not-found/',
-            target: '/found/',
-            redirectType: REDIRECT_TYPE_301,
-            isQueryStringPreserved: true,
+        it('should return 301 redirect when query string is preserved and target has additional parameters', async () => {
+          const cloneUrl = () => Object.assign({}, req.nextUrl);
+          const url = {
+            clone: cloneUrl,
+            href: 'http://localhost:3000/found?path=not-found&extra=1',
             locale: 'en',
-          },
-          req
-        );
+            origin: 'http://localhost:3000',
+            search: '?path=not-found&extra=1',
+            pathname: '/found',
+          };
 
-        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
-          headers: {},
-          redirected: undefined,
-          status: 301,
-          url,
+          const { res, req } = createTestRequestResponse({
+            response: { url },
+            request: {
+              nextUrl: {
+                pathname: '/not-found',
+                search: '?path=not-found',
+                href: 'http://localhost:3000/not-found?path=not-found',
+                locale: 'en',
+                origin: 'http://localhost:3000',
+                clone: cloneUrl,
+              },
+            },
+          });
+          setupRedirectStub(301);
+
+          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+            {
+              pattern: '/not-found',
+              target: '/found?extra=1',
+              redirectType: REDIRECT_TYPE_301,
+              isQueryStringPreserved: true,
+              locale: 'en',
+            },
+            req
+          );
+
+          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+            headers: {},
+            redirected: undefined,
+            status: 301,
+            url,
+          });
+
+          expect(siteResolver.getByHost).to.be.calledWith(hostname);
+          // eslint-disable-next-line no-unused-expressions
+          expect(fetchRedirects.called).to.be.true;
+          expect(finalRes).to.deep.equal(res);
+          expect(finalRes.status).to.equal(res.status);
         });
 
-        expect(siteResolver.getByHost).to.be.calledWith(hostname);
-        // eslint-disable-next-line no-unused-expressions
-        expect(fetchRedirects.called).to.be.true;
-        expect(finalRes).to.deep.equal(res);
-        expect(finalRes.status).to.equal(res.status);
-      });
+        it('should return 302 redirect when query string is not preserved and target has no parameters', async () => {
+          const cloneUrl = () => Object.assign({}, req.nextUrl);
+          const url = {
+            clone: cloneUrl,
+            href: 'http://localhost:3000/found',
+            locale: 'en',
+            origin: 'http://localhost:3000',
+            search: '',
+            pathname: '/found',
+          };
 
-      it('should clean redirect headers and return a 302 redirect', async () => {
-        const cloneUrl = () => Object.assign({}, req.nextUrl);
-        const url = {
-          clone: cloneUrl,
-          href: 'http://localhost:3000/found',
-          locale: 'en',
-          origin: 'http://localhost:3000',
-          search: '',
-          pathname: '/found',
-        };
-
-        const { res, req } = createTestRequestResponse({
-          response: { url },
-          request: {
-            nextUrl: {
-              pathname: '/not-found',
-              search: '?path=not-found&abc=edf',
-              href: 'http://localhost:3000/not-found?path=not-found&abc=edf',
-              locale: 'en',
-              origin: 'http://localhost:3000',
-              clone: cloneUrl,
+          const { res, req } = createTestRequestResponse({
+            response: { url },
+            request: {
+              nextUrl: {
+                pathname: '/not-found',
+                search: '?path=not-found',
+                href: 'http://localhost:3000/not-found?path=not-found',
+                locale: 'en',
+                origin: 'http://localhost:3000',
+                clone: cloneUrl,
+              },
             },
-          },
-          status: 302,
+            status: 302,
+          });
+          setupRedirectStub(302);
+
+          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+            {
+              pattern: '/not-found',
+              target: '/found',
+              redirectType: REDIRECT_TYPE_302,
+              isQueryStringPreserved: false,
+              locale: 'en',
+            },
+            req
+          );
+
+          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+            headers: {},
+            redirected: undefined,
+            status: 302,
+            url,
+          });
+
+          expect(siteResolver.getByHost).to.be.calledWith(hostname);
+          // eslint-disable-next-line no-unused-expressions
+          expect(fetchRedirects.called).to.be.true;
+          expect(finalRes).to.deep.equal(res);
+          expect(finalRes.status).to.equal(res.status);
+        });
+
+        it('should return 301 redirect when pattern and target have mixed case', async () => {
+          const cloneUrl = () => Object.assign({}, req.nextUrl);
+          const url = {
+            clone: cloneUrl,
+            href: 'http://localhost:3000/FoUnD',
+            locale: 'en',
+            origin: 'http://localhost:3000',
+            search: '',
+            pathname: '/FoUnD',
+          };
+
+          const { res, req } = createTestRequestResponse({
+            response: { url },
+            request: {
+              nextUrl: {
+                pathname: '/NoT-FoUnD',
+                search: '',
+                href: 'http://localhost:3000/NoT-FoUnD',
+                locale: 'en',
+                origin: 'http://localhost:3000',
+                clone: cloneUrl,
+              },
+            },
+          });
+          setupRedirectStub(301);
+
+          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+            {
+              pattern: '/NoT-FoUnD',
+              target: '/FoUnD',
+              redirectType: REDIRECT_TYPE_301,
+              isQueryStringPreserved: false,
+              locale: 'en',
+            },
+            req
+          );
+
+          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+            headers: {},
+            redirected: undefined,
+            status: 301,
+            url,
+          });
+
+          expect(siteResolver.getByHost).to.be.calledWith(hostname);
+          // eslint-disable-next-line no-unused-expressions
+          expect(fetchRedirects.called).to.be.true;
+          expect(finalRes).to.deep.equal(res);
+          expect(finalRes.status).to.equal(res.status);
+        });
+
+        it('should return 301 redirect when pattern includes regex and query string is preserved', async () => {
+          const cloneUrl = () => Object.assign({}, req.nextUrl);
+          const url = {
+            clone: cloneUrl,
+            href: 'http://localhost:3000/found?abc=123',
+            locale: 'en',
+            origin: 'http://localhost:3000',
+            search: '?abc=123',
+            pathname: '/found',
+          };
+
+          const { res, req } = createTestRequestResponse({
+            response: { url },
+            request: {
+              nextUrl: {
+                pathname: '/not-found',
+                search: '?abc=123',
+                href: 'http://localhost:3000/not-found?abc=123',
+                locale: 'en',
+                origin: 'http://localhost:3000',
+                clone: cloneUrl,
+              },
+            },
+          });
+          setupRedirectStub(301);
+
+          const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+            {
+              pattern: '/not-found\\?abc=123',
+              target: '/found',
+              redirectType: REDIRECT_TYPE_301,
+              isQueryStringPreserved: true,
+              locale: 'en',
+            },
+            req
+          );
+
+          validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+            headers: {},
+            redirected: undefined,
+            status: 301,
+            url,
+          });
+
+          expect(siteResolver.getByHost).to.be.calledWith(hostname);
+          // eslint-disable-next-line no-unused-expressions
+          expect(fetchRedirects.called).to.be.true;
+          expect(finalRes).to.deep.equal(res);
+          expect(finalRes.status).to.equal(res.status);
         });
         setupRedirectStub(302);
         res.headers.set('x-middleware-next', '1');

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1369,6 +1369,7 @@ describe('RedirectsMiddleware', () => {
           href: 'http://localhost:3000/found/',
           locale: 'en',
           origin: 'http://localhost:3000',
+          search: '',
           pathname: '/not-found/',
         };
         const { res, req } = createTestRequestResponse({
@@ -1388,7 +1389,7 @@ describe('RedirectsMiddleware', () => {
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
             pattern: '/not-found/',
-            target: 'http://localhost:3000/found/',
+            target: '/found/',
             redirectType: REDIRECT_TYPE_301,
             isQueryStringPreserved: true,
             locale: 'en',

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1,4 +1,4 @@
-﻿﻿/* eslint-disable no-unused-expressions */
+﻿/* eslint-disable no-unused-expressions */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable dot-notation */
 import { debug, GraphQLRequestClient } from '@sitecore-jss/sitecore-jss';
@@ -1784,16 +1784,8 @@ describe('RedirectsMiddleware', () => {
 
       it('should redirect regardless of case in pattern and target', async () => {
         // Set up a clone function (used by both req and res)
-        const cloneUrl = () => ({
-          href: 'http://localhost:3000/Found',
-          pathname: '/Found',
-          origin: 'http://localhost:3000',
-          locale: 'en',
-          search: '',
-          clone: cloneUrl,
-        });
-
-        const redirectUrl = {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
           href: 'http://localhost:3000/Found',
           pathname: '/Found',
           origin: 'http://localhost:3000',
@@ -1802,11 +1794,9 @@ describe('RedirectsMiddleware', () => {
           clone: cloneUrl,
         };
 
-        setupRedirectStub(301);
-
         // Create the test request and response
         const { res, req } = createTestRequestResponse({
-          response: { url: redirectUrl },
+          response: { url },
           request: {
             nextUrl: {
               pathname: '/About',
@@ -1819,23 +1809,27 @@ describe('RedirectsMiddleware', () => {
           status: 301,
         });
 
+        setupRedirectStub(301);
+        res.headers.set('x-middleware-next', '1');
+        res.headers.set('x-middleware-rewrite', '1');
+        res.headers.set(REWRITE_HEADER_NAME, 1);
+
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
-            pattern: '/about', // Lowercase pattern
-            target: '/Found', // Mixed-case target
+            pattern: '/About',
+            target: '/Found',
             redirectType: REDIRECT_TYPE_301,
             isQueryStringPreserved: false,
             locale: 'en',
           },
-          req,
-          res
+          req
         );
 
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
           headers: {},
           redirected: undefined,
           status: 301,
-          url: redirectUrl,
+          url,
         });
 
         expect(siteResolver.getByHost).to.have.been.called;

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1783,9 +1783,17 @@ describe('RedirectsMiddleware', () => {
       });
 
       it('should redirect regardless of case in pattern and target', async () => {
-        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        // Set up a clone function (used by both req and res)
+        const cloneUrl = () => ({
+          href: 'http://localhost:3000/Found',
+          pathname: '/Found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        });
 
-        const url = {
+        const redirectUrl = {
           href: 'http://localhost:3000/Found',
           pathname: '/Found',
           origin: 'http://localhost:3000',
@@ -1796,8 +1804,9 @@ describe('RedirectsMiddleware', () => {
 
         setupRedirectStub(301);
 
+        // Create the test request and response
         const { res, req } = createTestRequestResponse({
-          response: { url },
+          response: { url: redirectUrl },
           request: {
             nextUrl: {
               pathname: '/About',
@@ -1812,8 +1821,8 @@ describe('RedirectsMiddleware', () => {
 
         const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
           {
-            pattern: '/about',
-            target: '/Found',
+            pattern: '/about', // Lowercase pattern
+            target: '/Found', // Mixed-case target
             redirectType: REDIRECT_TYPE_301,
             isQueryStringPreserved: false,
             locale: 'en',
@@ -1822,15 +1831,14 @@ describe('RedirectsMiddleware', () => {
           res
         );
 
-        // Skip the annoying part — only validate the end log
         validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
           headers: {},
           redirected: undefined,
           status: 301,
-          url,
+          url: redirectUrl,
         });
 
-        // Only care about what's relevant
+        expect(siteResolver.getByHost).to.have.been.called;
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(301);
         expect(finalRes.headers.get('location')).to.equal('http://localhost:3000/Found');

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -333,10 +333,10 @@ export class RedirectsMiddleware extends MiddlewareBase {
       })
       .join('&');
 
-    const newUrl = new URL(`${url.pathname}?${newQueryString}`, url.origin);
+    const newUrl = new URL(`${url.pathname.toLowerCase()}?${newQueryString}`, url.origin);
 
     url.search = newUrl.search;
-    url.pathname = newUrl.pathname;
+    url.pathname = newUrl.pathname.toLowerCase();
     url.href = newUrl.href;
 
     return url;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
  With this fix we can now use case-insensitive redirects, which wasn't the case before. Redirects like this `/Old` -> `/New` wouldn't work due to case sensitivity preserved and only lower case redirects would be completed. After this fix all redirects should work despite casing. 

## Testing Details
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate) 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
