### PR TITLE
[sitecore-jss-nextjs] Fix basePath preservation when doing redirects in redirects-middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Fix server transfer redirects ([#2173](https://github.com/Sitecore/jss/pull/2173))
-* `[sitecore-jss-nextjs]` Preserve `basePath` when doing redirects in redirects-middleware ([#2178](https://github.com/Sitecore/jss/pull/2178))
+* `[sitecore-jss-nextjs]` Preserve `basePath` when doing redirects in redirects-middleware ([#2178](https://github.com/Sitecore/jss/pull/2178)) ([#2181](https://github.com/Sitecore/jss/pull/2181))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -19,7 +19,7 @@ import { REWRITE_HEADER_NAME } from './middleware';
 use(sinonChai);
 const expect = chai.use(chaiString).expect;
 
-describe.only('RedirectsMiddleware', () => {
+describe('RedirectsMiddleware', () => {
   let nextRedirectStub, nextRewriteStub;
 
   const debugSpy = spy(debug, 'redirects');
@@ -487,7 +487,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'en',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         const { res, req } = createTestRequestResponse({
           response: {
@@ -837,7 +836,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'en',
           search: '?abc=def',
           clone: cloneUrl,
-          basePath: undefined,
         };
         setupRedirectStub(301);
         const { res, req } = createTestRequestResponse({
@@ -890,7 +888,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'en',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         setupRedirectStub(301);
         const { res, req } = createTestRequestResponse({
@@ -943,7 +940,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'pl-PL',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         setupRedirectStub(301);
         const { res, req } = createTestRequestResponse({
@@ -997,7 +993,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'pl-PL',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         setupRedirectStub(301);
         const { res, req } = createTestRequestResponse({
@@ -1049,7 +1044,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'en',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         setupRedirectStub(301);
 
@@ -1103,7 +1097,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'en',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         const { res, req } = createTestRequestResponse({
           response: { url },
@@ -1466,7 +1459,6 @@ describe.only('RedirectsMiddleware', () => {
           locale: 'da',
           search: '',
           clone: cloneUrl,
-          basePath: undefined,
         };
         const { res, req } = createTestRequestResponse({
           response: { url },
@@ -2020,7 +2012,6 @@ describe.only('RedirectsMiddleware', () => {
           origin: 'http://localhost:3000',
           search: '?b=1&a=1',
           pathname: '/found',
-          basePath: undefined,
         };
         const { res, req } = createTestRequestResponse({
           response: { url },
@@ -2182,7 +2173,6 @@ describe.only('RedirectsMiddleware', () => {
           origin: 'http://localhost:3000',
           search: '?a=1&w=1',
           pathname: '/found',
-          basePath: undefined,
         };
 
         const { res, req } = createTestRequestResponse({
@@ -2237,7 +2227,6 @@ describe.only('RedirectsMiddleware', () => {
           origin: 'http://localhost:3000',
           search: '',
           pathname: '/found',
-          basePath: undefined,
         };
 
         const { res, req } = createTestRequestResponse({
@@ -2340,7 +2329,6 @@ describe.only('RedirectsMiddleware', () => {
           origin: 'http://localhost:3000',
           search: '',
           pathname: '/found/',
-          basePath: undefined,
         };
 
         const { res, req } = createTestRequestResponse({
@@ -2392,7 +2380,6 @@ describe.only('RedirectsMiddleware', () => {
           origin: 'http://localhost:3000',
           search: '',
           pathname: '/found',
-          basePath: undefined,
         };
 
         const { res, req } = createTestRequestResponse({

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.test.ts
@@ -582,6 +582,57 @@ describe.only('RedirectsMiddleware', () => {
         expect(finalRes.status).to.equal(res.status);
       });
 
+      it('should return 301 redirect with basePath if empty string', async () => {
+        const cloneUrl = () => Object.assign({}, req.nextUrl);
+        const url = {
+          href: 'http://localhost:3000/found',
+          pathname: '/found',
+          origin: 'http://localhost:3000',
+          locale: 'en',
+          search: '',
+          clone: cloneUrl,
+          basePath: '',
+        };
+        const { res, req } = createTestRequestResponse({
+          response: {
+            url,
+          },
+          request: {
+            nextUrl: {
+              pathname: '/not-found',
+              origin: 'http://localhost:3000',
+              locale: 'en',
+              href: 'http://localhost:3000/not-found',
+              clone: cloneUrl,
+              basePath: '',
+            },
+          },
+        });
+        setupRedirectStub(301);
+
+        const { finalRes, fetchRedirects, siteResolver } = await runTestWithRedirect(
+          {
+            pattern: 'not-found',
+            target: '/found',
+            redirectType: REDIRECT_TYPE_301,
+            isQueryStringPreserved: false,
+            locale: 'en',
+          },
+          req,
+          res
+        );
+
+        // update url.href to include basePath for comparison
+        normalizeHref(finalRes.url);
+
+        expect(siteResolver.getByHost).to.be.calledWith(hostname);
+        // eslint-disable-next-line no-unused-expressions
+        expect(fetchRedirects.called).to.be.true;
+
+        expect(finalRes).to.deep.equal(res);
+        expect(finalRes.status).to.equal(res.status);
+      });
+
       it('should override locale with locale parsed from target', async () => {
         const cloneUrl = () => Object.assign({}, req.nextUrl);
         const url = {

--- a/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
+++ b/packages/sitecore-jss-nextjs/src/middleware/redirects-middleware.ts
@@ -279,7 +279,9 @@ export class RedirectsMiddleware extends MiddlewareBase {
         url.pathname = prepareNewURL.pathname;
         url.search = prepareNewURL.search;
         url.locale = req.nextUrl.locale;
-        url.basePath = basePath;
+        if (basePath) {
+          url.basePath = basePath;
+        }
 
         return this.dispatchRedirect(url, existsRedirect.redirectType, req, response, false);
       }
@@ -343,7 +345,9 @@ export class RedirectsMiddleware extends MiddlewareBase {
     url.search = newUrl.search;
     url.pathname = newUrl.pathname.toLowerCase();
     url.href = newUrl.href;
-    url.basePath = basePath;
+    if (basePath) {
+      url.basePath = basePath;
+    }
 
     return url;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a follow-up to #2178 and addresses the following issue:
 - when assigning `basePath` property of NextUrl, if `basePath` is empty string it gets assigned as '/' instead of ''; this causes redirects to not work properly when `basePath` is not configured;

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate) - test redirects, with and without basePath, in both client side and server side navigation;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
