### PR TITLE
[sitecore-jss-nextjs] Add support for displayName based routing with special character encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. ([#2120](https://github.com/Sitecore/jss/pull/2120))
 
-
 ## 22.8.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#2114](https://github.com/Sitecore/jss/pull/2114))
 
+### 🎉 New Features & Improvements
+
+* `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. ([#2120](https://github.com/Sitecore/jss/pull/2120))
+
+
 ## 22.8.0
 
 ### 🎉 New Features & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. ([#2120](https://github.com/Sitecore/jss/pull/2120))
+* `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. This feature can be enabled by setting the `enableDisplayNameRouting` flag to true. By default, it is set to false. ([#2120](https://github.com/Sitecore/jss/pull/2120))
 
 ## 22.8.0
 

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -256,18 +256,32 @@ export abstract class BaseGraphQLSitemapService {
   ): Promise<StaticPath[]> {
     const aggregatedPaths: StaticPath[] = [];
 
-    // Step 1: Create a map of item segment -> displayName
+    // Build a map of the last segment of each path to its encoded display name.
+    // This is used later to substitute the final segment with a display name if available.
     const displayNameMap = new Map<string, string>();
     for (const item of sitePaths) {
+      if (!item || typeof item.path !== 'string') continue;
+
       const segments = item.path.replace(/^\/|\/$/g, '').split('/');
       const lastSegment = segments[segments.length - 1];
       const displayName = item.route?.displayName;
+
       if (displayName) {
         displayNameMap.set(lastSegment, encodeURIComponent(displayName));
       }
     }
 
-    // Step 2: Generate combinations recursively
+    /**
+     * STEP 2: Recursively generate all path combinations using either:
+     * - The item name segment (default)
+     * - Or the display name (if available in the map)
+     *
+     * For example: if path is ['about', 'team'] and displayName for 'team' is 'Team-Page',
+     * it will generate:
+     * - ['about', 'team']
+     * - ['about', 'Team-Page']
+     * @param segments
+     */
     const generateCombinations = (segments: string[]): string[][] => {
       const results: string[][] = [];
 
@@ -280,12 +294,12 @@ export abstract class BaseGraphQLSitemapService {
         const segment = segments[index];
         const display = displayNameMap.get(segment);
 
-        // Add itemName version
+        // Use item name segment
         current.push(segment);
         helper(index + 1, current);
         current.pop();
 
-        // Add displayName version (if available and different)
+        // Use display name segment (if different)
         if (display && display !== segment) {
           current.push(display);
           helper(index + 1, current);
@@ -297,18 +311,26 @@ export abstract class BaseGraphQLSitemapService {
       return results;
     };
 
+    /**
+     * Process each route in the result set to:
+     * - Add itemName-based and displayName-based paths
+     * - Add personalized variants (if applicable) for each of those paths
+     */
     for (const item of sitePaths) {
-      if (!item) continue;
+      if (!item || typeof item.path !== 'string') continue;
 
       const itemPath = item.path.replace(/^\/|\/$/g, '');
       const segments = itemPath ? itemPath.split('/') : [];
 
+      // Generate all display/item name path combinations
       const allCombinations = generateCombinations(segments);
+
+      // Add plain paths to the aggregated paths list
       for (const combo of allCombinations) {
         aggregatedPaths.push(formatStaticPath(combo, language));
       }
 
-      // Step 3: Handle personalization
+      // Check for personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
         (variantId) => !variantId.includes('_')
       );
@@ -325,41 +347,6 @@ export abstract class BaseGraphQLSitemapService {
     }
 
     return aggregatedPaths;
-  }
-
-  protected async fetchLanguageSitePaths(
-    language: string,
-    siteName: string
-  ): Promise<RouteListQueryResult[]> {
-    const args: SiteRouteQueryVariables = {
-      siteName: siteName,
-      language: language,
-      pageSize: this.options.pageSize,
-      includedPaths: this.options.includedPaths,
-      excludedPaths: this.options.excludedPaths,
-    };
-    let results: RouteListQueryResult[] = [];
-    let hasNext = true;
-    let after = '';
-
-    while (hasNext) {
-      const fetchResponse = await this.graphQLClient.request<
-        SiteRouteQueryResult<RouteListQueryResult>
-      >(this.query, {
-        ...args,
-        after,
-      });
-
-      if (!fetchResponse?.site?.siteInfo) {
-        throw new RangeError(getSiteEmptyError(siteName));
-      } else {
-        results = results.concat(fetchResponse.site.siteInfo.routes?.results);
-        hasNext = fetchResponse.site.siteInfo.routes?.pageInfo.hasNext;
-        after = fetchResponse.site.siteInfo.routes?.pageInfo.endCursor;
-      }
-    }
-
-    return results;
   }
 
   /**

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -50,6 +50,9 @@ query ${usesPersonalize ? 'PersonalizeSitemapQuery' : 'DefaultSitemapQuery'}(
         }
         results {
           path: routePath
+          route {
+            displayName
+          }
           ${
             usesPersonalize
               ? `
@@ -120,6 +123,7 @@ export interface SiteRouteQueryResult<T> {
 export type RouteListQueryResult = {
   path: string;
   route?: {
+    displayName: string;
     personalization?: {
       variantIds: string[];
     };
@@ -258,14 +262,27 @@ export abstract class BaseGraphQLSitemapService {
     sitePaths.forEach((item) => {
       if (!item) return;
 
-      aggregatedPaths.push(formatPath(item.path));
+      // ItemName-based path
+      const itemNamePath = item.path;
+      aggregatedPaths.push(formatPath(itemNamePath));
 
+      // DisplayName-based path
+      const displayName = item.route?.displayName;
+      if (typeof displayName === 'string' && displayName.trim().length > 0) {
+        const encodedDisplayName = encodeURIComponent(displayName);
+        const pathSegments = itemNamePath.replace(/^\/|\/$/g, '').split('/');
+        pathSegments[pathSegments.length - 1] = encodedDisplayName;
+
+        aggregatedPaths.push(formatStaticPath(pathSegments, language));
+      }
+
+      // Personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_') // exclude component A/B test variants
+        (variantId) => !variantId.includes('_')
       );
       if (variantIds?.length) {
         aggregatedPaths.push(
-          ...variantIds.map((varId) => formatPath(getPersonalizedRewrite(item.path, [varId])))
+          ...variantIds.map((varId) => formatPath(getPersonalizedRewrite(itemNamePath, [varId])))
         );
       }
     });

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -262,7 +262,10 @@ export abstract class BaseGraphQLSitemapService {
   ): Promise<StaticPath[]> {
     const aggregatedPaths: StaticPath[] = [];
 
-    // Step 1: Build display name map (only if display name routing is enabled)
+    /**
+     * Build a map of the last segment of each path to its encoded display name.
+     * This is used later to substitute the final segment with a display name if available.
+     */
     const displayNameMap = new Map<string, string>();
     if (this._enableDisplayNameRouting) {
       for (const item of sitePaths) {
@@ -278,10 +281,20 @@ export abstract class BaseGraphQLSitemapService {
       }
     }
 
-    // Step 2: Combination generator (item name only or display name permutations)
+    /**
+     * Recursively generate all path combinations using either:
+     * - The item name segment (default)
+     * - Or the display name (if available in the map)
+     *
+     * For example: if path is ['about', 'team'] and displayName for 'team' is 'Team-Page',
+     * it will generate:
+     * - ['about', 'team']
+     * - ['about', 'Team-Page']
+     * @param {string[]} segments
+     */
     const generateCombinations = (segments: string[]): string[][] => {
       if (!this._enableDisplayNameRouting) {
-        return [segments]; // Only item name path
+        return [segments];
       }
 
       const results: string[][] = [];
@@ -312,21 +325,26 @@ export abstract class BaseGraphQLSitemapService {
       return results;
     };
 
-    // Step 3: Process each route
+    /**
+     * Process each route in the result set to:
+     * - Add itemName-based and displayName-based paths
+     * - Add personalized variants (if applicable) for each of those paths
+     */
     for (const item of sitePaths) {
       if (!item || typeof item.path !== 'string') continue;
 
       const itemPath = item.path.replace(/^\/|\/$/g, '');
       const segments = itemPath ? itemPath.split('/') : [];
 
+      // Generate all display/item name path combinations
       const allCombinations = generateCombinations(segments);
 
-      // 3a. Add non-personalized paths
+      // Add plain paths to the aggregated paths list
       for (const combo of allCombinations) {
         aggregatedPaths.push(formatStaticPath(combo, language));
       }
 
-      // 3b. Add personalized paths
+      // Check for personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
         (variantId) => !variantId.includes('_')
       );

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -278,7 +278,7 @@ export abstract class BaseGraphQLSitemapService {
 
       // Personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_')
+        (variantId) => !variantId.includes('_') // exclude component A/B test variants
       );
       if (variantIds?.length) {
         aggregatedPaths.push(

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -254,38 +254,75 @@ export abstract class BaseGraphQLSitemapService {
     formatStaticPath: (path: string[], language: string) => StaticPath,
     language: string
   ): Promise<StaticPath[]> {
-    const formatPath = (path: string) =>
-      formatStaticPath(path.replace(/^\/|\/$/g, '').split('/'), language);
-
     const aggregatedPaths: StaticPath[] = [];
 
-    sitePaths.forEach((item) => {
-      if (!item) return;
-
-      // ItemName-based path
-      const itemNamePath = item.path;
-      aggregatedPaths.push(formatPath(itemNamePath));
-
-      // DisplayName-based path
+    // Step 1: Create a map of item segment -> displayName
+    const displayNameMap = new Map<string, string>();
+    for (const item of sitePaths) {
+      const segments = item.path.replace(/^\/|\/$/g, '').split('/');
+      const lastSegment = segments[segments.length - 1];
       const displayName = item.route?.displayName;
-      if (typeof displayName === 'string' && displayName.trim().length > 0) {
-        const encodedDisplayName = encodeURIComponent(displayName);
-        const pathSegments = itemNamePath.replace(/^\/|\/$/g, '').split('/');
-        pathSegments[pathSegments.length - 1] = encodedDisplayName;
+      if (displayName) {
+        displayNameMap.set(lastSegment, encodeURIComponent(displayName));
+      }
+    }
 
-        aggregatedPaths.push(formatStaticPath(pathSegments, language));
+    // Step 2: Generate combinations recursively
+    const generateCombinations = (segments: string[]): string[][] => {
+      const results: string[][] = [];
+
+      const helper = (index: number, current: string[]) => {
+        if (index === segments.length) {
+          results.push([...current]);
+          return;
+        }
+
+        const segment = segments[index];
+        const display = displayNameMap.get(segment);
+
+        // Add itemName version
+        current.push(segment);
+        helper(index + 1, current);
+        current.pop();
+
+        // Add displayName version (if available and different)
+        if (display && display !== segment) {
+          current.push(display);
+          helper(index + 1, current);
+          current.pop();
+        }
+      };
+
+      helper(0, []);
+      return results;
+    };
+
+    for (const item of sitePaths) {
+      if (!item) continue;
+
+      const itemPath = item.path.replace(/^\/|\/$/g, '');
+      const segments = itemPath ? itemPath.split('/') : [];
+
+      const allCombinations = generateCombinations(segments);
+      for (const combo of allCombinations) {
+        aggregatedPaths.push(formatStaticPath(combo, language));
       }
 
-      // Personalization variants
+      // Step 3: Handle personalization
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_') // exclude component A/B test variants
+        (variantId) => !variantId.includes('_')
       );
+
       if (variantIds?.length) {
-        aggregatedPaths.push(
-          ...variantIds.map((varId) => formatPath(getPersonalizedRewrite(itemNamePath, [varId])))
-        );
+        for (const variantId of variantIds) {
+          for (const combo of allCombinations) {
+            const rewritePath = getPersonalizedRewrite('/' + combo.join('/'), [variantId]);
+            const variantSegments = rewritePath.replace(/^\/|\/$/g, '').split('/');
+            aggregatedPaths.push(formatStaticPath(variantSegments, language));
+          }
+        }
       }
-    });
+    }
 
     return aggregatedPaths;
   }

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -142,6 +142,10 @@ export interface BaseGraphQLSitemapServiceConfig
    */
   includePersonalizedRoutes?: boolean;
   /**
+   * Gets a flag indicating whether display name routing is enabled.
+   */
+  enableDisplayNameRouting?: boolean;
+  /**
    * A GraphQL Request Client Factory is a function that accepts configuration and returns an instance of a GraphQLRequestClient.
    * This factory function is used to create and configure GraphQL clients for making GraphQL API requests.
    */
@@ -166,6 +170,7 @@ export type StaticPath = {
  */
 export abstract class BaseGraphQLSitemapService {
   private _graphQLClient: GraphQLClient;
+  private _enableDisplayNameRouting: boolean;
 
   /**
    * Creates an instance of graphQL sitemap service with the provided options
@@ -173,6 +178,7 @@ export abstract class BaseGraphQLSitemapService {
    */
   constructor(public options: BaseGraphQLSitemapServiceConfig) {
     this._graphQLClient = this.getGraphQLClient();
+    this._enableDisplayNameRouting = options.enableDisplayNameRouting ?? false;
   }
 
   /**
@@ -256,33 +262,28 @@ export abstract class BaseGraphQLSitemapService {
   ): Promise<StaticPath[]> {
     const aggregatedPaths: StaticPath[] = [];
 
-    // Build a map of the last segment of each path to its encoded display name.
-    // This is used later to substitute the final segment with a display name if available.
+    // Step 1: Build display name map (only if display name routing is enabled)
     const displayNameMap = new Map<string, string>();
-    for (const item of sitePaths) {
-      if (!item || typeof item.path !== 'string') continue;
+    if (this._enableDisplayNameRouting) {
+      for (const item of sitePaths) {
+        if (!item || typeof item.path !== 'string') continue;
 
-      const segments = item.path.replace(/^\/|\/$/g, '').split('/');
-      const lastSegment = segments[segments.length - 1];
-      const displayName = item.route?.displayName;
+        const segments = item.path.replace(/^\/|\/$/g, '').split('/');
+        const lastSegment = segments[segments.length - 1];
+        const displayName = item.route?.displayName;
 
-      if (displayName) {
-        displayNameMap.set(lastSegment, encodeURIComponent(displayName));
+        if (displayName) {
+          displayNameMap.set(lastSegment, encodeURIComponent(displayName));
+        }
       }
     }
 
-    /**
-     * STEP 2: Recursively generate all path combinations using either:
-     * - The item name segment (default)
-     * - Or the display name (if available in the map)
-     *
-     * For example: if path is ['about', 'team'] and displayName for 'team' is 'Team-Page',
-     * it will generate:
-     * - ['about', 'team']
-     * - ['about', 'Team-Page']
-     * @param segments
-     */
+    // Step 2: Combination generator (item name only or display name permutations)
     const generateCombinations = (segments: string[]): string[][] => {
+      if (!this._enableDisplayNameRouting) {
+        return [segments]; // Only item name path
+      }
+
       const results: string[][] = [];
 
       const helper = (index: number, current: string[]) => {
@@ -294,12 +295,12 @@ export abstract class BaseGraphQLSitemapService {
         const segment = segments[index];
         const display = displayNameMap.get(segment);
 
-        // Use item name segment
+        // Item name segment
         current.push(segment);
         helper(index + 1, current);
         current.pop();
 
-        // Use display name segment (if different)
+        // Display name segment (if available and different)
         if (display && display !== segment) {
           current.push(display);
           helper(index + 1, current);
@@ -311,26 +312,21 @@ export abstract class BaseGraphQLSitemapService {
       return results;
     };
 
-    /**
-     * Process each route in the result set to:
-     * - Add itemName-based and displayName-based paths
-     * - Add personalized variants (if applicable) for each of those paths
-     */
+    // Step 3: Process each route
     for (const item of sitePaths) {
       if (!item || typeof item.path !== 'string') continue;
 
       const itemPath = item.path.replace(/^\/|\/$/g, '');
       const segments = itemPath ? itemPath.split('/') : [];
 
-      // Generate all display/item name path combinations
       const allCombinations = generateCombinations(segments);
 
-      // Add plain paths to the aggregated paths list
+      // 3a. Add non-personalized paths
       for (const combo of allCombinations) {
         aggregatedPaths.push(formatStaticPath(combo, language));
       }
 
-      // Check for personalization variants
+      // 3b. Add personalized paths
       const variantIds = item.route?.personalization?.variantIds?.filter(
         (variantId) => !variantId.includes('_')
       );
@@ -347,6 +343,41 @@ export abstract class BaseGraphQLSitemapService {
     }
 
     return aggregatedPaths;
+  }
+
+  protected async fetchLanguageSitePaths(
+    language: string,
+    siteName: string
+  ): Promise<RouteListQueryResult[]> {
+    const args: SiteRouteQueryVariables = {
+      siteName: siteName,
+      language: language,
+      pageSize: this.options.pageSize,
+      includedPaths: this.options.includedPaths,
+      excludedPaths: this.options.excludedPaths,
+    };
+    let results: RouteListQueryResult[] = [];
+    let hasNext = true;
+    let after = '';
+
+    while (hasNext) {
+      const fetchResponse = await this.graphQLClient.request<
+        SiteRouteQueryResult<RouteListQueryResult>
+      >(this.query, {
+        ...args,
+        after,
+      });
+
+      if (!fetchResponse?.site?.siteInfo) {
+        throw new RangeError(getSiteEmptyError(siteName));
+      } else {
+        results = results.concat(fetchResponse.site.siteInfo.routes?.results);
+        hasNext = fetchResponse.site.siteInfo.routes?.pageInfo.hasNext;
+        after = fetchResponse.site.siteInfo.routes?.pageInfo.endCursor;
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -377,6 +377,7 @@ describe('GraphQLSitemapService', () => {
           clientFactory,
           siteName,
           includePersonalizedRoutes: true,
+          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
@@ -503,6 +504,7 @@ describe('GraphQLSitemapService', () => {
         const service = new GraphQLSitemapService({
           clientFactory,
           siteName,
+          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
@@ -557,6 +559,7 @@ describe('GraphQLSitemapService', () => {
         const service = new GraphQLSitemapService({
           clientFactory,
           siteName,
+          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -49,7 +49,7 @@ it('should return null if no app root found', async () => {
   });
 });
 */
-describe('GraphQLSitemapService', () => {
+describe.only('GraphQLSitemapService', () => {
   const endpoint = 'http://site';
   const apiKey = 'some-api-key';
   const siteName = 'site-name';
@@ -295,7 +295,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [''],
+              path: [],
             },
             locale: lang,
           },
@@ -333,6 +333,110 @@ describe('GraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
+      it.only('should return personalized displayName paths for a single site', async () => {
+        const lang = 'ua';
+
+        nock(endpoint)
+          .post('/', /PersonalizeSitemapQuery/gi)
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 2,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/',
+                        route: {
+                          displayName: 'Home',
+                          personalization: {
+                            variantIds: ['green'],
+                          },
+                        },
+                      },
+                      {
+                        path: '/y1/y2/y3/y4',
+                        route: {
+                          displayName: 'Y-Four',
+                          personalization: {
+                            variantIds: ['red', 'blue'],
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+
+        const service = new GraphQLSitemapService({
+          clientFactory,
+          siteName,
+          includePersonalizedRoutes: true,
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        console.log(JSON.stringify(sitemap, null, 2));
+
+        expect(sitemap).to.have.deep.members([
+          {
+            params: {
+              path: [],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['_variantId_green'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['y1', 'y2', 'y3', 'y4'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['y1', 'y2', 'y3', 'Y-Four'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['_variantId_red', 'y1', 'y2', 'y3', 'y4'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['_variantId_red', 'y1', 'y2', 'y3', 'Y-Four'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['_variantId_blue', 'y1', 'y2', 'y3', 'y4'],
+            },
+            locale: lang,
+          },
+          {
+            params: {
+              path: ['_variantId_blue', 'y1', 'y2', 'y3', 'Y-Four'],
+            },
+            locale: lang,
+          },
+        ]);
+
+        return expect(nock.isDone()).to.be.true;
+      });
+
       it('should not return personalized paths when personalize data is requested and component a/b testing returned', async () => {
         const lang = 'ua';
 
@@ -350,7 +454,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [''],
+              path: [],
             },
             locale: lang,
           },
@@ -423,11 +527,7 @@ describe('GraphQLSitemapService', () => {
             locale: lang,
           },
           {
-            params: { path: [''] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home'] },
+            params: { path: [] },
             locale: lang,
           },
         ]);
@@ -463,6 +563,8 @@ describe('GraphQLSitemapService', () => {
 
         const sitemap = await service.fetchSSGSitemap([lang]);
 
+        console.log(JSON.stringify(sitemap, null, 2));
+
         expect(sitemap).to.deep.equal([
           {
             params: { path: ['about'] },
@@ -481,11 +583,7 @@ describe('GraphQLSitemapService', () => {
             locale: lang,
           },
           {
-            params: { path: [''] },
-            locale: lang,
-          },
-          {
-            params: { path: ['H%C3%B4me'] },
+            params: { path: [] },
             locale: lang,
           },
         ]);
@@ -531,7 +629,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [''],
+              path: [],
             },
             locale: 'en',
           },
@@ -648,7 +746,7 @@ describe('GraphQLSitemapService', () => {
   const expectedSinglesiteExportSitemap = [
     {
       params: {
-        path: [''],
+        path: [],
       },
     },
     {

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -49,7 +49,7 @@ it('should return null if no app root found', async () => {
   });
 });
 */
-describe.only('GraphQLSitemapService', () => {
+describe('GraphQLSitemapService', () => {
   const endpoint = 'http://site';
   const apiKey = 'some-api-key';
   const siteName = 'site-name';
@@ -333,7 +333,7 @@ describe.only('GraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
-      it.only('should return personalized displayName paths for a single site', async () => {
+      it('should return personalized displayName paths for a single site', async () => {
         const lang = 'ua';
 
         nock(endpoint)
@@ -380,8 +380,6 @@ describe.only('GraphQLSitemapService', () => {
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
-
-        console.log(JSON.stringify(sitemap, null, 2));
 
         expect(sitemap).to.have.deep.members([
           {
@@ -562,8 +560,6 @@ describe.only('GraphQLSitemapService', () => {
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
-
-        console.log(JSON.stringify(sitemap, null, 2));
 
         expect(sitemap).to.deep.equal([
           {

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -92,7 +92,7 @@ describe('GraphQLSitemapService', () => {
       );
   };
 
-  describe.only('Fetch sitemap in SSG mode', () => {
+  describe('Fetch sitemap in SSG mode', () => {
     it('should work when 1 language is requested', async () => {
       mockPathsRequest();
 
@@ -364,7 +364,7 @@ describe('GraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
-      it.only('should return both itemName and encoded displayName paths for routes with displayName', async () => {
+      it('should return both itemName and encoded displayName paths for routes with displayName', async () => {
         const lang = 'en';
 
         nock(endpoint)
@@ -435,7 +435,7 @@ describe('GraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
-      it.only('should return encoded displayName paths when special characters are used', async () => {
+      it('should return encoded displayName paths when special characters are used', async () => {
         const lang = 'en';
 
         // Å → %C3%85, ü → %C3%BC, ç → %C3%A7

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -62,7 +62,9 @@ describe('GraphQLSitemapService', () => {
     nock.cleanAll();
   });
 
-  const mockPathsRequest = (results?: { url: { path: string } }[]) => {
+  const mockPathsRequest = (
+    results?: { path: string; route?: { displayName?: string | null } }[]
+  ) => {
     nock(endpoint)
       .post('/', /DefaultSitemapQuery/gi)
       .reply(
@@ -78,7 +80,10 @@ describe('GraphQLSitemapService', () => {
                       pageInfo: {
                         hasNext: false,
                       },
-                      results,
+                      results: results.map((item) => ({
+                        path: item.path,
+                        route: item.route || { displayName: null },
+                      })),
                     },
                   },
                 },
@@ -87,7 +92,7 @@ describe('GraphQLSitemapService', () => {
       );
   };
 
-  describe('Fetch sitemap in SSG mode', () => {
+  describe.only('Fetch sitemap in SSG mode', () => {
     it('should work when 1 language is requested', async () => {
       mockPathsRequest();
 
@@ -356,6 +361,135 @@ describe('GraphQLSitemapService', () => {
             locale: lang,
           },
         ]);
+        return expect(nock.isDone()).to.be.true;
+      });
+
+      it.only('should return both itemName and encoded displayName paths for routes with displayName', async () => {
+        const lang = 'en';
+
+        nock(endpoint)
+          .post('/')
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 3,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/Test',
+                        route: { displayName: 'New-test' },
+                      },
+                      {
+                        path: '/About',
+                        route: { displayName: 'New-about' },
+                      },
+                      {
+                        path: '/',
+                        route: { displayName: 'Home' },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+
+        const service = new GraphQLSitemapService({
+          clientFactory,
+          siteName,
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.deep.equal([
+          {
+            params: { path: ['Test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['New-test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['About'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['New-about'] },
+            locale: lang,
+          },
+          {
+            params: { path: [''] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home'] },
+            locale: lang,
+          },
+        ]);
+
+        return expect(nock.isDone()).to.be.true;
+      });
+
+      it.only('should return encoded displayName paths when special characters are used', async () => {
+        const lang = 'en';
+
+        // Å → %C3%85, ü → %C3%BC, ç → %C3%A7
+        const results = [
+          {
+            path: '/about',
+            route: { displayName: 'Åbout' },
+          },
+          {
+            path: '/team',
+            route: { displayName: 'Tëâm' },
+          },
+          {
+            path: '/',
+            route: { displayName: 'Hôme' },
+          },
+        ];
+
+        mockPathsRequest(results);
+
+        const service = new GraphQLSitemapService({
+          clientFactory,
+          siteName,
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.deep.equal([
+          {
+            params: { path: ['about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['%C3%85bout'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['team'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['T%C3%AB%C3%A2m'] },
+            locale: lang,
+          },
+          {
+            params: { path: [''] },
+            locale: lang,
+          },
+          {
+            params: { path: ['H%C3%B4me'] },
+            locale: lang,
+          },
+        ]);
+
         return expect(nock.isDone()).to.be.true;
       });
 

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -375,6 +375,7 @@ describe('MultisiteGraphQLSitemapService', () => {
         const service = new MultisiteGraphQLSitemapService({
           clientFactory,
           sites: [site],
+          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
@@ -584,6 +585,7 @@ describe('MultisiteGraphQLSitemapService', () => {
           clientFactory,
           sites: [site],
           includePersonalizedRoutes: true,
+          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -18,7 +18,7 @@ class TestService extends MultisiteGraphQLSitemapService {
   }
 }
 
-describe.only('MultisiteGraphQLSitemapService', () => {
+describe('MultisiteGraphQLSitemapService', () => {
   const endpoint = 'http://site';
   const apiKey = 'some-api-key';
   const sites = ['site-name'];

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -18,7 +18,7 @@ class TestService extends MultisiteGraphQLSitemapService {
   }
 }
 
-describe('MultisiteGraphQLSitemapService', () => {
+describe.only('MultisiteGraphQLSitemapService', () => {
   const endpoint = 'http://site';
   const apiKey = 'some-api-key';
   const sites = ['site-name'];
@@ -350,78 +350,6 @@ describe('MultisiteGraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
-      it('should return both itemName and encoded displayName paths for routes with displayName', async () => {
-        const site = 'test-site';
-        const lang = 'en';
-
-        nock(endpoint)
-          .post('/', (body) => body.variables.siteName === site)
-          .reply(200, {
-            data: {
-              site: {
-                siteInfo: {
-                  routes: {
-                    total: 3,
-                    pageInfo: {
-                      hasNext: false,
-                    },
-                    results: [
-                      {
-                        path: '/Test',
-                        route: { displayName: 'New-test' },
-                      },
-                      {
-                        path: '/About',
-                        route: { displayName: 'New-about' },
-                      },
-                      {
-                        path: '/',
-                        route: { displayName: 'Home' },
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-          });
-
-        const service = new MultisiteGraphQLSitemapService({
-          clientFactory,
-          sites: [site],
-        });
-
-        const sitemap = await service.fetchSSGSitemap([lang]);
-
-        expect(sitemap).to.deep.equal([
-          {
-            params: { path: ['_site_test-site', 'Test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'New-test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'About'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'New-about'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home'] },
-            locale: lang,
-          },
-        ]);
-
-        return expect(nock.isDone()).to.be.true;
-      });
-
       it('should return encoded displayName paths when special characters are used', async () => {
         const site = 'test-site';
         const lang = 'en';
@@ -461,11 +389,27 @@ describe('MultisiteGraphQLSitemapService', () => {
             locale: lang,
           },
           {
+            params: { path: ['H%C3%B4me', 'about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['H%C3%B4me', '%C3%85bout'] },
+            locale: lang,
+          },
+          {
             params: { path: ['_site_test-site', 'team'] },
             locale: lang,
           },
           {
             params: { path: ['_site_test-site', 'T%C3%AB%C3%A2m'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['H%C3%B4me', 'team'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['H%C3%B4me', 'T%C3%AB%C3%A2m'] },
             locale: lang,
           },
           {
@@ -592,6 +536,101 @@ describe('MultisiteGraphQLSitemapService', () => {
             locale: lang,
           },
         ]);
+        return expect(nock.isDone()).to.be.true;
+      });
+
+      it('should return personalized displayName paths correctly', async () => {
+        const site = 'site1';
+        const lang = 'en';
+
+        nock(endpoint)
+          .post('/', /PersonalizeSitemapQuery/gi)
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 2,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/x1',
+                        route: {
+                          displayName: 'X-One',
+                          personalization: {
+                            variantIds: ['green'],
+                          },
+                        },
+                      },
+                      {
+                        path: '/y1/y2',
+                        route: {
+                          displayName: 'Y-Two',
+                          personalization: {
+                            variantIds: ['red', 'blue'],
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+
+        const service = new MultisiteGraphQLSitemapService({
+          clientFactory,
+          sites: [site],
+          includePersonalizedRoutes: true,
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.deep.equal([
+          {
+            params: { path: ['_site_site1', 'x1'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_site1', 'X-One'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_green', '_site_site1', 'x1'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_green', '_site_site1', 'X-One'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_site1', 'y1', 'y2'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_site1', 'y1', 'Y-Two'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_red', '_site_site1', 'y1', 'y2'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_red', '_site_site1', 'y1', 'Y-Two'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_blue', '_site_site1', 'y1', 'y2'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_variantId_blue', '_site_site1', 'y1', 'Y-Two'] },
+            locale: lang,
+          },
+        ]);
+
         return expect(nock.isDone()).to.be.true;
       });
 

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -18,7 +18,7 @@ class TestService extends MultisiteGraphQLSitemapService {
   }
 }
 
-describe('MultisiteGraphQLSitemapService', () => {
+describe.only('MultisiteGraphQLSitemapService', () => {
   const endpoint = 'http://site';
   const apiKey = 'some-api-key';
   const sites = ['site-name'];
@@ -31,7 +31,9 @@ describe('MultisiteGraphQLSitemapService', () => {
     nock.cleanAll();
   });
 
-  const mockPathsRequest = (results?: { url: { path: string } }[]) => {
+  const mockPathsRequest = (
+    results?: { path: string; route?: { displayName?: string | null } }[]
+  ) => {
     nock(endpoint)
       .post('/', /DefaultSitemapQuery/gi)
       .reply(
@@ -47,7 +49,10 @@ describe('MultisiteGraphQLSitemapService', () => {
                       pageInfo: {
                         hasNext: false,
                       },
-                      results,
+                      results: results.map((item) => ({
+                        path: item.path,
+                        route: item.route || { displayName: null },
+                      })),
                     },
                   },
                 },
@@ -342,6 +347,137 @@ describe('MultisiteGraphQLSitemapService', () => {
             locale: lang,
           },
         ]);
+        return expect(nock.isDone()).to.be.true;
+      });
+
+      it('should return both itemName and encoded displayName paths for routes with displayName', async () => {
+        const site = 'test-site';
+        const lang = 'en';
+
+        nock(endpoint)
+          .post('/', (body) => body.variables.siteName === site)
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 3,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/Test',
+                        route: { displayName: 'New-test' },
+                      },
+                      {
+                        path: '/About',
+                        route: { displayName: 'New-about' },
+                      },
+                      {
+                        path: '/',
+                        route: { displayName: 'Home' },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+
+        const service = new MultisiteGraphQLSitemapService({
+          clientFactory,
+          sites: [site],
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.deep.equal([
+          {
+            params: { path: ['_site_test-site', 'Test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'New-test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'About'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'New-about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home'] },
+            locale: lang,
+          },
+        ]);
+
+        return expect(nock.isDone()).to.be.true;
+      });
+
+      it('should return encoded displayName paths when special characters are used', async () => {
+        const site = 'test-site';
+        const lang = 'en';
+
+        // Å → %C3%85, ü → %C3%BC, ç → %C3%A7
+        const results = [
+          {
+            path: '/about',
+            route: { displayName: 'Åbout' },
+          },
+          {
+            path: '/team',
+            route: { displayName: 'Tëâm' },
+          },
+          {
+            path: '/',
+            route: { displayName: 'Hôme' },
+          },
+        ];
+
+        mockPathsRequest(results);
+
+        const service = new MultisiteGraphQLSitemapService({
+          clientFactory,
+          sites: [site],
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.deep.equal([
+          {
+            params: { path: ['_site_test-site', 'about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', '%C3%85bout'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'team'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'T%C3%AB%C3%A2m'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['H%C3%B4me'] },
+            locale: lang,
+          },
+        ]);
+
         return expect(nock.isDone()).to.be.true;
       });
 

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -350,6 +350,95 @@ describe('MultisiteGraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
+      it('should return both itemName and encoded displayName paths for routes with displayName', async () => {
+        const site = 'test-site';
+        const lang = 'en';
+
+        nock(endpoint)
+          .post('/', (body) => body.variables.siteName === site)
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 3,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/Test',
+                        route: { displayName: 'New-test' },
+                      },
+                      {
+                        path: '/About',
+                        route: { displayName: 'New-about' },
+                      },
+                      {
+                        path: '/',
+                        route: { displayName: 'Home' },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
+
+        const service = new MultisiteGraphQLSitemapService({
+          clientFactory,
+          sites: [site],
+          enableDisplayNameRouting: true,
+        });
+
+        const sitemap = await service.fetchSSGSitemap([lang]);
+
+        expect(sitemap).to.have.deep.members([
+          {
+            params: { path: ['_site_test-site', 'Test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'New-test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'About'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site', 'New-about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['_site_test-site'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home', 'Test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home', 'New-test'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home', 'About'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home', 'New-about'] },
+            locale: lang,
+          },
+          {
+            params: { path: ['Home'] },
+            locale: lang,
+          },
+        ]);
+
+        return expect(nock.isDone()).to.be.true;
+      });
+
       it('should return encoded displayName paths when special characters are used', async () => {
         const site = 'test-site';
         const lang = 'en';

--- a/packages/sitecore-jss-nextjs/src/test-data/sitemapServiceSinglesiteResult.ts
+++ b/packages/sitecore-jss-nextjs/src/test-data/sitemapServiceSinglesiteResult.ts
@@ -1,7 +1,7 @@
 export default [
   {
     params: {
-      path: [''],
+      path: [],
     },
     locale: 'ua',
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.

### Changes
- Extended GraphQL query to include `route.displayName`
- Updated sitemap transformation logic to generate additional paths based on `displayName`
- Ensured `displayName` paths are UTF-8 encoded using `encodeURIComponent`
- `enableDisplayNameRouting` (optional, boolean): When set to true, the service will generate static paths using the displayName of Sitecore items in addition to their itemName. Default is false.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
