### PR TITLE
[sitecore-jss-nextjs] Add regex variable substitution for absolute and external URL redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
-* `[Next.js]` [Redirects] Preserve default locale in external absolute urls ([#2142](https://github.com/Sitecore/jss/pull/2142))
+* `[sitecore-jss-nextjs]` Preserve default locale in external absolute urls ([#2142](https://github.com/Sitecore/jss/pull/2142))
 * `[React]` Custom properties are not applied to empty field in editing metadata mode ([#2141](https://github.com/Sitecore/jss/pull/2141))
+* `[sitecore-jss-nextjs]` Add regex variable substitution for absolute and external URL redirects. ([#2159](https://github.com/Sitecore/jss/pull/2159))
 
 ## 22.9.0
 
@@ -440,6 +441,36 @@ Our versioning strategy is as follows:
   * Removed deprecated _defaultProps_ react component property
 * `[templates/nextjs]` GraphQL-based services can now only be initialized with clientFactory parameter. Previously deprecated option of providing endpoint and apiKey has been removed ([#1780](https://github.com/Sitecore/jss/pull/1780)).
 * `[templates/nextjs]` `[templates/react]` `[templates/vue]` `[templates/angular]` Deprecated JSS_APP_NAME environment variable has been removed ([#1780](https://github.com/Sitecore/jss/pull/1780)).
+
+## 21.10.1
+
+### 🐛 Bug Fixes
+
+`[sitecore-jss-nextjs]` Prevent infinite redirect loops and prioritize locale-specific rules in the redirects middleware ([#2158](https://github.com/Sitecore/jss/pull/2158)):
+  * Enhanced RedirectsMiddleware extensibility by introducing the new `getRedirects` method.
+  * Included multiple improvements and refactoring carried over from JSS 22.
+
+
+## 21.10.0
+
+### 🛠 Breaking Changes
+
+* `[sitecore-jss]` `[sitecore-jss-react]` `[sitecore-jss-nextjs]` `[create-sitecore-jss]` `[sitecore-jss-react-forms]` Upgrade React to version 19 and Nextjs to version 15 ([#2078](https://github.com/Sitecore/jss/pull/2078))([#2084](https://github.com/Sitecore/jss/pull/2084)) ([#2093](https://github.com/Sitecore/jss/pull/2093)) ([#2103](https://github.com/Sitecore/jss/pull/2103)):
+  * upgrade React and Nextjs dependencies for the new major versions
+  * with React 19, JSX is in the 'react' namespace and therefore 'react' needs to be imported befoore using JSX. All OOTB react and nextjs components have been updated
+  * `react-test-renderer` has been deprecated in react 19. additionaly `enzyme` is not supported anymore so all unit tests have been migrated to use `@`testing-library/react`
+  * `propTypes` have been deprecated by react and have been removed from the solution
+  * in NextJs 15 the `geo` and `ip` properties on `NextRequest` have been removed. To account for this `@sitecore-cloudsdk` dependencies have been upgraded to 0.5.1, which includes breaking changes, see upgrade guide for details. Also cloudsdk v0.4.0 introduces breaking changes
+     - replaces the old init approach for cloudsdk with new one according to upgrade guide. This causes several followup changes.
+     - Context logic is no longer used
+     - New object type is passed into `FEAAS.setContextProperties` instead of context passed previously
+     - `@sitecore/components` dependency updated to 2.0.0
+     - Browser-side CloudSDK is initialized in Bootstrap component. It should be initialized for events to work.
+  * remove 'react' dependency from nextconfig webpack externals in monorepo next config plugin as it is not needed anymore.
+  * PersonalizeMiddleware handler now accepts PersonalizeOptions, that can be used to provide geolocation data from application level
+  * `eslint-plugin-react` depenency has been upgraded to latest
+  * `[templates/nextjs]` `graphql` has been upgraded to 15.10.1
+  * `[templates/nextjs-styleguide]` `[templates/nextjs-styleguide-tracking]` styleguide components types have been fixed
 
 ## 21.9.0
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -26,6 +26,7 @@ describe('RedirectsMiddleware', () => {
   const validateDebugLog = (message, ...params) =>
     expect(debugSpy.args.find((log) => log[0] === message)).to.deep.equal([message, ...params]);
 
+  // eslint-disable-next-line jsdoc/require-jsdoc
   function validateEndMessageDebugLog(actualOrMsg: any, expected: any) {
     const actual =
       typeof actualOrMsg === 'string'
@@ -1068,6 +1069,270 @@ describe('RedirectsMiddleware', () => {
         // so normalize to compare safely.
         const normalizeUrlValue = (u: any) => (typeof u === 'string' ? u : u?.href ?? '');
         expect(normalizeUrlValue(finalRes.url)).to.equal(externalUrl);
+      });
+
+      it('should perform variable substitution for regex redirects to external absolute URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'https://museum.olympics.com/docs/AOTC/LONGUEURSDAVANCE-9.4-DE.pdf';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/docs/AOTC/LONGUEURSDAVANCE-9.4-DE.pdf',
+          origin: 'https://museum.olympics.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/redirect/docs/AOTC/LONGUEURSDAVANCE-9.4-DE.pdf',
+              href: 'http://localhost:3000/redirect/docs/AOTC/LONGUEURSDAVANCE-9.4-DE.pdf',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 302,
+        });
+
+        setupRedirectStub(302);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/redirect/docs/([^/]+)/([^/]+)$',
+            target: 'https://museum.olympics.com/docs/$1/$2',
+            redirectType: REDIRECT_TYPE_302,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
+      });
+
+      it('should perform variable substitution for regex redirects to internal absolute URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'http://localhost:3000/About/fruit/apple';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/About/fruit/apple',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/redirect/fruit/apple',
+              href: 'http://localhost:3000/redirect/fruit/apple',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        setupRedirectStub(301);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/redirect/(.*)/(.*)$',
+            target: 'http://localhost:3000/About/$1/$2',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
+      });
+
+      it('should handle multiple capture groups in regex redirects to external URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'https://example.com/products/electronics/laptop/dell';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/products/electronics/laptop/dell',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/old-shop/electronics/laptop/dell',
+              href: 'http://localhost:3000/old-shop/electronics/laptop/dell',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        setupRedirectStub(301);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/old-shop/([^/]+)/([^/]+)/([^/]+)$',
+            target: 'https://example.com/products/$1/$2/$3',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
+      });
+
+      it('should handle regex redirects with no capture groups to external URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'https://example.com/static-page';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/static-page',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/old-static',
+              href: 'http://localhost:3000/old-static',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 302,
+        });
+
+        setupRedirectStub(302);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/old-static$',
+            target: 'https://example.com/static-page',
+            redirectType: REDIRECT_TYPE_302,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
+      });
+
+      it('should handle regex redirects with trailing slash in external URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'https://example.com/docs/guide/intro/';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/docs/guide/intro/',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/documentation/guide/intro/',
+              href: 'http://localhost:3000/documentation/guide/intro/',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        setupRedirectStub(301);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/documentation/([^/]+)/([^/]+)/?$',
+            target: 'https://example.com/docs/$1/$2/',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
+      });
+
+      it('should preserve unmatched placeholder variables as literal text in external URLs', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const expectedUrl = 'https://example.com/path/first/second/';
+
+        const url = {
+          href: expectedUrl,
+          pathname: '/path/first/second/',
+          origin: 'https://example.com',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+        };
+
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/old/first/second',
+              href: 'http://localhost:3000/old/first/second',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              clone: cloneUrl,
+            },
+          },
+          status: 301,
+        });
+
+        setupRedirectStub(301);
+
+        const { finalRes } = await runTestWithRedirect(
+          {
+            pattern: '^/old/([^/]+)/([^/]+)$',
+            target: 'https://example.com/path/$1/$2/$3',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(normalizeUrlValue(finalRes.url)).to.equal(expectedUrl);
       });
 
       it('should redirect uses token $siteLang in target url', async () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -224,13 +224,21 @@ export class RedirectsMiddleware extends MiddlewareBase {
       const url = this.normalizeUrl(req.nextUrl.clone());
 
       if (REGEXP_ABSOLUTE_URL.test(existsRedirect.target)) {
-        return this.dispatchRedirect(
-          existsRedirect.target,
-          existsRedirect.redirectType,
-          req,
-          response,
-          true
-        );
+        // Perform variable substitution for absolute URLs
+        let finalTarget = existsRedirect.target;
+
+        if (isRegexOrUrl(existsRedirect.pattern) === 'regex') {
+          const matched = url.pathname
+            .replace(/\/*$/gi, '')
+            .match(regexParser(existsRedirect.pattern));
+          if (matched) {
+            finalTarget = existsRedirect.target.replace(/\$(\d+)/g, (_, index) => {
+              return matched[parseInt(index, 10)] || '';
+            });
+          }
+        }
+
+        return this.dispatchRedirect(finalTarget, existsRedirect.redirectType, req, response, true);
       } else {
         const isUrl = isRegexOrUrl(existsRedirect.pattern) === 'url';
         const targetParts = existsRedirect.target.split('/');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixes regex-based redirects with variable extraction when the target URL is external or absolute.

Resolves issue where redirects like:
- Source: `^/redirect/docs/([^/]+)/([^/]+)$`
- Target: `https://museum.olympics.com/docs/$1/$2$`
Would redirect to `https://museum.olympics.com/docs/$1/$2` instead of the expected URL with substituted values.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
