### PR TITLE
[sitecore-jss-nextjs] Normalize redirect path matching to be case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextjs]` Ensure Redirect Middleware Handles Case-Insensitive Path Matching to Prevent Missed Redirects Due to Casing Differences ([#2114](https://github.com/Sitecore/jss/pull/2114))
+
 ## 22.8.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
-* `[sitecore-jss-nextjs]` Ensure Redirect Middleware Handles Case-Insensitive Path Matching to Prevent Missed Redirects Due to Casing Differences ([#2114](https://github.com/Sitecore/jss/pull/2114))
+* `[sitecore-jss-nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#2114](https://github.com/Sitecore/jss/pull/2114))
 
 ## 22.8.0
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -19,7 +19,7 @@ import { REWRITE_HEADER_NAME } from './middleware';
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
-describe.only('RedirectsMiddleware', () => {
+describe('RedirectsMiddleware', () => {
   let nextRedirectStub, nextRewriteStub;
 
   const debugSpy = spy(debug, 'redirects');

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -19,7 +19,7 @@ import { REWRITE_HEADER_NAME } from './middleware';
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
-describe('RedirectsMiddleware', () => {
+describe.only('RedirectsMiddleware', () => {
   let nextRedirectStub, nextRewriteStub;
 
   const debugSpy = spy(debug, 'redirects');
@@ -1818,6 +1818,60 @@ describe('RedirectsMiddleware', () => {
           {
             pattern: '/About',
             target: '/Found',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req
+        );
+
+        validateEndMessageDebugLog('redirects middleware end in %dms: %o', {
+          headers: {},
+          redirected: undefined,
+          status: 301,
+          url,
+        });
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        expect(siteResolver.getByHost).to.have.been.called;
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(301);
+      });
+
+      it('should redirect to lowercase target even if incoming path is mixed-case', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/about',
+          pathname: '/about',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/AnotherPage',
+              href: 'http://localhost:3000/AnotherPage',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        setupRedirectStub(301);
+        res.headers.set('x-middleware-next', '1');
+        res.headers.set('x-middleware-rewrite', '1');
+        res.headers.set(REWRITE_HEADER_NAME, 1);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: '/anotherpage',
+            target: '/about',
             redirectType: REDIRECT_TYPE_301,
             isQueryStringPreserved: false,
             locale: 'en',

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -86,7 +86,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
       req.nextUrl.clone()
     );
     const locale = this.getLanguage(req);
-    const normalizedPath = incomingURL.replace(/\/*$/gi, '');
+    const normalizedPath = incomingURL.replace(/\/*$/gi, '').toLowerCase();
     const redirects = await this.getRedirects(siteName);
     const language = this.getLanguage(req);
     const modifyRedirects = structuredClone(redirects);
@@ -101,7 +101,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
               ? redirect.pattern.slice(0, -1).split('?')
               : redirect.pattern.split('?');
             const patternQS = urlArray[1];
-            let patternPath = urlArray[0];
+            let patternPath = urlArray[0].toLowerCase();
             // nextjs routes are case-sensitive, but locales should be compared case-insensitively
             const patternParts = patternPath.split('/');
             const maybeLocale = patternParts[1].toLowerCase();
@@ -109,6 +109,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
             if (new RegExp(this.locales.join('|'), 'i').test(maybeLocale)) {
               patternPath = patternPath.replace(`/${patternParts[1]}`, `/${maybeLocale}`);
             }
+
             return (
               (patternPath === localePath || patternPath === normalizedPath) &&
               (!patternQS ||
@@ -194,6 +195,7 @@ export class RedirectsMiddleware extends MiddlewareBase {
       if (this.isPrefetch(req)) {
         debug.redirects('skipped (prefetch)');
         response.headers.set('x-middleware-cache', 'no-cache');
+        response.headers.set('Cache-Control', 'no-store, must-revalidate');
         return response;
       }
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -109,7 +109,6 @@ export class RedirectsMiddleware extends MiddlewareBase {
             if (new RegExp(this.locales.join('|'), 'i').test(maybeLocale)) {
               patternPath = patternPath.replace(`/${patternParts[1]}`, `/${maybeLocale}`);
             }
-
             return (
               (patternPath === localePath || patternPath === normalizedPath) &&
               (!patternQS ||


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
This PR updates the redirect middleware to perform case-insensitive matching between the incoming request path and redirect patterns by lowercasing both values. This ensures redirects like /AnotherPage → /about are correctly applied even if the request URL casing differs from the stored pattern.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
