### PR TITLE
[sitecore-jss-rendering-host] Replace deprecated opn npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 * `[sitecore-jss-nextjs]` Ensure Redirect Middleware handles case-insensitive path matching to prevent missed redirects due to casing differences ([#2114](https://github.com/Sitecore/jss/pull/2114))
 * `[sitecore-jss-nextjs]` Fix redirect regex processing to prevent over-escaping of question marks in regex patterns ([#2119](https://github.com/Sitecore/jss/pull/2119))
+* `[sitecore-jss-rendering-host]` Replaced deprecated opn package ([#2129](https://github.com/Sitecore/jss/pull/2129))
 
 ### 🎉 New Features & Improvements
 

--- a/packages/sitecore-jss-rendering-host/package.json
+++ b/packages/sitecore-jss-rendering-host/package.json
@@ -31,7 +31,7 @@
     "express": "^5.1.0",
     "import-fresh": "^3.3.1",
     "ngrok": "^4.3.3",
-    "opn": "^6.0.0",
+    "open": "^8.4.2",
     "webpack": "5.101.0"
   },
   "devDependencies": {

--- a/packages/sitecore-jss-rendering-host/src/devServer.ts
+++ b/packages/sitecore-jss-rendering-host/src/devServer.ts
@@ -1,9 +1,8 @@
 import { deleteSync as delSync } from 'del';
 import { Application } from 'express';
 import { PathParams } from 'express-serve-static-core';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import openBrowser from 'opn';
+import open from 'open';
+
 import path from 'path';
 import webpack from 'webpack';
 import { MultiCompiler } from 'webpack';
@@ -152,7 +151,7 @@ export function startDevServer({
       (stats) => {
         if (!browserOpened) {
           console.log('opening browser', stats.compilation.compiler.name);
-          openBrowser(urlToOpenOnStart).then(() => {
+          open(urlToOpenOnStart).then(() => {
             browserOpened = true;
           });
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6769,7 +6769,7 @@ __metadata:
     mocha: ^11.7.0
     ngrok: ^4.3.3
     nyc: ^17.1.0
-    opn: ^6.0.0
+    open: ^8.4.2
     ts-node: ^10.9.1
     typescript: ~5.9.2
     webpack: 5.101.0
@@ -22771,7 +22771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"open@npm:^8.4.0":
+"open@npm:^8.4.0, open@npm:^8.4.2":
   version: 8.4.2
   resolution: "open@npm:8.4.2"
   dependencies:
@@ -22779,15 +22779,6 @@ __metadata:
     is-docker: ^2.1.1
     is-wsl: ^2.2.0
   checksum: 6388bfff21b40cb9bd8f913f9130d107f2ed4724ea81a8fd29798ee322b361ca31fa2cdfb491a5c31e43a3996cfe9566741238c7a741ada8d7af1cb78d85cf26
-  languageName: node
-  linkType: hard
-
-"opn@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "opn@npm:6.0.0"
-  dependencies:
-    is-wsl: ^1.1.0
-  checksum: aa49c7ffb13d886611d3d74ddca42e132b0437ecde2e86c626fe52eaf223d9cf63c35f01da46b1a91187f275306375c914525c7b98685396d60019861f05b032
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Replaced the deprecated npm package: `opn` with it's replacement `open`

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
