### PR TITLE
[sitecore-jss-nextjs] Add missing unit tests for disableSuspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Our versioning strategy is as follows:
 
 * Upgrade cloudsdk to 0.5 ([#2060](https://github.com/Sitecore/jss/pull/2060)):
   * This upgrade doesn't introduce any breaking changes, however you will have to upgrade your cloudsdk dependencies to meet peer dependencies requirements
-* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-proxy]` `[sitecore-jss-angular]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)):
+* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-proxy]` `[sitecore-jss-angular]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078)) ([#2085](https://github.com/Sitecore/jss/pull/2085)):
   * upgrade React and Nextjs dependencies for the new major versions
   * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
   * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -436,7 +436,7 @@ describe('BYOC fallback', () => {
     byocWrapperStub.restore();
   });
 
-  it.skip('should render ErrorBoundary without Suspense for byoc wrapper', () => {
+  it('should render ErrorBoundary without Suspense for byoc wrapper', () => {
     const component = byocWrapperData.sitecore.route as RouteData;
     const phKey = 'main';
 
@@ -456,8 +456,16 @@ describe('BYOC fallback', () => {
       </SitecoreContext>
     );
 
-    expect(renderedComponent.container.querySelectorAll('ErrorBoundary').length).to.equal(2);
-    expect(renderedComponent.container.querySelectorAll('Suspense').length).to.equal(1);
+    expect(renderedComponent.container.innerHTML).to.not.contain('Loading component...');
+
+    expect(renderedComponent.container.querySelectorAll('.byoc-wrapper').length).to.equal(1);
+
+    const components = renderedComponent.container.querySelectorAll('.byoc-component');
+
+    expect(components.length).to.equal(2);
+
+    expect(components[0].textContent).to.equal('Foo');
+    expect(components[1].textContent).to.equal('Foo');
 
     byocComponentStub.restore();
     byocWrapperStub.restore();

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -65,6 +65,10 @@ const componentFactory: ComponentFactory = (componentName: string) => {
 
   components.set('DownloadCallout', DownloadCallout);
   components.set('Jumbotron', () => <div className="jumbotron-mock" />);
+  components.set(
+    'DynamicComponent',
+    React.lazy(() => import('../test-data/test-dynamic-component'))
+  );
 
   return components.get(componentName) || null;
 };
@@ -495,8 +499,21 @@ describe('FEaaS fallback', () => {
   });
 });
 
-it.skip('should not render Suspense when disableSuspense is true', () => {
-  const component = sxaRenderingVariantData.sitecore.route as RouteData;
+it('should render Suspense when disableSuspense is false', () => {
+  const component = nonEeDevData.sitecore.route as RouteData;
+  const phKey = 'main';
+
+  const renderedComponent = render(
+    <SitecoreContext componentFactory={componentFactory}>
+      <Placeholder name={phKey} disableSuspense={false} rendering={component} />
+    </SitecoreContext>
+  );
+
+  expect(renderedComponent.container.innerHTML).to.contain('Loading component...');
+});
+
+it('should not render Suspense when disableSuspense is true', () => {
+  const component = nonEeDevData.sitecore.route as RouteData;
   const phKey = 'main';
 
   const renderedComponent = render(
@@ -505,8 +522,7 @@ it.skip('should not render Suspense when disableSuspense is true', () => {
     </SitecoreContext>
   );
 
-  expect(renderedComponent.container.querySelectorAll('ErrorBoundary').length).to.equal(1);
-  expect(renderedComponent.container.querySelectorAll('Suspense').length).to.equal(0);
+  expect(renderedComponent.container.innerHTML).to.not.contain('Loading component...');
 });
 
 it('should populate the "key" attribute of placeholder chrome', () => {

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -4,9 +4,9 @@
 /* eslint-disable react/prop-types */
 import { ComponentRendering, RouteData } from '@sitecore-jss/sitecore-jss/layout';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { findByText, render } from '@testing-library/react';
 import React from 'react';
-import { spy, stub } from 'sinon';
+import { stub } from 'sinon';
 import { convertedData as eeData, emptyPlaceholderData } from '../test-data/ee-data';
 import {
   byocWrapperData,
@@ -31,6 +31,8 @@ import { Placeholder } from './Placeholder';
 import { ComponentProps } from './PlaceholderCommon';
 import { SitecoreContext } from './SitecoreContext';
 import { ComponentFactory } from './sharedTypes';
+
+const dynamicComponent = React.lazy(() => import('../test-data/test-dynamic-component'));
 
 const componentFactory: ComponentFactory = (componentName: string) => {
   const components = new Map<string, React.FC>();
@@ -65,10 +67,7 @@ const componentFactory: ComponentFactory = (componentName: string) => {
 
   components.set('DownloadCallout', DownloadCallout);
   components.set('Jumbotron', () => <div className="jumbotron-mock" />);
-  components.set(
-    'DynamicComponent',
-    React.lazy(() => import('../test-data/test-dynamic-component'))
-  );
+  components.set('DynamicComponent', dynamicComponent);
 
   return components.get(componentName) || null;
 };
@@ -499,7 +498,7 @@ describe('FEaaS fallback', () => {
   });
 });
 
-it('should render Suspense when disableSuspense is false', () => {
+it('should render Suspense when disableSuspense is false', async () => {
   const component = nonEeDevData.sitecore.route as RouteData;
   const phKey = 'main';
 
@@ -510,9 +509,11 @@ it('should render Suspense when disableSuspense is false', () => {
   );
 
   expect(renderedComponent.container.innerHTML).to.contain('Loading component...');
+
+  await findByText(renderedComponent.container, 'No error');
 });
 
-it('should not render Suspense when disableSuspense is true', () => {
+it('should not render Suspense when disableSuspense is true', async () => {
   const component = nonEeDevData.sitecore.route as RouteData;
   const phKey = 'main';
 
@@ -523,6 +524,8 @@ it('should not render Suspense when disableSuspense is true', () => {
   );
 
   expect(renderedComponent.container.innerHTML).to.not.contain('Loading component...');
+
+  await findByText(renderedComponent.container, 'No error');
 });
 
 it('should populate the "key" attribute of placeholder chrome', () => {

--- a/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
@@ -77,49 +77,6 @@ export const convertedDevData: LayoutServiceData = {
   },
 };
 
-export const dynamicComponentData: LayoutServiceData = {
-  sitecore: {
-    context: {
-      pageEditing: false,
-    },
-    route: {
-      name: 'home',
-      displayName: 'Home',
-      placeholders: {
-        main: [
-          {
-            componentName: 'Home',
-            fields: {
-              message: {
-                value: 'JavaScript all the things!',
-              },
-            },
-            uid: '2339622d-093b-4258-8334-95979e41efa6',
-            placeholders: {
-              'page-content': [
-                {
-                  uid: '77777777-845d-4de4-bf8e-1f4feddf8908',
-                  componentName: 'DynamicComponent',
-                  fields: {
-                    title: {
-                      value: 'Dynamic Component',
-                    },
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-      fields: {
-        key: {
-          value: 'This is a some sample &lt;p&gt;field data&lt;/p&gt; o&#39;boy! &quot;wow&quot;',
-        },
-      },
-    },
-  },
-};
-
 export const convertedLayoutServiceData = {
   sitecore: {
     context: {

--- a/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
+++ b/packages/sitecore-jss-react/src/test-data/non-ee-data.ts
@@ -77,6 +77,49 @@ export const convertedDevData: LayoutServiceData = {
   },
 };
 
+export const dynamicComponentData: LayoutServiceData = {
+  sitecore: {
+    context: {
+      pageEditing: false,
+    },
+    route: {
+      name: 'home',
+      displayName: 'Home',
+      placeholders: {
+        main: [
+          {
+            componentName: 'Home',
+            fields: {
+              message: {
+                value: 'JavaScript all the things!',
+              },
+            },
+            uid: '2339622d-093b-4258-8334-95979e41efa6',
+            placeholders: {
+              'page-content': [
+                {
+                  uid: '77777777-845d-4de4-bf8e-1f4feddf8908',
+                  componentName: 'DynamicComponent',
+                  fields: {
+                    title: {
+                      value: 'Dynamic Component',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      fields: {
+        key: {
+          value: 'This is a some sample &lt;p&gt;field data&lt;/p&gt; o&#39;boy! &quot;wow&quot;',
+        },
+      },
+    },
+  },
+};
+
 export const convertedLayoutServiceData = {
   sitecore: {
     context: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR adds missed unit tests (testing the `disableSuspense` Placeholder prop) during previous merge.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
