### PR TITLE
[Angular] Support preview mode for metadata rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Our versioning strategy is as follows:
 - Minor: may include breaking changes in framework packages (e.g. framework upgrades, new features, improvements)
 - Major: may include breaking changes in core packages (e.g. major architectural changes, major features)
 
+## 22.11.0
+
+### 🎉 New Features & Improvements
+
+* `[Angular]` `[Proxy]` Support Preview mode using Metadata ([#2184](https://github.com/Sitecore/jss/pull/2184))
+
 ## 22.10.0
 
 * `[Next.js]` Support component-level data fetching in 404/500 pages ([#2140](https://github.com/Sitecore/jss/pull/2140))

--- a/packages/sitecore-jss-proxy/src/middleware/editing/render.test.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/render.test.ts
@@ -72,6 +72,7 @@ describe('editingRouter - /editing/render', () => {
     language: validQS.sc_lang,
     version: validQS.sc_version,
     layoutKind: validQS.sc_layoutKind,
+    mode: validQS.mode,
   };
 
   let fetchEditingDataStub: sinon.SinonStub;
@@ -321,6 +322,51 @@ describe('editingRouter - /editing/render', () => {
       .expect('Content-Security-Policy', `${getSCPHeader()}`)
       .expect(() => {
         expect(fetchEditingDataStub.calledOnceWith(fetchEditingDataArgs)).to.be.true;
+        expect(
+          renderView.calledOnceWith(sinon.match.func, '/', layoutData, {
+            dictionary,
+          })
+        ).to.be.true;
+      })
+      .end(done);
+  });
+
+  it('should response 200 status code when renderView returns result in preview', (done) => {
+    const layoutData = {
+      sitecore: { context: { pageEditing: true }, route: { name: '/', placeholders: {} } },
+    };
+    const dictionary = {};
+
+    fetchEditingDataStub.resolves({
+      layoutData,
+      dictionary,
+    });
+
+    renderView.callsFake((callback) => callback(null, { html: '<div>Hello World</div>' }));
+
+    app.use(
+      '/api/editing',
+      editingRouter({
+        ...defaultOptions,
+        render: {
+          ...defaultOptions.render,
+          renderView,
+        },
+      })
+    );
+
+    request(app)
+      .get('/api/editing/render')
+      .query({ ...validQS, mode: LayoutServicePageState.Preview })
+      .expect(200, '<div>Hello World</div>')
+      .expect('Content-Security-Policy', `${getSCPHeader()}`)
+      .expect(() => {
+        expect(
+          fetchEditingDataStub.calledOnceWith({
+            ...fetchEditingDataArgs,
+            mode: LayoutServicePageState.Preview,
+          })
+        ).to.be.true;
         expect(
           renderView.calledOnceWith(sinon.match.func, '/', layoutData, {
             dictionary,

--- a/packages/sitecore-jss-proxy/src/middleware/editing/render.ts
+++ b/packages/sitecore-jss-proxy/src/middleware/editing/render.ts
@@ -1,5 +1,4 @@
 import { GraphQLRequestClientFactory, debug } from '@sitecore-jss/sitecore-jss';
-import { AppRenderer, RenderResponse } from '../../types/AppRenderer';
 import { Request, Response } from 'express';
 import { getAllowedOriginsFromEnv } from '@sitecore-jss/sitecore-jss/utils';
 import {
@@ -7,12 +6,14 @@ import {
   EDITING_ALLOWED_ORIGINS,
   RenderMetadataQueryParams,
 } from '@sitecore-jss/sitecore-jss/editing';
-import { PersonalizeHelper } from '../../personalize';
 import {
   DEFAULT_VARIANT,
   getGroomedVariantIds,
   personalizeLayout,
 } from '@sitecore-jss/sitecore-jss/personalize';
+import { LayoutServicePageState } from '@sitecore-jss/sitecore-jss/layout';
+import { AppRenderer, RenderResponse } from '../../types/AppRenderer';
+import { PersonalizeHelper } from '../../personalize';
 
 /**
  * Configuration for the editing render endpoint
@@ -38,7 +39,9 @@ export type EditingRenderEndpointOptions = {
   personalizeHelper?: PersonalizeHelper;
 };
 
-type MetadataRequest = Request & { query: RenderMetadataQueryParams };
+type MetadataRequest = Request & {
+  query: RenderMetadataQueryParams & { mode: Exclude<LayoutServicePageState, 'Normal'> };
+};
 
 /**
  * Middleware to handle editing render requests
@@ -84,6 +87,7 @@ export const editingRenderMiddleware = (config: EditingRenderEndpointOptions) =>
       language: query.sc_lang,
       version: query.sc_version,
       layoutKind: query.sc_layoutKind,
+      mode: query.mode,
     });
 
     if (!data || !data.layoutData || !data.dictionary) {

--- a/packages/sitecore-jss/src/editing/graphql-editing-service.test.ts
+++ b/packages/sitecore-jss/src/editing/graphql-editing-service.test.ts
@@ -14,7 +14,7 @@ import {
   mockEditingServiceDictionaryResponse,
   mockEditingServiceResponse,
 } from '../test-data/mockEditingServiceResponse';
-import { EditMode } from '../layout';
+import { EditMode, LayoutServicePageState } from '../layout';
 import { LayoutKind } from './models';
 import debug from '../debug';
 
@@ -86,9 +86,6 @@ describe('GraphQLEditingService', () => {
     expect(
       clientFactorySpy.calledWith({
         debugger: debug.editing,
-        headers: {
-          sc_editMode: 'true',
-        },
       })
     ).to.be.true;
     expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
@@ -103,6 +100,62 @@ describe('GraphQLEditingService', () => {
       {
         headers: {
           sc_layoutKind: 'final',
+          sc_editMode: 'true',
+        },
+      }
+    );
+
+    expect(result).to.deep.equal({
+      layoutData: layoutDataResponse,
+      dictionary: {
+        foo: 'foo-phrase',
+        bar: 'bar-phrase',
+      },
+    });
+
+    spy.restore(clientFactorySpy);
+  });
+
+  it('should fetch preview data', async () => {
+    nock(hostname, { reqheaders: { sc_editMode: 'false' } })
+      .post(endpointPath, /EditingQuery/gi)
+      .reply(200, editingData);
+
+    const clientFactorySpy = sinon.spy(clientFactory);
+
+    const service = new GraphQLEditingService({
+      clientFactory: clientFactorySpy,
+    });
+
+    spy.on(clientFactorySpy.returnValues[0], 'request');
+
+    const result = await service.fetchEditingData({
+      language,
+      version,
+      itemId,
+      siteName,
+      mode: LayoutServicePageState.Preview,
+    });
+
+    expect(clientFactorySpy.calledOnce).to.be.true;
+    expect(
+      clientFactorySpy.calledWith({
+        debugger: debug.editing,
+      })
+    ).to.be.true;
+    expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
+    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(
+      query,
+      {
+        language,
+        version,
+        itemId,
+        siteName,
+      },
+      {
+        headers: {
+          sc_layoutKind: 'final',
+          sc_editMode: 'false',
         },
       }
     );
@@ -151,9 +204,6 @@ describe('GraphQLEditingService', () => {
     expect(
       clientFactorySpy.calledWith({
         debugger: debug.editing,
-        headers: {
-          sc_editMode: 'true',
-        },
       })
     ).to.be.true;
     expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
@@ -168,6 +218,7 @@ describe('GraphQLEditingService', () => {
       {
         headers: {
           sc_layoutKind: 'final',
+          sc_editMode: 'true',
         },
       }
     );
@@ -208,18 +259,24 @@ describe('GraphQLEditingService', () => {
     expect(
       clientFactorySpy.calledWith({
         debugger: debug.editing,
-        headers: {
-          sc_editMode: 'true',
-        },
       })
     ).to.be.true;
     expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(query, {
-      language,
-      itemId,
-      siteName,
-      version: undefined,
-    });
+    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(
+      query,
+      {
+        language,
+        itemId,
+        siteName,
+        version: undefined,
+      },
+      {
+        headers: {
+          sc_editMode: 'true',
+          sc_layoutKind: 'final',
+        },
+      }
+    );
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,
@@ -266,6 +323,7 @@ describe('GraphQLEditingService', () => {
       {
         headers: {
           sc_layoutKind: 'shared',
+          sc_editMode: 'true',
         },
       }
     );
@@ -282,15 +340,15 @@ describe('GraphQLEditingService', () => {
   });
 
   it('should fetch editing data when dicionary has multiple pages', async () => {
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
+    nock(hostname, { reqheaders: { sc_editMode: 'true', sc_layoutKind: 'final' } })
       .post(endpointPath, /EditingQuery/gi)
       .reply(200, mockEditingServiceResponse(true));
 
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
+    nock(hostname)
       .post(endpointPath, /DictionaryQuery/gi)
       .reply(200, mockEditingServiceDictionaryResponse.pageOne);
 
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
+    nock(hostname)
       .post(endpointPath, /DictionaryQuery/gi)
       .reply(200, mockEditingServiceDictionaryResponse.pageTwo);
 
@@ -313,19 +371,25 @@ describe('GraphQLEditingService', () => {
     expect(
       clientFactorySpy.calledWith({
         debugger: debug.editing,
-        headers: {
-          sc_editMode: 'true',
-        },
       })
     ).to.be.true;
 
     expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(3);
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(query, {
-      language,
-      version,
-      itemId,
-      siteName,
-    });
+    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(
+      query,
+      {
+        language,
+        version,
+        itemId,
+        siteName,
+      },
+      {
+        headers: {
+          sc_layoutKind: 'final',
+          sc_editMode: 'true',
+        },
+      }
+    );
 
     expect(clientFactorySpy.returnValues[0].request)
       .on.nth(2)
@@ -359,11 +423,11 @@ describe('GraphQLEditingService', () => {
   });
 
   it('should request dictionary from scratch when fetchDictionaryData called on its own', async () => {
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
+    nock(hostname)
       .post(endpointPath, /DictionaryQuery/gi)
       .reply(200, mockEditingServiceDictionaryResponse.pageOne);
 
-    nock(hostname, { reqheaders: { sc_editMode: 'true' } })
+    nock(hostname)
       .post(endpointPath, /DictionaryQuery/gi)
       .reply(200, mockEditingServiceDictionaryResponse.pageTwo);
 
@@ -412,18 +476,24 @@ describe('GraphQLEditingService', () => {
     expect(
       clientFactorySpy.calledWith({
         debugger: debug.editing,
-        headers: {
-          sc_editMode: 'true',
-        },
       })
     ).to.be.true;
     expect(clientFactorySpy.returnValues[0].request).to.be.called.exactly(1);
-    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(query, {
-      language,
-      version,
-      itemId,
-      siteName,
-    });
+    expect(clientFactorySpy.returnValues[0].request).to.be.called.with(
+      query,
+      {
+        language,
+        version,
+        itemId,
+        siteName,
+      },
+      {
+        headers: {
+          sc_editMode: 'true',
+          sc_layoutKind: 'final',
+        },
+      }
+    );
 
     expect(result).to.deep.equal({
       layoutData: layoutDataResponse,

--- a/packages/sitecore-jss/src/editing/graphql-editing-service.ts
+++ b/packages/sitecore-jss/src/editing/graphql-editing-service.ts
@@ -2,7 +2,7 @@ import debug from '../debug';
 import { PageInfo } from '../graphql';
 import { GraphQLClient, GraphQLRequestClientFactory } from '../graphql-request-client';
 import { DictionaryPhrases } from '../i18n';
-import { EditMode, LayoutServiceData } from '../layout';
+import { EditMode, LayoutServiceData, LayoutServicePageState } from '../layout';
 import { LayoutKind } from './models';
 
 /**
@@ -94,6 +94,15 @@ export interface GraphQLEditingServiceConfig {
   clientFactory: GraphQLRequestClientFactory;
 }
 
+interface EditingOptions {
+  siteName: string;
+  itemId: string;
+  language: string;
+  version?: string;
+  layoutKind?: LayoutKind;
+  mode?: Exclude<LayoutServicePageState, 'Normal'>;
+}
+
 /**
  * Service for fetching editing data from Sitecore using the Sitecore's GraphQL API.
  * Expected to be used in XMCloud Pages preview (editing) Metadata Edit Mode.
@@ -117,6 +126,7 @@ export class GraphQLEditingService {
    * @param {string} variables.language - The language to fetch layout data for.
    * @param {string} [variables.version] - The version of the item (optional).
    * @param {LayoutKind} [variables.layoutKind] - The final or shared layout variant.
+   * @param {string} [variables.mode] - The editing mode to fetch layout data for.
    * @returns {Promise} The layout data and dictionary phrases.
    */
   async fetchEditingData({
@@ -125,13 +135,8 @@ export class GraphQLEditingService {
     language,
     version,
     layoutKind = LayoutKind.Final,
-  }: {
-    siteName: string;
-    itemId: string;
-    language: string;
-    version?: string;
-    layoutKind?: LayoutKind;
-  }) {
+    mode = LayoutServicePageState.Edit,
+  }: EditingOptions) {
     debug.editing(
       'fetching editing data for %s %s %s %s',
       siteName,
@@ -153,6 +158,8 @@ export class GraphQLEditingService {
     let hasNext = true;
     let after = '';
 
+    const editModeHeader = mode === 'edit' ? 'true' : 'false';
+
     const editingData = await this.graphQLClient.request<GraphQLEditingQueryResponse>(
       query,
       {
@@ -164,6 +171,7 @@ export class GraphQLEditingService {
       {
         headers: {
           sc_layoutKind: layoutKind,
+          sc_editMode: editModeHeader,
         },
       }
     );
@@ -244,9 +252,6 @@ export class GraphQLEditingService {
 
     return this.serviceConfig.clientFactory({
       debugger: debug.editing,
-      headers: {
-        sc_editMode: 'true',
-      },
     });
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
Adds support for Angular applications in Sitecore AI, enabling rendering in Pages Preview via Metadata mode.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
