### PR TITLE
[sitecore-jss-proxy] Fix build failure of XMCloud Proxy application when using PNPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Our versioning strategy is as follows:
 * `[templates/NextJs-Styleguide]` `[templates/NextJs-Styleguide-Tracking]` Bug fixes in Styleguide-Layout-Tabs-Tab, Styleguide-Layout-Tabs, Styleguide-Tracking components ([#2100](https://github.com/Sitecore/jss/pull/2100))
 * `[sitecore-jss-nextjs]` Prevent false prefetch detection for mobile navigation in middlewares and  ([#2102](https://github.com/Sitecore/jss/pull/2102)) 
 * `[sitecore-jss-nextjs]` Add `Cache-Control: no-store, no-cache, must-revalidate` to personalize middleware to ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#2105](https://github.com/Sitecore/jss/pull/2105))
+* `[sitecore-jss-proxy]` Fix build failure of XMCloud Proxy application when using PNPM ([#2106](https://github.com/Sitecore/jss/pull/2106))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-proxy/src/middleware/editing/index.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/index.ts
@@ -101,7 +101,7 @@ const editingNotFoundMiddleware = (req: Request, res: Response) => {
  * @param {EditingRouterConfig} options Editing router configuration
  * @returns {Router} Editing router
  */
-export const editingRouter = (options: EditingRouterConfig) => {
+export const editingRouter = (options: EditingRouterConfig): Router => {
   const router = Router();
 
   router.use(editingMiddleware);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
When the Router type is not explicitly imported from "express" and is instead inferred from "express-serve-static-core", it can lead to TypeScript build errors. This happens because "express-serve-static-core" is a transitive dependency. In case of version mismatches or conflicts, TypeScript may resolve it from a nested @types subfolder (e.g., node_modules/@types/express/node_modules/@types/express-serve-static-core), which breaks type resolution and causes type check failures and mismatch.

To avoid this issue, the Router type should be explicitly imported from "express" to ensure consistent type resolution.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
