### PR TITLE
[sitecore-jss-nextjs] Fix server transfer redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Our versioning strategy is as follows:
 
 ## 22.10.0
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-nextjs]` Fix server transfer redirects ([#2173](https://github.com/Sitecore/jss/pull/2173))
+
 ### 🎉 New Features & Improvements
 
 * `[Next.js]` Support component-level data fetching in 404/500 pages ([#2140](https://github.com/Sitecore/jss/pull/2140))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
-## 22.10.0
-
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Fix server transfer redirects ([#2173](https://github.com/Sitecore/jss/pull/2173))
+
+## 22.10.0
 
 ### 🎉 New Features & Improvements
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -19,7 +19,7 @@ import { REWRITE_HEADER_NAME } from './middleware';
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
-describe('RedirectsMiddleware', () => {
+describe.only('RedirectsMiddleware', () => {
   let nextRedirectStub, nextRewriteStub;
 
   const debugSpy = spy(debug, 'redirects');
@@ -520,7 +520,7 @@ describe('RedirectsMiddleware', () => {
       it('should override locale with locale parsed from target', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
-          pathname: 'http://localhost:3000/found',
+          pathname: '/found',
           href: 'http://localhost:3000/not-found',
           origin: 'http://localhost:3000',
           locale: 'ua',
@@ -573,7 +573,7 @@ describe('RedirectsMiddleware', () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {
           origin: 'http://localhost:3000',
-          pathname: 'http://localhost:3000/found?abc=def',
+          pathname: '/found?abc=def',
           href: 'http://localhost:3000/not-found?abc=def',
           search: '?abc=def',
           locale: 'en',
@@ -1484,6 +1484,105 @@ describe('RedirectsMiddleware', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
+      });
+
+      it('should rewrite using pathname and search instead of full href for server transfer with NextURL target', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          clone: cloneUrl,
+          href: 'http://localhost:3000/found?param=value',
+          locale: 'en',
+          origin: 'http://localhost:3000',
+          pathname: '/found',
+          search: '?param=value',
+        };
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/not-found',
+              search: '',
+              href: 'http://localhost:3000/not-found',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: 'not-found',
+            target: '/found?param=value',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+        // Verify NextResponse.rewrite was called
+        expect(nextRewriteStub.called).to.be.true;
+        const rewriteArg = nextRewriteStub.firstCall.args[0];
+        // The rewrite should receive a URL with the target path (pathname + search),
+        // not the original request's href. This verifies the fix that uses
+        // pathname + search instead of full href for NextURL targets.
+        expect(rewriteArg.pathname).to.include('/found');
+      });
+
+      it('should rewrite with empty search when server transfer target has no query string', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          clone: cloneUrl,
+          href: 'http://localhost:3000/found',
+          locale: 'en',
+          origin: 'http://localhost:3000',
+          pathname: '/found',
+          search: '',
+        };
+        const { res, req } = createTestRequestResponse({
+          response: { url },
+          request: {
+            nextUrl: {
+              pathname: '/not-found',
+              search: '',
+              href: 'http://localhost:3000/not-found',
+              locale: 'en',
+              origin: 'http://localhost:3000',
+              clone: cloneUrl,
+            },
+          },
+          status: 200,
+        });
+        setupRewriteStub(200, res);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: 'not-found',
+            target: '/found',
+            redirectType: REDIRECT_TYPE_SERVER_TRANSFER,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+        expect(finalRes.status).to.equal(res.status);
+        // Verify NextResponse.rewrite was called
+        expect(nextRewriteStub.called).to.be.true;
+        const rewriteArg = nextRewriteStub.firstCall.args[0];
+        expect(rewriteArg.pathname).to.equal('/found');
       });
 
       it('should use sc_site cookie', async () => {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -1528,12 +1528,8 @@ describe.only('RedirectsMiddleware', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
-        // Verify NextResponse.rewrite was called
         expect(nextRewriteStub.called).to.be.true;
         const rewriteArg = nextRewriteStub.firstCall.args[0];
-        // The rewrite should receive a URL with the target path (pathname + search),
-        // not the original request's href. This verifies the fix that uses
-        // pathname + search instead of full href for NextURL targets.
         expect(rewriteArg.pathname).to.include('/found');
       });
 
@@ -1579,7 +1575,6 @@ describe.only('RedirectsMiddleware', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(fetchRedirects.called).to.be.true;
         expect(finalRes.status).to.equal(res.status);
-        // Verify NextResponse.rewrite was called
         expect(nextRewriteStub.called).to.be.true;
         const rewriteArg = nextRewriteStub.firstCall.args[0];
         expect(rewriteArg.pathname).to.equal('/found');

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -363,14 +363,12 @@ export class RedirectsMiddleware extends MiddlewareBase {
         return this.createRedirectResponse(target, res, 301, 'Moved Permanently');
       case REDIRECT_TYPE_302:
         return this.createRedirectResponse(target, res, 302, 'Found');
-      case REDIRECT_TYPE_SERVER_TRANSFER:
-        // rewrite expects a string; unwrap NextURL if needed
-        return this.rewrite(
-          typeof target === 'string' ? target : target.href,
-          req,
-          res,
-          isExternal
-        );
+      case REDIRECT_TYPE_SERVER_TRANSFER: {
+        // rewrite expects a path string; for NextURL extract pathname + search, not full href
+        const rewritePath =
+          typeof target === 'string' ? target : `${target.pathname}${target.search}`;
+        return this.rewrite(rewritePath, req, res, isExternal);
+      }
       default:
         // Unknown type: return the input response unchanged
         return res;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Fixed an issue in the redirects middleware where server transfer (rewrite) redirects were incorrectly passing the full href URL to the rewrite method instead of just the path.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
