### PR TITLE
[sitecore-jss-nextjs] Improve device detection logic for Personalize middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-react]` Add an optional `disableSuspense` flag to the Placeholder component to prevent error boundaries from rendering Suspense which helps contain errors for components. This can help avoid hydration issues in connected mode. ([#2081](https://github.com/Sitecore/jss/pull/2081))([#2085](https://github.com/Sitecore/jss/pull/2085))
 * `[templates/NextJs-Styleguide]` `[templates/NextJs-Styleguide-Tracking]` Bug fixes in Styleguide-Layout-Tabs-Tab, Styleguide-Layout-Tabs, Styleguide-Tracking components ([#2100](https://github.com/Sitecore/jss/pull/2100))
-* `[sitecore-jss-nextjs]` Prevent false prefetch detection for mobile navigation in middlewares and  ([#2102](https://github.com/Sitecore/jss/pull/2102)) 
+* `[sitecore-jss-nextjs]` Improve device detection and prevent false prefetch handling in Personalize middleware. ([#2102](https://github.com/Sitecore/jss/pull/2102)) ([#2107](https://github.com/Sitecore/jss/pull/2107)) 
 * `[sitecore-jss-nextjs]` Add `Cache-Control: no-store, no-cache, must-revalidate` to personalize middleware to ensure personalized responses are not served from prefetch cache and proper personalization was applied during client side navigation. ([#2105](https://github.com/Sitecore/jss/pull/2105))
 * `[sitecore-jss-proxy]` Fix build failure of XMCloud Proxy application when using PNPM ([#2106](https://github.com/Sitecore/jss/pull/2106))
 

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.test.ts
@@ -150,13 +150,12 @@ describe('MiddlewareBase', () => {
       expect(middleware['isPrefetch'](req)).to.equal(false);
     });
 
-    it('should return false when a mobile device is detected via sec-ch-ua-mobile', () => {
+    it('returns false for known device with x-middleware-prefetch header', () => {
       const middleware = new SampleMiddleware({ siteResolver: new MockSiteResolver([]) });
       const req = createReq({
         headerValues: {
-          purpose: 'prefetch',
-          'sec-ch-ua-mobile': '?1',
           'x-middleware-prefetch': '1',
+          'user-agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X)',
         },
       });
 

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
@@ -56,7 +56,7 @@ export abstract class MiddlewareBase {
   protected isPrefetch(req: NextRequest): boolean {
     const isMobile = req.headers.get('sec-ch-ua-mobile') === '?1';
     const userAgent = req.headers.get('user-agent') || '';
-    const isKnownPlatform = /iPhone|Mac|Linux|Windows/i.test(userAgent);
+    const isKnownPlatform = /iPhone|Mac|Linux|Windows|Android/i.test(userAgent);
     const isKnownDevice = isMobile || isKnownPlatform;
 
     const purpose = req.headers.get('purpose');

--- a/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/middleware.ts
@@ -55,13 +55,17 @@ export abstract class MiddlewareBase {
    */
   protected isPrefetch(req: NextRequest): boolean {
     const isMobile = req.headers.get('sec-ch-ua-mobile') === '?1';
+    const userAgent = req.headers.get('user-agent') || '';
+    const isKnownPlatform = /iPhone|Mac|Linux|Windows/i.test(userAgent);
+    const isKnownDevice = isMobile || isKnownPlatform;
+
     const purpose = req.headers.get('purpose');
     const nextRouterPrefetch = req.headers.get('Next-Router-Prefetch');
     const middlewarePrefetch = req.headers.get('x-middleware-prefetch');
 
-    // Mobile requests often include 'prefetch' headers even during real navigations.
-    // We rely on 'x-middleware-prefetch' to more accurately identify actual prefetches on mobile.
-    if (isMobile && middlewarePrefetch === '1') {
+    // Some real navigations on different devices may incorrectly include 'prefetch' headers.
+    // To avoid skipping personalization in such cases, we treat 'x-middleware-prefetch' as a more reliable signal of true prefetch behavior.
+    if (isKnownDevice && middlewarePrefetch === '1') {
       return false;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Follow up of https://github.com/Sitecore/jss/pull/2102
Refines the `isMobile` check to more accurately detect real user devices by considering known platform indicators (like iPhone, Mac, Linux, Windows) in addition to the `sec-ch-ua-mobile` header. This helps ensure that personalization is consistently applied across devices where standard mobile headers may not be set.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
