### PR TITLE
[sitecore-jss-nextjs] Revert generating SSG paths for display names paths separately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss-nextjs]` Introduced support for using `displayName` values in route generation for statically built pages in JSS Next.js apps. This enables localized and user-friendly URLs when SXA link provider is configured to use display names.  Ensured `displayName` paths are UTF-8 encoded. This feature can be enabled by setting the `enableDisplayNameRouting` flag to true. By default, it is set to false. ([#2120](https://github.com/Sitecore/jss/pull/2120))([#2121](https://github.com/Sitecore/jss/pull/2121))
+* `[sitecore-jss-nextjs]` Ensure displayName paths are properly UTF-8 encoded. ([#2121](https://github.com/Sitecore/jss/pull/2121))
 
 ### Chores
 

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -263,7 +263,7 @@ export abstract class BaseGraphQLSitemapService {
       aggregatedPaths.push(formatStaticPath(toSegments(item.path), language));
 
       const variantIds = item.route?.personalization?.variantIds?.filter(
-        (variantId) => !variantId.includes('_')
+        (variantId) => !variantId.includes('_') // exclude component A/B test
       );
 
       if (variantIds?.length) {

--- a/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
+++ b/packages/sitecore-jss-nextjs/src/services/base-graphql-sitemap-service.ts
@@ -50,9 +50,6 @@ query ${usesPersonalize ? 'PersonalizeSitemapQuery' : 'DefaultSitemapQuery'}(
         }
         results {
           path: routePath
-          route {
-            displayName
-          }
           ${
             usesPersonalize
               ? `
@@ -123,7 +120,6 @@ export interface SiteRouteQueryResult<T> {
 export type RouteListQueryResult = {
   path: string;
   route?: {
-    displayName: string;
     personalization?: {
       variantIds: string[];
     };
@@ -141,10 +137,6 @@ export interface BaseGraphQLSitemapServiceConfig
    * Turned off by default.
    */
   includePersonalizedRoutes?: boolean;
-  /**
-   * Gets a flag indicating whether display name routing is enabled.
-   */
-  enableDisplayNameRouting?: boolean;
   /**
    * A GraphQL Request Client Factory is a function that accepts configuration and returns an instance of a GraphQLRequestClient.
    * This factory function is used to create and configure GraphQL clients for making GraphQL API requests.
@@ -170,7 +162,6 @@ export type StaticPath = {
  */
 export abstract class BaseGraphQLSitemapService {
   private _graphQLClient: GraphQLClient;
-  private _enableDisplayNameRouting: boolean;
 
   /**
    * Creates an instance of graphQL sitemap service with the provided options
@@ -178,7 +169,6 @@ export abstract class BaseGraphQLSitemapService {
    */
   constructor(public options: BaseGraphQLSitemapServiceConfig) {
     this._graphQLClient = this.getGraphQLClient();
-    this._enableDisplayNameRouting = options.enableDisplayNameRouting ?? false;
   }
 
   /**
@@ -260,105 +250,30 @@ export abstract class BaseGraphQLSitemapService {
     formatStaticPath: (path: string[], language: string) => StaticPath,
     language: string
   ): Promise<StaticPath[]> {
+    const toSegments = (p: string) =>
+      decodeURI(p)
+        .replace(/^\/|\/$/g, '')
+        .split('/');
+
     const aggregatedPaths: StaticPath[] = [];
 
-    /**
-     * Build a map of the last segment of each path to its encoded display name.
-     * This is used later to substitute the final segment with a display name if available.
-     */
-    const displayNameMap = new Map<string, string>();
-    if (this._enableDisplayNameRouting) {
-      for (const item of sitePaths) {
-        if (!item || typeof item.path !== 'string') continue;
+    sitePaths.forEach((item) => {
+      if (!item) return;
 
-        const segments = item.path.replace(/^\/|\/$/g, '').split('/');
-        const lastSegment = segments[segments.length - 1];
-        const displayName = item.route?.displayName;
+      aggregatedPaths.push(formatStaticPath(toSegments(item.path), language));
 
-        if (displayName) {
-          displayNameMap.set(lastSegment, encodeURIComponent(displayName));
-        }
-      }
-    }
-
-    /**
-     * Recursively generate all path combinations using either:
-     * - The item name segment (default)
-     * - Or the display name (if available in the map)
-     *
-     * For example: if path is ['about', 'team'] and displayName for 'team' is 'Team-Page',
-     * it will generate:
-     * - ['about', 'team']
-     * - ['about', 'Team-Page']
-     * @param {string[]} segments
-     */
-    const generateCombinations = (segments: string[]): string[][] => {
-      if (!this._enableDisplayNameRouting) {
-        return [segments];
-      }
-
-      const results: string[][] = [];
-
-      const helper = (index: number, current: string[]) => {
-        if (index === segments.length) {
-          results.push([...current]);
-          return;
-        }
-
-        const segment = segments[index];
-        const display = displayNameMap.get(segment);
-
-        // Item name segment
-        current.push(segment);
-        helper(index + 1, current);
-        current.pop();
-
-        // Display name segment (if available and different)
-        if (display && display !== segment) {
-          current.push(display);
-          helper(index + 1, current);
-          current.pop();
-        }
-      };
-
-      helper(0, []);
-      return results;
-    };
-
-    /**
-     * Process each route in the result set to:
-     * - Add itemName-based and displayName-based paths
-     * - Add personalized variants (if applicable) for each of those paths
-     */
-    for (const item of sitePaths) {
-      if (!item || typeof item.path !== 'string') continue;
-
-      const itemPath = item.path.replace(/^\/|\/$/g, '');
-      const segments = itemPath ? itemPath.split('/') : [];
-
-      // Generate all display/item name path combinations
-      const allCombinations = generateCombinations(segments);
-
-      // Add plain paths to the aggregated paths list
-      for (const combo of allCombinations) {
-        aggregatedPaths.push(formatStaticPath(combo, language));
-      }
-
-      // Check for personalization variants
       const variantIds = item.route?.personalization?.variantIds?.filter(
         (variantId) => !variantId.includes('_')
       );
 
       if (variantIds?.length) {
-        for (const variantId of variantIds) {
-          for (const combo of allCombinations) {
-            const rewritePath = getPersonalizedRewrite('/' + combo.join('/'), [variantId]);
-            const variantSegments = rewritePath.replace(/^\/|\/$/g, '').split('/');
-            aggregatedPaths.push(formatStaticPath(variantSegments, language));
-          }
-        }
+        aggregatedPaths.push(
+          ...variantIds.map((varId) =>
+            formatStaticPath(toSegments(getPersonalizedRewrite(item.path, [varId])), language)
+          )
+        );
       }
-    }
+    });
 
     return aggregatedPaths;
   }
@@ -390,6 +305,7 @@ export abstract class BaseGraphQLSitemapService {
         throw new RangeError(getSiteEmptyError(siteName));
       } else {
         results = results.concat(fetchResponse.site.siteInfo.routes?.results);
+
         hasNext = fetchResponse.site.siteInfo.routes?.pageInfo.hasNext;
         after = fetchResponse.site.siteInfo.routes?.pageInfo.endCursor;
       }

--- a/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/graphql-sitemap-service.test.ts
@@ -62,9 +62,7 @@ describe('GraphQLSitemapService', () => {
     nock.cleanAll();
   });
 
-  const mockPathsRequest = (
-    results?: { path: string; route?: { displayName?: string | null } }[]
-  ) => {
+  const mockPathsRequest = (results?: { url: { path: string } }[]) => {
     nock(endpoint)
       .post('/', /DefaultSitemapQuery/gi)
       .reply(
@@ -80,10 +78,7 @@ describe('GraphQLSitemapService', () => {
                       pageInfo: {
                         hasNext: false,
                       },
-                      results: results.map((item) => ({
-                        path: item.path,
-                        route: item.route || { displayName: null },
-                      })),
+                      results,
                     },
                   },
                 },
@@ -295,7 +290,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [],
+              path: [''],
             },
             locale: lang,
           },
@@ -332,110 +327,6 @@ describe('GraphQLSitemapService', () => {
         ]);
         return expect(nock.isDone()).to.be.true;
       });
-
-      it('should return personalized displayName paths for a single site', async () => {
-        const lang = 'ua';
-
-        nock(endpoint)
-          .post('/', /PersonalizeSitemapQuery/gi)
-          .reply(200, {
-            data: {
-              site: {
-                siteInfo: {
-                  routes: {
-                    total: 2,
-                    pageInfo: {
-                      hasNext: false,
-                    },
-                    results: [
-                      {
-                        path: '/',
-                        route: {
-                          displayName: 'Home',
-                          personalization: {
-                            variantIds: ['green'],
-                          },
-                        },
-                      },
-                      {
-                        path: '/y1/y2/y3/y4',
-                        route: {
-                          displayName: 'Y-Four',
-                          personalization: {
-                            variantIds: ['red', 'blue'],
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-          });
-
-        const service = new GraphQLSitemapService({
-          clientFactory,
-          siteName,
-          includePersonalizedRoutes: true,
-          enableDisplayNameRouting: true,
-        });
-
-        const sitemap = await service.fetchSSGSitemap([lang]);
-
-        expect(sitemap).to.have.deep.members([
-          {
-            params: {
-              path: [],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['_variantId_green'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['y1', 'y2', 'y3', 'y4'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['y1', 'y2', 'y3', 'Y-Four'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['_variantId_red', 'y1', 'y2', 'y3', 'y4'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['_variantId_red', 'y1', 'y2', 'y3', 'Y-Four'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['_variantId_blue', 'y1', 'y2', 'y3', 'y4'],
-            },
-            locale: lang,
-          },
-          {
-            params: {
-              path: ['_variantId_blue', 'y1', 'y2', 'y3', 'Y-Four'],
-            },
-            locale: lang,
-          },
-        ]);
-
-        return expect(nock.isDone()).to.be.true;
-      });
-
       it('should not return personalized paths when personalize data is requested and component a/b testing returned', async () => {
         const lang = 'ua';
 
@@ -453,7 +344,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [],
+              path: [''],
             },
             locale: lang,
           },
@@ -504,31 +395,28 @@ describe('GraphQLSitemapService', () => {
         const service = new GraphQLSitemapService({
           clientFactory,
           siteName,
-          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
 
         expect(sitemap).to.deep.equal([
           {
-            params: { path: ['Test'] },
-            locale: lang,
+            params: {
+              path: ['Test'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['New-test'] },
-            locale: lang,
+            params: {
+              path: ['About'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['About'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['New-about'] },
-            locale: lang,
-          },
-          {
-            params: { path: [] },
-            locale: lang,
+            params: {
+              path: [''],
+            },
+            locale: 'en',
           },
         ]);
 
@@ -538,52 +426,59 @@ describe('GraphQLSitemapService', () => {
       it('should return encoded displayName paths when special characters are used', async () => {
         const lang = 'en';
 
-        // Å → %C3%85, ü → %C3%BC, ç → %C3%A7
-        const results = [
-          {
-            path: '/about',
-            route: { displayName: 'Åbout' },
-          },
-          {
-            path: '/team',
-            route: { displayName: 'Tëâm' },
-          },
-          {
-            path: '/',
-            route: { displayName: 'Hôme' },
-          },
-        ];
-
-        mockPathsRequest(results);
+        nock(endpoint)
+          .post('/', /DefaultSitemapQuery/gi)
+          .reply(200, {
+            data: {
+              site: {
+                siteInfo: {
+                  routes: {
+                    total: 3,
+                    pageInfo: {
+                      hasNext: false,
+                    },
+                    results: [
+                      {
+                        path: '/Åbout',
+                      },
+                      {
+                        path: '/Tëâm',
+                      },
+                      {
+                        path: '/',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          });
 
         const service = new GraphQLSitemapService({
           clientFactory,
           siteName,
-          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
 
         expect(sitemap).to.deep.equal([
           {
-            params: { path: ['about'] },
-            locale: lang,
+            params: {
+              path: ['Åbout'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['%C3%85bout'] },
-            locale: lang,
+            params: {
+              path: ['Tëâm'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['team'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['T%C3%AB%C3%A2m'] },
-            locale: lang,
-          },
-          {
-            params: { path: [] },
-            locale: lang,
+            params: {
+              path: [''],
+            },
+            locale: 'en',
           },
         ]);
 
@@ -628,7 +523,7 @@ describe('GraphQLSitemapService', () => {
         expect(sitemap).to.deep.equal([
           {
             params: {
-              path: [],
+              path: [''],
             },
             locale: 'en',
           },
@@ -745,7 +640,7 @@ describe('GraphQLSitemapService', () => {
   const expectedSinglesiteExportSitemap = [
     {
       params: {
-        path: [],
+        path: [''],
       },
     },
     {

--- a/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
+++ b/packages/sitecore-jss-nextjs/src/services/mutisite-graphql-sitemap-service.test.ts
@@ -30,12 +30,9 @@ describe('MultisiteGraphQLSitemapService', () => {
   afterEach(() => {
     nock.cleanAll();
   });
-
-  const mockPathsRequest = (
-    results?: { path: string; route?: { displayName?: string | null } }[]
-  ) => {
+  const mockPathsRequest = (results?: { url: { path: string } }[]) => {
     nock(endpoint)
-      .post('/', new RegExp(/SitemapQuery/gi))
+      .post('/', /DefaultSitemapQuery/gi)
       .reply(
         200,
         results === undefined
@@ -49,10 +46,7 @@ describe('MultisiteGraphQLSitemapService', () => {
                       pageInfo: {
                         hasNext: false,
                       },
-                      results: results.map((item) => ({
-                        path: item.path,
-                        route: item.route || { displayName: null },
-                      })),
+                      results,
                     },
                   },
                 },
@@ -350,12 +344,12 @@ describe('MultisiteGraphQLSitemapService', () => {
         return expect(nock.isDone()).to.be.true;
       });
 
-      it('should return both itemName and encoded displayName paths for routes with displayName', async () => {
+      it('should return encoded paths when special characters are used', async () => {
         const site = 'test-site';
         const lang = 'en';
 
         nock(endpoint)
-          .post('/', (body) => body.variables.siteName === site)
+          .post('/', /DefaultSitemapQuery/gi)
           .reply(200, {
             data: {
               site: {
@@ -367,16 +361,13 @@ describe('MultisiteGraphQLSitemapService', () => {
                     },
                     results: [
                       {
-                        path: '/Test',
-                        route: { displayName: 'New-test' },
+                        path: '/Åbout',
                       },
                       {
-                        path: '/About',
-                        route: { displayName: 'New-about' },
+                        path: '/Tëâm',
                       },
                       {
                         path: '/',
-                        route: { displayName: 'Home' },
                       },
                     ],
                   },
@@ -388,127 +379,28 @@ describe('MultisiteGraphQLSitemapService', () => {
         const service = new MultisiteGraphQLSitemapService({
           clientFactory,
           sites: [site],
-          enableDisplayNameRouting: true,
-        });
-
-        const sitemap = await service.fetchSSGSitemap([lang]);
-
-        expect(sitemap).to.have.deep.members([
-          {
-            params: { path: ['_site_test-site', 'Test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'New-test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'About'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'New-about'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home', 'Test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home', 'New-test'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home', 'About'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home', 'New-about'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['Home'] },
-            locale: lang,
-          },
-        ]);
-
-        return expect(nock.isDone()).to.be.true;
-      });
-
-      it('should return encoded displayName paths when special characters are used', async () => {
-        const site = 'test-site';
-        const lang = 'en';
-
-        // Å → %C3%85, ü → %C3%BC, ç → %C3%A7
-        const results = [
-          {
-            path: '/about',
-            route: { displayName: 'Åbout' },
-          },
-          {
-            path: '/team',
-            route: { displayName: 'Tëâm' },
-          },
-          {
-            path: '/',
-            route: { displayName: 'Hôme' },
-          },
-        ];
-
-        mockPathsRequest(results);
-
-        const service = new MultisiteGraphQLSitemapService({
-          clientFactory,
-          sites: [site],
-          enableDisplayNameRouting: true,
         });
 
         const sitemap = await service.fetchSSGSitemap([lang]);
 
         expect(sitemap).to.deep.equal([
           {
-            params: { path: ['_site_test-site', 'about'] },
-            locale: lang,
+            params: {
+              path: ['_site_test-site', 'Åbout'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['_site_test-site', '%C3%85bout'] },
-            locale: lang,
+            params: {
+              path: ['_site_test-site', 'Tëâm'],
+            },
+            locale: 'en',
           },
           {
-            params: { path: ['H%C3%B4me', 'about'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['H%C3%B4me', '%C3%85bout'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'team'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site', 'T%C3%AB%C3%A2m'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['H%C3%B4me', 'team'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['H%C3%B4me', 'T%C3%AB%C3%A2m'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_test-site'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['H%C3%B4me'] },
-            locale: lang,
+            params: {
+              path: ['_site_test-site'],
+            },
+            locale: 'en',
           },
         ]);
 
@@ -626,229 +518,6 @@ describe('MultisiteGraphQLSitemapService', () => {
             locale: lang,
           },
         ]);
-        return expect(nock.isDone()).to.be.true;
-      });
-
-      it('should return personalized displayName paths correctly', async () => {
-        const site = 'site1';
-        const lang = 'en';
-
-        nock(endpoint)
-          .post('/', /PersonalizeSitemapQuery/gi)
-          .reply(200, {
-            data: {
-              site: {
-                siteInfo: {
-                  routes: {
-                    total: 2,
-                    pageInfo: {
-                      hasNext: false,
-                    },
-                    results: [
-                      {
-                        path: '/x1',
-                        route: {
-                          displayName: 'X-One',
-                          personalization: {
-                            variantIds: ['green'],
-                          },
-                        },
-                      },
-                      {
-                        path: '/y1/y2',
-                        route: {
-                          displayName: 'Y-Two',
-                          personalization: {
-                            variantIds: ['red', 'blue'],
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-          });
-
-        const service = new MultisiteGraphQLSitemapService({
-          clientFactory,
-          sites: [site],
-          includePersonalizedRoutes: true,
-          enableDisplayNameRouting: true,
-        });
-
-        const sitemap = await service.fetchSSGSitemap([lang]);
-
-        expect(sitemap).to.deep.equal([
-          {
-            params: { path: ['_site_site1', 'x1'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_site1', 'X-One'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_green', '_site_site1', 'x1'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_green', '_site_site1', 'X-One'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_site1', 'y1', 'y2'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_site_site1', 'y1', 'Y-Two'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_red', '_site_site1', 'y1', 'y2'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_red', '_site_site1', 'y1', 'Y-Two'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_blue', '_site_site1', 'y1', 'y2'] },
-            locale: lang,
-          },
-          {
-            params: { path: ['_variantId_blue', '_site_site1', 'y1', 'Y-Two'] },
-            locale: lang,
-          },
-        ]);
-
-        return expect(nock.isDone()).to.be.true;
-      });
-
-      it('should work when multiple languages are requested', async () => {
-        const lang1 = 'ua';
-        const lang2 = 'da-DK';
-
-        nock(endpoint)
-          .post('/', (body) => {
-            return body.variables.language === lang1;
-          })
-          .reply(200, {
-            data: {
-              site: {
-                siteInfo: {
-                  routes: {
-                    total: 4,
-                    pageInfo: {
-                      hasNext: false,
-                    },
-                    results: [
-                      {
-                        path: '/',
-                      },
-                      {
-                        path: '/x1',
-                      },
-                      {
-                        path: '/y1/y2/y3/y4',
-                      },
-                      {
-                        path: '/y1/y2',
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-          });
-
-        nock(endpoint)
-          .post('/', (body) => {
-            return body.variables.language === lang2;
-          })
-          .reply(200, {
-            data: {
-              site: {
-                siteInfo: {
-                  routes: {
-                    total: 4,
-                    pageInfo: {
-                      hasNext: false,
-                    },
-                    results: [
-                      {
-                        path: '/',
-                      },
-                      {
-                        path: '/x1-da-DK',
-                      },
-                      {
-                        path: '/y1/y2/y3/y4-da-DK',
-                      },
-                      {
-                        path: '/y1/y2-da-DK',
-                      },
-                    ],
-                  },
-                },
-              },
-            },
-          });
-
-        const service = new MultisiteGraphQLSitemapService({ clientFactory, sites });
-        const sitemap = await service.fetchSSGSitemap([lang1, lang2]);
-
-        expect(sitemap).to.deep.equal([
-          {
-            params: {
-              path: ['_site_site-name'],
-            },
-            locale: 'ua',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'x1'],
-            },
-            locale: 'ua',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'y1', 'y2', 'y3', 'y4'],
-            },
-            locale: 'ua',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'y1', 'y2'],
-            },
-            locale: 'ua',
-          },
-          {
-            params: {
-              path: ['_site_site-name'],
-            },
-            locale: 'da-DK',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'x1-da-DK'],
-            },
-            locale: 'da-DK',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'y1', 'y2', 'y3', 'y4-da-DK'],
-            },
-            locale: 'da-DK',
-          },
-          {
-            params: {
-              path: ['_site_site-name', 'y1', 'y2-da-DK'],
-            },
-            locale: 'da-DK',
-          },
-        ]);
-
         return expect(nock.isDone()).to.be.true;
       });
 

--- a/packages/sitecore-jss-nextjs/src/test-data/sitemapServiceSinglesiteResult.ts
+++ b/packages/sitecore-jss-nextjs/src/test-data/sitemapServiceSinglesiteResult.ts
@@ -1,7 +1,7 @@
 export default [
   {
     params: {
-      path: [],
+      path: [''],
     },
     locale: 'ua',
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Enabling display name routes through a patch config removes the need to manually generate SSG paths, since our existing logic already supports both display name–based and item name–based routes.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
