### PR TITLE
[Next.js] Experience Editor and Preview render 500 when using Vercel Editing Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-nextjs]` Experience Editor and Preview render 500 when using Vercel Editing Host ([#2077](https://github.com/Sitecore/jss/pull/2077))
 * `[sitecore-jss-nextjs]` Fix for case sensitive redirects (make all redirects case-insensitive) [#2074](https://github.com/Sitecore/jss/pull/2074)
 * `[sitecore-jss]` Fix for lookbehind regex. (not supported on ios 16) [#2057](https://github.com/Sitecore/jss/issues/2057)
 * `[sitecore-jss-nextjs]` Fix React warning from Link component when using custom emptyFieldEditingComponent prop ([#2061](https://github.com/Sitecore/jss/pull/2061))

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-service.test.ts
@@ -89,7 +89,11 @@ describe('ServerlessEditingDataService', () => {
         expect(previewData.key).to.equal(key);
         expect(previewData.serverUrl).to.equal(serverUrl);
         expect(fetcher.put).to.have.been.calledOnce;
-        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data);
+        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
       });
     });
 
@@ -112,7 +116,11 @@ describe('ServerlessEditingDataService', () => {
       return service.setEditingData(data, serverUrl, params).then((previewData) => {
         expect(previewData.params).to.equal(params);
         expect(fetcher.put).to.have.been.calledOnce;
-        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data);
+        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
       });
     });
 
@@ -134,7 +142,11 @@ describe('ServerlessEditingDataService', () => {
 
       return service.setEditingData(data, serverUrl).then(() => {
         expect(fetcher.put).to.have.been.calledOnce;
-        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data);
+        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
       });
     });
 
@@ -156,7 +168,11 @@ describe('ServerlessEditingDataService', () => {
 
       return service.setEditingData(data, serverUrl, { param: superSecret }).then(() => {
         expect(fetcher.put).to.have.been.calledOnce;
-        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data);
+        expect(fetcher.put).to.have.been.calledWithExactly(expectedUrl, data, {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
       });
     });
   });

--- a/packages/sitecore-jss-nextjs/src/editing/editing-data-service.ts
+++ b/packages/sitecore-jss-nextjs/src/editing/editing-data-service.ts
@@ -169,9 +169,15 @@ export class ServerlessEditingDataService implements EditingDataService {
     } as EditingPreviewData;
 
     debug.editing('storing editing data for %o: %o', previewData, data);
-    return this.dataFetcher.put(url, data).then(() => {
-      return previewData;
-    });
+    return this.dataFetcher
+      .put(url, data, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      .then(() => {
+        return previewData;
+      });
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
After investigation, we identified that the issue was introduced when Axios support was dropped. Axios automatically included certain headers, such as Content-Type, which are not added by default with native fetch.
To ensure proper request handling by the Vercel API endpoint, we now explicitly set the Content-Type header. This helps the function to correctly recognize the type of the request body.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other - Editing host using Vercel Deployment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
