### PR TITLE
[Angular] Application fails with "TypeError: Cannot read properties of undefined (reading 'tap')"

### DIFF
--- a/packages/create-sitecore-jss/src/templates/angular/package.json
+++ b/packages/create-sitecore-jss/src/templates/angular/package.json
@@ -92,7 +92,7 @@
     "cross-env": "~7.0.3",
     "del-cli": "^5.0.0",
     "dotenv": "^17.2.1",
-    "dotenv-webpack": "^7.1.0",
+    "dotenv-webpack": "^8.1.1",
     "eslint": "^8.56.0",
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jsdoc": "48.7.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
An error like ‘Cannot read properties of undefined (reading 'tap')’ almost always occurs due to a version incompatibility between a webpack plugin and the current webpack (broken API). In our case, the culprit is dotenv-webpack
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
