### PR TITLE
[create-sitecore-jss] Resolve high vulnerability warnings in react template packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Our versioning strategy is as follows:
 
 ### Chores
 
-* `[All]` Partial update for 3rd party dependencies ([#2123](https://github.com/Sitecore/jss/pull/2123) [#2125](https://github.com/Sitecore/jss/pull/2125) [#2129](https://github.com/Sitecore/jss/pull/2129) [#2130](https://github.com/Sitecore/jss/pull/2130) [#2131](https://github.com/Sitecore/jss/pull/2131))
+* `[All]` Partial update for 3rd party dependencies ([#2123](https://github.com/Sitecore/jss/pull/2123) [#2125](https://github.com/Sitecore/jss/pull/2125) [#2129](https://github.com/Sitecore/jss/pull/2129) [#2130](https://github.com/Sitecore/jss/pull/2130) [#2131](https://github.com/Sitecore/jss/pull/2131) [#2133](https://github.com/Sitecore/jss/pull/2133))
 
 ## 22.8.0
 

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -114,5 +114,10 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "overrides": {
+    "nth-check": "2.0.1",
+    "postcss": "^8.4.38",
+    "webpack-dev-server": "^4.15.2"
+  }
 }

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -115,7 +115,9 @@
     "not ie <= 11",
     "not op_mini all"
   ],
+  // Resolves security vulnerabilities: https://github.com/facebook/create-react-app/issues/17120
   "overrides": {
+
     "nth-check": "^2.0.1",
     "postcss": "^8.4.38",
     "webpack-dev-server": "^4.15.2"

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -116,7 +116,7 @@
     "not op_mini all"
   ],
   "overrides": {
-    "nth-check": "2.0.1",
+    "nth-check": "^2.0.1",
     "postcss": "^8.4.38",
     "webpack-dev-server": "^4.15.2"
   }

--- a/packages/create-sitecore-jss/src/templates/react/package.json
+++ b/packages/create-sitecore-jss/src/templates/react/package.json
@@ -115,10 +115,9 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  // Resolves security vulnerabilities: https://github.com/facebook/create-react-app/issues/17120
+  "//": "Resolves security vulnerabilities: https://github.com/facebook/create-react-app/issues/17120",
   "overrides": {
-
-    "nth-check": "^2.0.1",
+    "nth-check": "2.0.1",
     "postcss": "^8.4.38",
     "webpack-dev-server": "^4.15.2"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- `react-scripts 5.0.1` pulls in vulnerable transitive deps that trigger high/moderate advisories:
  - `@svgr/webpack` → `svgo@1` → `css-select` → `nth-check (<2.0.1)`
  - `resolve-url-loader` → `postcss (<8.4.31)`
  - `webpack-dev-server (≤5.2.0)`
- There’s no newer `react-scripts` 5 that fixes these upstream.
- Added minimal npm overrides in the React app template so new apps resolve safe versions

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
