### PR TITLE
[sitecore-jss-nextjs] Ensure proper caching behavior for personalized responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#2081](https://github.com/Sitecore/jss/pull/2081))([#2085](https://github.com/Sitecore/jss/pull/2085))
 * `[templates/NextJs-Styleguide]` `[templates/NextJs-Styleguide-Tracking]` Bug fixes in Styleguide-Layout-Tabs-Tab, Styleguide-Layout-Tabs, Styleguide-Tracking components ([#2100](https://github.com/Sitecore/jss/pull/2100))
-* `[sitecore-jss-nextjs]` Prevent false prefetch detection for mobile navigation in middlewares. ([#2102](https://github.com/Sitecore/jss/pull/2102))
+* `[sitecore-jss-nextjs]` Prevent false prefetch detection for mobile navigation in middlewares and  ([#2102](https://github.com/Sitecore/jss/pull/2102)) 
+* `[sitecore-jss-nextjs]` Add `Cache-Control: no-store, no-cache, must-revalidate` to personalize middleware to ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#2105](https://github.com/Sitecore/jss/pull/2105))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -493,9 +493,16 @@ describe('PersonalizeMiddleware', () => {
           ...req.headers,
         },
       });
+
+      console.log(
+        'Actual response headers:',
+        JSON.stringify(Object.fromEntries(Object.entries(res.headers)), null, 2)
+      );
+
       validateDebugLog('skipped (prefetch)');
       expect(finalRes).to.deep.equal(res);
       expect(finalRes.headers['x-middleware-cache']).to.equal('no-cache');
+      expect(finalRes.headers['Cache-Control']).to.equal('no-store, must-revalidate');
     });
   });
 
@@ -511,6 +518,11 @@ describe('PersonalizeMiddleware', () => {
     const { middleware } = createMiddleware();
 
     const finalRes = await middleware.getHandler()(req, res);
+
+    console.log(
+      'Actual response headers:',
+      JSON.stringify(Object.fromEntries(Object.entries(res.headers)), null, 2)
+    );
 
     validateDebugLog('personalize middleware start: %o', {
       hostname: 'foo.net',

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.test.ts
@@ -494,11 +494,6 @@ describe('PersonalizeMiddleware', () => {
         },
       });
 
-      console.log(
-        'Actual response headers:',
-        JSON.stringify(Object.fromEntries(Object.entries(res.headers)), null, 2)
-      );
-
       validateDebugLog('skipped (prefetch)');
       expect(finalRes).to.deep.equal(res);
       expect(finalRes.headers['x-middleware-cache']).to.equal('no-cache');
@@ -518,11 +513,6 @@ describe('PersonalizeMiddleware', () => {
     const { middleware } = createMiddleware();
 
     const finalRes = await middleware.getHandler()(req, res);
-
-    console.log(
-      'Actual response headers:',
-      JSON.stringify(Object.fromEntries(Object.entries(res.headers)), null, 2)
-    );
 
     validateDebugLog('personalize middleware start: %o', {
       hostname: 'foo.net',

--- a/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/personalize-middleware.ts
@@ -329,6 +329,7 @@ export class PersonalizeMiddleware extends MiddlewareBase {
       // Disable preflight caching to force revalidation on client-side navigation (personalization WILL be influenced).
       // Note the reason we don't move this any earlier in the middleware is that we would then be sacrificing performance for non-personalized pages.
       response.headers.set('x-middleware-cache', 'no-cache');
+      response.headers.set('Cache-Control', 'no-store, must-revalidate');
       return response;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This issue began after upgrading to Next.js 15, where personalization was no longer applied during client side navigation due to cached responses being served by the server. Previously, setting `x-middleware-cache: no-cache` only disabled caching within the Next.js middleware but had no effect on browser or CDN-level caching. To address this, we now add the `Cache-Control: no-store, no-cache, must-revalidate` header to non-prefetch responses, ensuring all requests bypass intermediary caches and always fetch fresh, personalized content from the server.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
