### PR TITLE
[React] Custom properties are not applied to empty field in editing metadata mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Our versioning strategy is as follows:
 
 * `[Next.js]` Support component-level data fetching in 404/500 pages ([#2140](https://github.com/Sitecore/jss/pull/2140))
 
+### 🐛 Bug Fixes
+
+* `[React]` Custom properties are not applied to empty field in editing metadata mode ([#2141](https://github.com/Sitecore/jss/pull/2141))
+
 ## 22.9.0
 
 ### 🐛 Bug Fixes

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -501,7 +501,7 @@ describe('<Link />', () => {
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
             testMetadata
           )}</code>`,
-          '<span>[No text in field]</span>',
+          '<span data-react-link="true">[No text in field]</span>',
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );
@@ -524,7 +524,7 @@ describe('<Link />', () => {
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
             testMetadata
           )}</code>`,
-          '<span>[No text in field]</span>',
+          '<span data-react-link="true">[No text in field]</span>',
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );

--- a/packages/sitecore-jss-react/src/components/Date.tsx
+++ b/packages/sitecore-jss-react/src/components/Date.tsx
@@ -6,7 +6,7 @@ import { EditableFieldProps } from './sharedTypes';
 import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
-export interface DateFieldProps extends EditableFieldProps {
+export interface DateFieldProps extends EditableFieldProps<DateFieldProps> {
   /** The date field data. */
   [htmlAttributes: string]: unknown;
   field: FieldMetadata & {

--- a/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 
-export const DefaultEmptyFieldEditingComponentText: React.FC = () => {
-  return <span>[No text in field]</span>;
+export interface DefaultEmptyFieldEditingComponentProps {
+  field: unknown
+}
+
+export const DefaultEmptyFieldEditingComponentText: React.FC<DefaultEmptyFieldEditingComponentProps> = ({field, ...props}) => {
+  return <span {...props}>[No text in field]</span>;
 };
 
-export const DefaultEmptyFieldEditingComponentImage: React.FC = () => {
+export const DefaultEmptyFieldEditingComponentImage: React.FC<DefaultEmptyFieldEditingComponentProps> = ({field, ...props}) => {
   const inlineStyles = {
     minWidth: '48px',
     minHeight: '48px',
@@ -19,6 +23,7 @@ export const DefaultEmptyFieldEditingComponentImage: React.FC = () => {
       src='data:image/svg+xml,%3Csvg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 240 240" style="enable-background:new 0 0 240 240;" xml:space="preserve"%3E%3Cstyle type="text/css"%3E .st0%7Bfill:none;%7D .st1%7Bfill:%23969696;%7D .st2%7Bfill:%23FFFFFF;%7D .st3%7Bfill:%23FFFFFF;stroke:%23FFFFFF;stroke-width:0.75;stroke-miterlimit:10;%7D%0A%3C/style%3E%3Cg%3E%3Crect class="st0" width="240" height="240"/%3E%3Cg%3E%3Cg%3E%3Crect x="20" y="20" class="st1" width="200" height="200"/%3E%3C/g%3E%3Cg%3E%3Ccircle class="st2" cx="174" cy="67" r="14"/%3E%3Cpath class="st2" d="M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z"/%3E%3C/g%3E%3Cpolyline class="st3" points="29.5,179.25 81.32,122.25 95.41,137.75 137.23,91.75 209.5,179.75 "/%3E%3C/g%3E%3C/g%3E%3C/svg%3E'
       className="scEmptyImage"
       style={inlineStyles}
+      {...props}
     />
   );
 };

--- a/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 
 export interface DefaultEmptyFieldEditingComponentProps {
-  field: unknown
+  field: unknown;
 }
 
-export const DefaultEmptyFieldEditingComponentText: React.FC<DefaultEmptyFieldEditingComponentProps> = ({field, ...props}) => {
+export const DefaultEmptyFieldEditingComponentText: React.FC<DefaultEmptyFieldEditingComponentProps> = ({
+  field,
+  ...props
+}) => {
   return <span {...props}>[No text in field]</span>;
 };
 
-export const DefaultEmptyFieldEditingComponentImage: React.FC<DefaultEmptyFieldEditingComponentProps> = ({field, ...props}) => {
+export const DefaultEmptyFieldEditingComponentImage: React.FC<DefaultEmptyFieldEditingComponentProps> = ({
+  field,
+  ...props
+}) => {
   const inlineStyles = {
     minWidth: '48px',
     minHeight: '48px',

--- a/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -1,20 +1,10 @@
 import React from 'react';
 
-export interface DefaultEmptyFieldEditingComponentProps {
-  field: unknown;
-}
-
-export const DefaultEmptyFieldEditingComponentText: React.FC<DefaultEmptyFieldEditingComponentProps> = ({
-  field,
-  ...props
-}) => {
+export const DefaultEmptyFieldEditingComponentText: React.FC = (props) => {
   return <span {...props}>[No text in field]</span>;
 };
 
-export const DefaultEmptyFieldEditingComponentImage: React.FC<DefaultEmptyFieldEditingComponentProps> = ({
-  field,
-  ...props
-}) => {
+export const DefaultEmptyFieldEditingComponentImage: React.FC = (props) => {
   const inlineStyles = {
     minWidth: '48px',
     minHeight: '48px',

--- a/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -7,7 +7,10 @@ export const DefaultEmptyFieldEditingComponentText: React.FC<{
   return React.createElement(props.tag || 'span', props, '[No text in field]');
 };
 
-export const DefaultEmptyFieldEditingComponentImage: React.FC = (props) => {
+export const DefaultEmptyFieldEditingComponentImage: React.FC<{
+  [key: string]: unknown;
+  className?: string;
+}> = (props) => {
   const inlineStyles = {
     minWidth: '48px',
     minHeight: '48px',
@@ -18,11 +21,11 @@ export const DefaultEmptyFieldEditingComponentImage: React.FC = (props) => {
 
   return (
     <img
+      {...props}
       alt=""
       src='data:image/svg+xml,%3Csvg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 240 240" style="enable-background:new 0 0 240 240;" xml:space="preserve"%3E%3Cstyle type="text/css"%3E .st0%7Bfill:none;%7D .st1%7Bfill:%23969696;%7D .st2%7Bfill:%23FFFFFF;%7D .st3%7Bfill:%23FFFFFF;stroke:%23FFFFFF;stroke-width:0.75;stroke-miterlimit:10;%7D%0A%3C/style%3E%3Cg%3E%3Crect class="st0" width="240" height="240"/%3E%3Cg%3E%3Cg%3E%3Crect x="20" y="20" class="st1" width="200" height="200"/%3E%3C/g%3E%3Cg%3E%3Ccircle class="st2" cx="174" cy="67" r="14"/%3E%3Cpath class="st2" d="M174,54c7.17,0,13,5.83,13,13s-5.83,13-13,13s-13-5.83-13-13S166.83,54,174,54 M174,52 c-8.28,0-15,6.72-15,15s6.72,15,15,15s15-6.72,15-15S182.28,52,174,52L174,52z"/%3E%3C/g%3E%3Cpolyline class="st3" points="29.5,179.25 81.32,122.25 95.41,137.75 137.23,91.75 209.5,179.75 "/%3E%3C/g%3E%3C/g%3E%3C/svg%3E'
-      className="scEmptyImage"
       style={inlineStyles}
-      {...props}
+      className={`scEmptyImage ${props.className || ''}`}
     />
   );
 };

--- a/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
+++ b/packages/sitecore-jss-react/src/components/DefaultEmptyFieldEditingComponents.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-export const DefaultEmptyFieldEditingComponentText: React.FC = (props) => {
-  return <span {...props}>[No text in field]</span>;
+export const DefaultEmptyFieldEditingComponentText: React.FC<{
+  [key: string]: unknown;
+  tag?: string;
+}> = (props) => {
+  return React.createElement(props.tag || 'span', props, '[No text in field]');
 };
 
 export const DefaultEmptyFieldEditingComponentImage: React.FC = (props) => {

--- a/packages/sitecore-jss-react/src/components/Image.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.test.tsx
@@ -372,8 +372,10 @@ describe('<Image />', () => {
         metadata: testMetadata,
       };
 
-      const rendered = render(<Image field={field} />);
-      const defaultEmptyImagePlaceholder = render(<DefaultEmptyFieldEditingComponentImage />);
+      const rendered = render(<Image field={field} className="my-custom-class" />);
+      const defaultEmptyImagePlaceholder = render(
+        <DefaultEmptyFieldEditingComponentImage className="my-custom-class" />
+      );
       expect(rendered.container.innerHTML).to.equal(
         [
           `<code type="text/sitecore" chrometype="field" class="scpm" kind="open">${JSON.stringify(
@@ -383,6 +385,8 @@ describe('<Image />', () => {
           '<code type="text/sitecore" chrometype="field" class="scpm" kind="close"></code>',
         ].join('')
       );
+      expect(rendered.container.innerHTML).to.contain('my-custom-class');
+      expect(rendered.container.innerHTML).to.contain('scEmptyImage');
     });
 
     it('should render custom empty field component when provided, when field value src is not present', () => {

--- a/packages/sitecore-jss-react/src/components/Image.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.tsx
@@ -38,7 +38,7 @@ export interface ImageSizeParameters {
   sc?: number;
 }
 
-export interface ImageProps extends EditableFieldProps {
+export interface ImageProps extends EditableFieldProps<ImageProps> {
   [attributeName: string]: unknown;
   /** Image field data (consistent with other field types) */
   field?: (ImageField | ImageFieldValue) & FieldMetadata;

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -25,7 +25,7 @@ export interface LinkField {
   editableLastPart?: string;
 }
 
-export type LinkProps = EditableFieldProps &
+export type LinkProps = EditableFieldProps<LinkProps> &
   React.AnchorHTMLAttributes<HTMLAnchorElement> &
   RefAttributes<HTMLAnchorElement> & {
     /** The link field data. */

--- a/packages/sitecore-jss-react/src/components/RichText.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.tsx
@@ -10,7 +10,7 @@ export interface RichTextField extends FieldMetadata {
   editable?: string;
 }
 
-export interface RichTextProps extends EditableFieldProps {
+export interface RichTextProps extends EditableFieldProps<RichTextProps> {
   [htmlAttributes: string]: unknown;
   /** The rich text field data. */
   field?: RichTextField;

--- a/packages/sitecore-jss-react/src/components/Text.tsx
+++ b/packages/sitecore-jss-react/src/components/Text.tsx
@@ -10,7 +10,7 @@ export interface TextField extends FieldMetadata {
   editable?: string;
 }
 
-export interface TextProps extends EditableFieldProps {
+export interface TextProps extends EditableFieldProps<TextProps> {
   [htmlAttributes: string]: unknown;
   /** The text field data. */
   field?: TextField;

--- a/packages/sitecore-jss-react/src/components/sharedTypes.ts
+++ b/packages/sitecore-jss-react/src/components/sharedTypes.ts
@@ -21,7 +21,7 @@ export type JssComponentType = ComponentType & {
 /**
  * Shared editing field props
  */
-export interface EditableFieldProps {
+export interface EditableFieldProps<EmptyFieldEditingComponentProps = unknown> {
   /**
    * Can be used to explicitly disable inline editing.
    * If true and `field.editable` has a value, then `field.editable` will be processed and rendered as component output. If false, `field.editable` value will be ignored and not rendered.
@@ -33,5 +33,7 @@ export interface EditableFieldProps {
    *
    * Custom element to render in Pages in Metadata edit mode if field value is empty
    */
-  emptyFieldEditingComponent?: React.ComponentClass<unknown> | React.FC<unknown>;
+  emptyFieldEditingComponent?:
+    | React.ComponentClass<EmptyFieldEditingComponentProps>
+    | React.FC<EmptyFieldEditingComponentProps>;
 }

--- a/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
@@ -56,6 +56,7 @@ describe('withEmptyFieldEditingComponent', () => {
 
     it('Should render provided default empty value component component if field value is not provided', () => {
       const props = {
+        tag: 'h1',
         field: {
           value: '',
           metadata: testMetadata,
@@ -67,11 +68,10 @@ describe('withEmptyFieldEditingComponent', () => {
       });
 
       const rendered = render(<WrappedComponent {...props} />);
-      const expected = render(<DefaultEmptyFieldEditingComponentText />);
+      const expected = render(<DefaultEmptyFieldEditingComponentText tag="h1" />);
 
       expect(rendered.container.innerHTML).to.equal(expected.container.innerHTML);
-      expect(rendered.container.innerHTML).to.not.contain('field=');
-      expect(rendered.container.innerHTML).to.not.contain('editable');
+      expect(rendered.container.innerHTML).to.equal('<h1 tag="h1">[No text in field]</h1>');
     });
 
     it('Should render custom empty value component if provided via props if field value is not provided', () => {

--- a/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.test.tsx
@@ -70,6 +70,8 @@ describe('withEmptyFieldEditingComponent', () => {
       const expected = render(<DefaultEmptyFieldEditingComponentText />);
 
       expect(rendered.container.innerHTML).to.equal(expected.container.innerHTML);
+      expect(rendered.container.innerHTML).to.not.contain('field=');
+      expect(rendered.container.innerHTML).to.not.contain('editable');
     });
 
     it('Should render custom empty value component if provided via props if field value is not provided', () => {

--- a/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.tsx
@@ -44,7 +44,7 @@ export function withEmptyFieldEditingComponent<
 ) {
   const getEmptyFieldEditingComponent = (
     props: FieldComponentProps
-  ): React.ComponentClass | React.FC => {
+  ): React.ComponentType<WithEmptyFieldEditingComponentProps> => {
     const { editable = true } = props;
     if (props.field?.metadata && editable && isFieldValueEmpty(props.field)) {
       return props.emptyFieldEditingComponent || options.defaultEmptyFieldEditingComponent;
@@ -61,7 +61,7 @@ export function withEmptyFieldEditingComponent<
       );
       return (
         <>
-          {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent />) || (
+          {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent {...props} />) || (
             <FieldComponent {...(props as FieldComponentProps)} ref={ref} />
           )}
         </>
@@ -74,7 +74,7 @@ export function withEmptyFieldEditingComponent<
     const EmptyFieldEditingComponent = getEmptyFieldEditingComponent(props);
     return (
       <>
-        {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent />) || (
+        {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent {...props} />) || (
           <FieldComponent {...props} />
         )}
       </>

--- a/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withEmptyFieldEditingComponent.tsx
@@ -23,11 +23,11 @@ export interface WithEmptyFieldEditingComponentOptions {
 /*
  * represents the WithEmptyFieldEditingComponent HOC's props
  */
-interface WithEmptyFieldEditingComponentProps {
+interface WithEmptyFieldEditingComponentProps<Props> {
   // Partial<T> type is used here because _field.value_ could be required or optional for the different field types
   field?: (Partial<Field> | GenericFieldValue) & FieldMetadata;
   editable?: boolean;
-  emptyFieldEditingComponent?: React.ComponentClass | React.FC;
+  emptyFieldEditingComponent?: React.ComponentClass<Props> | React.FC<Props>;
 }
 
 /**
@@ -36,18 +36,31 @@ interface WithEmptyFieldEditingComponentProps {
  * @param {WithEmptyFieldEditingComponentProps} options the options of the HOC;
  */
 export function withEmptyFieldEditingComponent<
-  FieldComponentProps extends WithEmptyFieldEditingComponentProps,
+  FieldComponentProps extends WithEmptyFieldEditingComponentProps<FieldComponentProps>,
   RefElementType = HTMLElement
 >(
   FieldComponent: ComponentType<FieldComponentProps>,
   options: WithEmptyFieldEditingComponentOptions
 ) {
-  const getEmptyFieldEditingComponent = (
-    props: FieldComponentProps
-  ): React.ComponentType<WithEmptyFieldEditingComponentProps> => {
+  const getEmptyFieldEditingComponent = (props: FieldComponentProps) => {
     const { editable = true } = props;
     if (props.field?.metadata && editable && isFieldValueEmpty(props.field)) {
-      return props.emptyFieldEditingComponent || options.defaultEmptyFieldEditingComponent;
+      const Component =
+        props.emptyFieldEditingComponent || options.defaultEmptyFieldEditingComponent;
+
+      let resolvedProps = props;
+
+      // If no custom empty field editing component is provided, we can omit unnecessary props
+      // to do not insert them to html
+      if (!props.emptyFieldEditingComponent) {
+        resolvedProps = {
+          ...props,
+          editable: undefined,
+          field: undefined,
+        };
+      }
+
+      return <Component {...resolvedProps} />;
     }
 
     return null;
@@ -56,28 +69,21 @@ export function withEmptyFieldEditingComponent<
   if (options.isForwardRef) {
     // eslint-disable-next-line react/display-name
     return forwardRef<RefElementType, FieldComponentProps>((props, ref) => {
-      const EmptyFieldEditingComponent = getEmptyFieldEditingComponent(
+      const emptyFieldEditingComponent = getEmptyFieldEditingComponent(
         props as FieldComponentProps
       );
+
       return (
-        <>
-          {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent {...props} />) || (
-            <FieldComponent {...(props as FieldComponentProps)} ref={ref} />
-          )}
-        </>
+        emptyFieldEditingComponent || (
+          <FieldComponent {...(props as FieldComponentProps)} ref={ref} />
+        )
       );
     });
   }
 
   // eslint-disable-next-line react/display-name
   return (props: FieldComponentProps) => {
-    const EmptyFieldEditingComponent = getEmptyFieldEditingComponent(props);
-    return (
-      <>
-        {(EmptyFieldEditingComponent && <EmptyFieldEditingComponent {...props} />) || (
-          <FieldComponent {...props} />
-        )}
-      </>
-    );
+    const emptyFieldEditingComponent = getEmptyFieldEditingComponent(props);
+    return emptyFieldEditingComponent || <FieldComponent {...props} />;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Previously, any custom properties passed to a Field component were not propagated to its corresponding empty field component. As a result, developers could not access these additional props when rendering custom empty states and the default empty component didn't apply these properties as well

This change ensures that all custom properties provided to the Field component are now also passed down to the empty field component.

Based on initial suggestings from [#2001](https://github.com/Sitecore/jss/pull/2001?utm_source=chatgpt.com), further adjusted and refined
## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
