### PR TITLE
[Next.js] Next Link props unavailable when using Sitecore Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Our versioning strategy is as follows:
 * `[React]` Custom properties are not applied to empty field in editing metadata mode ([#2141](https://github.com/Sitecore/jss/pull/2141))
 * `[sitecore-jss-nextjs]` Add regex variable substitution for absolute and external URL redirects. ([#2159](https://github.com/Sitecore/jss/pull/2159))
 * `[sitecore-jss-react]` Disable React Suspense in the Placeholder component for Editing. ([#2161](https://github.com/Sitecore/jss/pull/2161))
-* `[GitHub Issue]` `[JSS SDK]` Next Link props unavailable when using Sitecore Link component ([#2170](https://github.com/Sitecore/content-sdk/pull/2170))
+* `[sitecore-jss-nextjs]` Next Link props unavailable when using Sitecore Link component ([#2170](https://github.com/Sitecore/content-sdk/pull/2170))
 
 ### 🛠 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Our versioning strategy is as follows:
 * `[React]` Custom properties are not applied to empty field in editing metadata mode ([#2141](https://github.com/Sitecore/jss/pull/2141))
 * `[sitecore-jss-nextjs]` Add regex variable substitution for absolute and external URL redirects. ([#2159](https://github.com/Sitecore/jss/pull/2159))
 * `[sitecore-jss-react]` Disable React Suspense in the Placeholder component for Editing. ([#2161](https://github.com/Sitecore/jss/pull/2161))
+* `[GitHub Issue]` `[JSS SDK]` Next Link props unavailable when using Sitecore Link component ([#2170](https://github.com/Sitecore/content-sdk/pull/2170))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -180,14 +180,11 @@ describe('<Link />', () => {
 
     fireEvent.click(link!);
 
-    expect(pushSpy.calledOnce).to.be.true;
-    expect(
-      pushSpy.calledOnceWith('/lorem', '/custom', {
-        shallow: true,
-        locale: 'fr-FR',
-        scroll: true,
-      })
-    ).to.be.true;
+    expect(pushSpy).to.have.been.calledOnceWith('/lorem', '/custom', {
+      shallow: true,
+      locale: 'fr-FR',
+      scroll: true,
+    });
   });
 
   it('should pass NextLink props correctly', () => {

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -40,7 +40,7 @@ const Page = ({ children }: { children: ReactNode }) => (
   <RouterContext.Provider value={Router()}>{children}</RouterContext.Provider>
 );
 
-describe.only('<Link />', () => {
+describe('<Link />', () => {
   it('should render all value attributes', () => {
     const field = {
       value: {

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -2,18 +2,10 @@ import React, { createRef, ReactNode } from 'react';
 import { NextRouter } from 'next/router';
 import { LinkField, DefaultEmptyFieldEditingComponentText } from '@sitecore-jss/sitecore-jss-react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import { Link } from './Link';
 import { spy } from 'sinon';
-
-const pushSpy = spy(() => Promise.resolve(true));
-const replaceSpy = spy(() => Promise.resolve(true));
-const reloadSpy = spy();
-const backSpy = spy();
-const forwardSpy = spy();
-const prefetchSpy = spy(() => Promise.resolve());
-const beforePopStateSpy = spy();
 
 const Router = (): NextRouter => ({
   pathname: '/',
@@ -26,13 +18,12 @@ const Router = (): NextRouter => ({
   isPreview: false,
   isReady: false,
   events: { emit: spy(), off: spy(), on: spy() },
-  push: pushSpy,
-  replace: replaceSpy,
-  reload: reloadSpy,
-  back: backSpy,
-  forward: forwardSpy,
-  prefetch: prefetchSpy,
-  beforePopState: beforePopStateSpy,
+  push: spy(() => Promise.resolve(true)),
+  replace: spy(() => Promise.resolve(true)),
+  reload: spy(),
+  back: spy(),
+  prefetch: spy(() => Promise.resolve()),
+  beforePopState: spy(),
 });
 
 // Should provide RouterContext in case if we render Link from next/link
@@ -167,39 +158,26 @@ describe('<Link />', () => {
     expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
   });
 
-  it('should call router.push with provided props when link is clicked', () => {
-    const field = { href: '/lorem', text: 'ipsum' };
+  it('should render with prefetch prop provided', () => {
+    const field = {
+      href: '/lorem',
+      text: 'ipsum',
+    };
+    const prefetch = false;
+
     const c = render(
       <Page>
-        <Link field={field} as="/custom" scroll={true} shallow={true} locale="fr-FR" />
+        <Link field={field} prefetch={prefetch} />
       </Page>
     );
-    const link = c.container.querySelector('a')!;
+
+    const link = c.container.querySelector('a');
+
+    expect(link?.outerHTML).to.contain(field.href);
+    expect(link?.outerHTML).to.contain(field.text);
 
     expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
-
-    fireEvent.click(link!);
-
-    expect(pushSpy).to.have.been.calledOnceWith('/lorem', '/custom', {
-      shallow: true,
-      locale: 'fr-FR',
-      scroll: true,
-    });
-  });
-
-  it('should pass NextLink props correctly', () => {
-    const field = { href: '/lorem', text: 'ipsum' };
-    const c = render(
-      <Page>
-        <Link field={field} replace={true} passHref={true} prefetch={true} />
-      </Page>
-    );
-    const link = c.container.querySelector('a')!;
-
-    expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
-    expect(link?.getAttribute('data-nextjs-prefetch')).to.equal('true');
-    expect(link.getAttribute('data-nextjs-replace')).to.equal('true');
-    expect(link.getAttribute('data-nextjs-passHref')).to.equal('true');
+    expect(link?.getAttribute('data-nextjs-link-prefetch')).to.equal(prefetch.toString());
   });
 
   it('should render other attributes with other props provided', () => {

--- a/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.test.tsx
@@ -2,10 +2,18 @@ import React, { createRef, ReactNode } from 'react';
 import { NextRouter } from 'next/router';
 import { LinkField, DefaultEmptyFieldEditingComponentText } from '@sitecore-jss/sitecore-jss-react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
 import { Link } from './Link';
 import { spy } from 'sinon';
+
+const pushSpy = spy(() => Promise.resolve(true));
+const replaceSpy = spy(() => Promise.resolve(true));
+const reloadSpy = spy();
+const backSpy = spy();
+const forwardSpy = spy();
+const prefetchSpy = spy(() => Promise.resolve());
+const beforePopStateSpy = spy();
 
 const Router = (): NextRouter => ({
   pathname: '/',
@@ -18,12 +26,13 @@ const Router = (): NextRouter => ({
   isPreview: false,
   isReady: false,
   events: { emit: spy(), off: spy(), on: spy() },
-  push: spy(() => Promise.resolve(true)),
-  replace: spy(() => Promise.resolve(true)),
-  reload: spy(),
-  back: spy(),
-  prefetch: spy(() => Promise.resolve()),
-  beforePopState: spy(),
+  push: pushSpy,
+  replace: replaceSpy,
+  reload: reloadSpy,
+  back: backSpy,
+  forward: forwardSpy,
+  prefetch: prefetchSpy,
+  beforePopState: beforePopStateSpy,
 });
 
 // Should provide RouterContext in case if we render Link from next/link
@@ -31,7 +40,7 @@ const Page = ({ children }: { children: ReactNode }) => (
   <RouterContext.Provider value={Router()}>{children}</RouterContext.Provider>
 );
 
-describe('<Link />', () => {
+describe.only('<Link />', () => {
   it('should render all value attributes', () => {
     const field = {
       value: {
@@ -158,26 +167,42 @@ describe('<Link />', () => {
     expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
   });
 
-  it('should render with prefetch prop provided', () => {
-    const field = {
-      href: '/lorem',
-      text: 'ipsum',
-    };
-    const prefetch = false;
-
+  it('should call router.push with provided props when link is clicked', () => {
+    const field = { href: '/lorem', text: 'ipsum' };
     const c = render(
       <Page>
-        <Link field={field} prefetch={prefetch} />
+        <Link field={field} as="/custom" scroll={true} shallow={true} locale="fr-FR" />
       </Page>
     );
-
-    const link = c.container.querySelector('a');
-
-    expect(link?.outerHTML).to.contain(field.href);
-    expect(link?.outerHTML).to.contain(field.text);
+    const link = c.container.querySelector('a')!;
 
     expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
-    expect(link?.getAttribute('data-nextjs-link-prefetch')).to.equal(prefetch.toString());
+
+    fireEvent.click(link!);
+
+    expect(pushSpy.calledOnce).to.be.true;
+    expect(
+      pushSpy.calledOnceWith('/lorem', '/custom', {
+        shallow: true,
+        locale: 'fr-FR',
+        scroll: true,
+      })
+    ).to.be.true;
+  });
+
+  it('should pass NextLink props correctly', () => {
+    const field = { href: '/lorem', text: 'ipsum' };
+    const c = render(
+      <Page>
+        <Link field={field} replace={true} passHref={true} prefetch={true} />
+      </Page>
+    );
+    const link = c.container.querySelector('a')!;
+
+    expect(link?.getAttribute('data-nextjs-link')).to.equal('true');
+    expect(link?.getAttribute('data-nextjs-prefetch')).to.equal('true');
+    expect(link.getAttribute('data-nextjs-replace')).to.equal('true');
+    expect(link.getAttribute('data-nextjs-passHref')).to.equal('true');
   });
 
   it('should render other attributes with other props provided', () => {

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -118,19 +118,10 @@ Link.displayName = 'NextLink';
  * @returns sanitized props for ReactLink.
  */
 function sanitizeLinkProps(props: LinkProps) {
-  const nextLinkProps: (keyof NextLinkProps)[] = [
-    'as',
-    'onNavigate',
-    'passHref',
-    'prefetch',
-    'replace',
-    'scroll',
-    'shallow',
-  ];
   const internalProps: (keyof LinkProps)[] = ['internalLinkMatcher'];
 
   const sanitizedProps: LinkProps = { ...props };
-  for (const prop of [...nextLinkProps, ...internalProps]) {
+  for (const prop of [...supportedNextLinkProps, ...internalProps]) {
     delete sanitizedProps[prop as keyof LinkProps];
   }
 

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -14,12 +14,10 @@ export type LinkProps = ReactLinkProps & {
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
-
-  /**
-   * Next.js Link prefetch.
-   */
-  prefetch?: NextLinkProps['prefetch'];
-};
+} & Pick<
+    NextLinkProps,
+    'prefetch' | 'locale' | 'replace' | 'scroll' | 'shallow' | 'as' | 'onNavigate' | 'passHref'
+  >;
 
 /**
  * Matches relative URLs that end with a file extension.
@@ -77,7 +75,12 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             {...htmlLinkProps}
             ref={ref}
             {...(process.env.TEST
-              ? { 'data-nextjs-link': true, 'data-nextjs-link-prefetch': props.prefetch }
+              ? {
+                  'data-nextjs-link': true,
+                  'data-nextjs-replace': props.replace,
+                  'data-nextjs-prefetch': props.prefetch,
+                  'data-nextjs-passhref': props.passHref,
+                }
               : {})}
           >
             {text}

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -73,7 +73,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             {...(process.env.TEST
               ? {
                   'data-nextjs-link': true,
-                  'data-nextjs-prefetch': props.prefetch,
+                  'data-nextjs-link-prefetch': props.prefetch,
                 }
               : {})}
           >

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -8,13 +8,26 @@ import {
   LinkProps as ReactLinkProps,
 } from '@sitecore-jss/sitecore-jss-react';
 
+/**
+ * The list of NextLink props to be supported by the Link component.
+ */
+const supportedNextLinkProps = [
+  'as',
+  'onNavigate',
+  'passHref',
+  'prefetch',
+  'replace',
+  'scroll',
+  'shallow',
+] as const;
+
 export type LinkProps = ReactLinkProps & {
   /**
    * If `href` match with `internalLinkMatcher` regexp, then it's internal link and NextLink will be rendered
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
-} & Omit<NextLinkProps, 'href' | 'locale'>;
+} & Pick<NextLinkProps, typeof supportedNextLinkProps[number]>;
 
 /**
  * Matches relative URLs that end with a file extension.
@@ -29,7 +42,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       children,
       internalLinkMatcher = /^\//g,
       showLinkTextWithChildrenPresent,
-      ...htmlLinkProps
+      ...rest
     } = props;
 
     if (
@@ -59,7 +72,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 
       // determine if a link is a route or not. File extensions are not routes and should not be pre-fetched.
       if (isMatching && !isFileUrl) {
-        delete htmlLinkProps.emptyFieldEditingComponent;
+        delete rest.emptyFieldEditingComponent;
+
         return (
           <NextLink
             href={{ pathname: href, query: querystring, hash: anchor }}
@@ -67,7 +81,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
             title={value.title}
             target={value.target}
             className={value.class}
-            {...htmlLinkProps}
+            {...rest}
             locale={false}
             ref={ref}
             {...(process.env.TEST

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -14,10 +14,7 @@ export type LinkProps = ReactLinkProps & {
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
-} & Pick<
-    NextLinkProps,
-    'prefetch' | 'locale' | 'replace' | 'scroll' | 'shallow' | 'as' | 'onNavigate' | 'passHref'
-  >;
+} & Omit<NextLinkProps, 'href'>;
 
 /**
  * Matches relative URLs that end with a file extension.

--- a/packages/sitecore-jss-nextjs/src/components/Link.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/Link.tsx
@@ -14,7 +14,7 @@ export type LinkProps = ReactLinkProps & {
    * @default /^\//g
    */
   internalLinkMatcher?: RegExp;
-} & Omit<NextLinkProps, 'href'>;
+} & Omit<NextLinkProps, 'href' | 'locale'>;
 
 /**
  * Matches relative URLs that end with a file extension.
@@ -64,19 +64,16 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
           <NextLink
             href={{ pathname: href, query: querystring, hash: anchor }}
             key="link"
-            locale={false}
             title={value.title}
             target={value.target}
             className={value.class}
-            prefetch={props.prefetch}
             {...htmlLinkProps}
+            locale={false}
             ref={ref}
             {...(process.env.TEST
               ? {
                   'data-nextjs-link': true,
-                  'data-nextjs-replace': props.replace,
                   'data-nextjs-prefetch': props.prefetch,
-                  'data-nextjs-passhref': props.passHref,
                 }
               : {})}
           >
@@ -87,10 +84,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       }
     }
 
-    // prevent passing internalLinkMatcher or prefetch as it is an invalid DOM element prop
-    const reactLinkProps = { ...props };
-    delete reactLinkProps.internalLinkMatcher;
-    delete reactLinkProps.prefetch;
+    const reactLinkProps = sanitizeLinkProps(props);
 
     return (
       <ReactLink
@@ -103,3 +97,28 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 );
 
 Link.displayName = 'NextLink';
+
+/**
+ * Sanitize props for ReactLink by removing Next.js and internal props to prevent invalid DOM attributes.
+ * @param {LinkProps} props - The props the Link component received.
+ * @returns sanitized props for ReactLink.
+ */
+function sanitizeLinkProps(props: LinkProps) {
+  const nextLinkProps: (keyof NextLinkProps)[] = [
+    'as',
+    'onNavigate',
+    'passHref',
+    'prefetch',
+    'replace',
+    'scroll',
+    'shallow',
+  ];
+  const internalProps: (keyof LinkProps)[] = ['internalLinkMatcher'];
+
+  const sanitizedProps: LinkProps = { ...props };
+  for (const prop of [...nextLinkProps, ...internalProps]) {
+    delete sanitizedProps[prop as keyof LinkProps];
+  }
+
+  return sanitizedProps;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
- Added missing NextLink props to Link component

Fixes #2155 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
