### PR TITLE
[sitecore-jss-nextjs] Personalize middleware: geolocation data can now be passed to personalize middleware from application level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
 
 * Upgrade cloudsdk to 0.5 ([#2060](https://github.com/Sitecore/jss/pull/2060)):
   * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
-* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-proxy]` `[sitecore-jss-angular]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)):
+* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-proxy]` `[sitecore-jss-angular]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)) ([#2084](https://github.com/Sitecore/jss/pull/2084)):
   * upgrade React and Nextjs dependencies for the new major versions
   * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
   * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`
@@ -27,6 +27,7 @@ Our versioning strategy is as follows:
   * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
   * remove 'react' dependency from nextconfig webpack externals in monorepo next config plugin as it is not needed anymore.
   * for `[sitecore-jss-proxy]` `[sitecore-jss-angular]` - `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
+  * PersonalizeMiddleware handler now accepts PersonalizeOptions, that can be used to provide geolocation data from application level
 
 ## 22.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Our versioning strategy is as follows:
   * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
   * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`
   * `propTypes` have been deprecated by react and have been removed from the solution
-  * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
+  * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `@sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
   * remove 'react' dependency from nextconfig webpack externals in monorepo next config plugin as it is not needed anymore.
   * PersonalizeMiddleware handler now accepts PersonalizeOptions, that can be used to provide geolocation data from application level
 * `[Angular]`: `[sitecore-jss-proxy]` `[sitecore-jss-angular]` `@sitecore-cloudsdk` dependencies have been upgraded to 0.5.1 ([#2060](https://github.com/Sitecore/jss/pull/2060))([#2078](https://github.com/Sitecore/jss/pull/2078))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,16 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Changes
 
-* Upgrade cloudsdk to 0.5 ([#2060](https://github.com/Sitecore/jss/pull/2060)):
-  * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
-* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-proxy]` `[sitecore-jss-angular]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)) ([#2084](https://github.com/Sitecore/jss/pull/2084)):
+* `[Next.js]` `[React]`: `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)) ([#2084](https://github.com/Sitecore/jss/pull/2084)):
   * upgrade React and Nextjs dependencies for the new major versions
   * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
   * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`
   * `propTypes` have been deprecated by react and have been removed from the solution
   * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
   * remove 'react' dependency from nextconfig webpack externals in monorepo next config plugin as it is not needed anymore.
-  * for `[sitecore-jss-proxy]` `[sitecore-jss-angular]` - `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
   * PersonalizeMiddleware handler now accepts PersonalizeOptions, that can be used to provide geolocation data from application level
+* `[Angular]`: `[sitecore-jss-proxy]` `[sitecore-jss-angular]` - `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change. ([#2060](https://github.com/Sitecore/jss/pull/2060))([#2078](https://github.com/Sitecore/jss/pull/2078))
+  * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
 
 ## 22.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Our versioning strategy is as follows:
 
 ### 🛠 Breaking Changes
 
-* `[Next.js]` `[React]`: `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)) ([#2084](https://github.com/Sitecore/jss/pull/2084)):
+* `[Next.js]` `[React]`: `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078))([#2084](https://github.com/Sitecore/jss/pull/2084)):
   * upgrade React and Nextjs dependencies for the new major versions
   * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
   * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Our versioning strategy is as follows:
   * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change.
   * remove 'react' dependency from nextconfig webpack externals in monorepo next config plugin as it is not needed anymore.
   * PersonalizeMiddleware handler now accepts PersonalizeOptions, that can be used to provide geolocation data from application level
-* `[Angular]`: `[sitecore-jss-proxy]` `[sitecore-jss-angular]` - `sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which does not include breaking change. ([#2060](https://github.com/Sitecore/jss/pull/2060))([#2078](https://github.com/Sitecore/jss/pull/2078))
+* `[Angular]`: `[sitecore-jss-proxy]` `[sitecore-jss-angular]` `@sitecore-cloudsdk` dependencies have been upgraded to 0.5.1 ([#2060](https://github.com/Sitecore/jss/pull/2060))([#2078](https://github.com/Sitecore/jss/pull/2078))
   * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
 
 ## 22.6.0

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -672,6 +672,7 @@ describe('PersonalizeMiddleware', () => {
       expect(finalRes).to.deep.equal(res);
       nextRewriteStub.restore();
     });
+
     it('sc_site cookie is provided', async () => {
       const req = createRequest();
       const res = createResponse({
@@ -868,6 +869,37 @@ describe('PersonalizeMiddleware', () => {
           sinon.match.any
         )
       ).to.be.true;
+      expect(finalRes).to.deep.equal(res);
+      nextRewriteStub.restore();
+    });
+
+    it('passess geo data', async () => {
+      const pageId = 'item-id';
+      const scope = 'myscope';
+      const req = createRequest();
+      const res = createResponse();
+      const nextRewriteStub = sinon.stub(nextjs.NextResponse, 'rewrite').returns(res);
+      const personalizeStub = sinon.stub().returns(Promise.resolve({ variantId: undefined }));
+      const { middleware, getPersonalizeInfo, personalize } = createMiddleware({
+        scope,
+        personalizeInfo: {
+          pageId,
+          variantIds: ['variant1'],
+        },
+        personalizeStub,
+      });
+      const personalizeOptions = {
+        geo: {
+          country: 'US',
+          region: 'CA',
+          city: 'San Francisco',
+        },
+      };
+      const finalRes = await middleware.getHandler()(req, res, personalizeOptions);
+
+      expect(getPersonalizeInfo.calledWith('/styleguide', 'en', siteName)).to.be.true;
+      expect(personalize.calledWith(sinon.match({ options: personalizeOptions }), sinon.match.any))
+        .to.be.true;
       expect(finalRes).to.deep.equal(res);
       nextRewriteStub.restore();
     });

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -52,6 +52,25 @@ export type PersonalizeMiddlewareConfig = MiddlewareBaseConfig & {
 };
 
 /**
+ * Personalization options
+ */
+export type PersonalizeOptions = {
+  /**
+   * Geolocation data used for personalization
+   */
+  geo?: PersonalizeGeoData;
+};
+
+/**
+ * Represents the geolocation data used for personalization
+ */
+export type PersonalizeGeoData = {
+  city?: string;
+  country?: string;
+  region?: string;
+};
+
+/**
  * Object model of Experience Context data
  */
 export type ExperienceParams = {
@@ -97,10 +116,14 @@ export class PersonalizeMiddleware extends MiddlewareBase {
    * Gets the Next.js middleware handler with error handling
    * @returns middleware handler
    */
-  public getHandler(): (req: NextRequest, res?: NextResponse) => Promise<NextResponse> {
-    return async (req, res) => {
+  public getHandler(): (
+    req: NextRequest,
+    res?: NextResponse,
+    options?: PersonalizeOptions
+  ) => Promise<NextResponse> {
+    return async (req, res, options) => {
       try {
-        return await this.handler(req, res);
+        return await this.handler(req, res, options);
       } catch (error) {
         console.log('Personalize middleware failed:');
         console.log(error);
@@ -138,12 +161,14 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       language,
       timeout,
       variantIds,
+      options,
     }: {
       params: ExperienceParams;
       friendlyId: string;
       language: string;
       timeout?: number;
       variantIds?: string[];
+      options?: PersonalizeOptions;
     },
     request: NextRequest
   ) {
@@ -158,6 +183,7 @@ export class PersonalizeMiddleware extends MiddlewareBase {
         params,
         language,
         pageVariantIds: variantIds,
+        geo: options?.geo,
       },
       { timeout }
     )) as {
@@ -243,7 +269,11 @@ export class PersonalizeMiddleware extends MiddlewareBase {
     }, results);
   }
 
-  private handler = async (req: NextRequest, res?: NextResponse): Promise<NextResponse> => {
+  private handler = async (
+    req: NextRequest,
+    res?: NextResponse,
+    options?: PersonalizeOptions
+  ): Promise<NextResponse> => {
     const pathname = req.nextUrl.pathname;
     const language = this.getLanguage(req);
     const hostname = this.getHostHeader(req) || this.defaultHostname;
@@ -326,6 +356,7 @@ export class PersonalizeMiddleware extends MiddlewareBase {
             params,
             language,
             timeout,
+            options,
           },
           req
         ).then((personalization) => {

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -11,6 +11,7 @@ import { debug } from '@sitecore-jss/sitecore-jss';
 import { MiddlewareBase, MiddlewareBaseConfig, REWRITE_HEADER_NAME } from './middleware';
 import { CloudSDK } from '@sitecore-cloudsdk/core/server';
 import { personalize } from '@sitecore-cloudsdk/personalize/server';
+import { PersonalizeGeolocation } from '@sitecore-cloudsdk/personalize/dist/esm/src/lib/personalization/personalizer';
 
 export type CdpServiceConfig = {
   /**
@@ -58,16 +59,7 @@ export type PersonalizeOptions = {
   /**
    * Geolocation data used for personalization
    */
-  geo?: PersonalizeGeoData;
-};
-
-/**
- * Represents the geolocation data used for personalization
- */
-export type PersonalizeGeoData = {
-  city?: string;
-  country?: string;
-  region?: string;
+  geo?: PersonalizeGeolocation;
 };
 
 /**

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -11,7 +11,6 @@ import { debug } from '@sitecore-jss/sitecore-jss';
 import { MiddlewareBase, MiddlewareBaseConfig, REWRITE_HEADER_NAME } from './middleware';
 import { CloudSDK } from '@sitecore-cloudsdk/core/server';
 import { personalize } from '@sitecore-cloudsdk/personalize/server';
-import { PersonalizeGeolocation } from '@sitecore-cloudsdk/personalize/dist/esm/src/lib/personalization/personalizer';
 
 export type CdpServiceConfig = {
   /**
@@ -59,7 +58,16 @@ export type PersonalizeOptions = {
   /**
    * Geolocation data used for personalization
    */
-  geo?: PersonalizeGeolocation;
+  geo?: PersonalizeGeoData;
+};
+
+/**
+ * Represents the geolocation data used for personalization
+ */
+export type PersonalizeGeoData = {
+  city?: string;
+  country?: string;
+  region?: string;
 };
 
 /**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Geolocation data can now be passed to personalize middleware from application level: 
- Introduced PersonalizeOptions type
- Perdonalize middleware handler now accepts PersonalizeOptions parameter

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
