### PR TITLE
[sitecore-jss-tools] Fix `jss deploy component` command failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Our versioning strategy is as follows:
 
 ## Unreleased
 
+### 🐛 Bug Fixes
+
+* `[sitecore-jss-tools]` Fix `jss deploy component` command failing ([#2195](https://github.com/Sitecore/jss/pull/2195))
+
 ## 22.12.1
 
 ### 🎉 New Features & Improvements

--- a/packages/sitecore-jss-dev-tools/src/package-generate.test.ts
+++ b/packages/sitecore-jss-dev-tools/src/package-generate.test.ts
@@ -1,12 +1,21 @@
 /* eslint-disable no-unused-expressions */
 import * as updateUtils from './update';
 import fsExtra from 'fs-extra';
+import path from 'path';
 import sinon from 'sinon';
 import { packageGenerate } from './package-generate';
 import { expect } from 'chai';
 
 describe('package-generate', () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    // Use fake timers to control Date.now() for consistent testing
+    clock = sinon.useFakeTimers(new Date('2024-01-15T10:30:00.000Z').getTime());
+  });
+
   afterEach(() => {
+    clock.restore();
     sinon.restore();
   });
 
@@ -26,5 +35,187 @@ describe('package-generate', () => {
     await packageGenerate(options);
 
     expect(createPackageStub.called).to.be.true;
+  });
+
+  it('should clear output folder before generating package', async () => {
+    const emptyDirSyncStub = sinon.stub(fsExtra, 'emptyDirSync');
+    sinon.stub(fsExtra, 'copySync');
+    sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const options = {
+      appName: 'myApp',
+      outputPath: 'C:/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    expect(emptyDirSyncStub.calledOnce).to.be.true;
+    expect(emptyDirSyncStub.calledWith('C:/output')).to.be.true;
+  });
+
+  it('should copy manifest from source to destination with timestamp path', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    const copySyncStub = sinon.stub(fsExtra, 'copySync');
+    sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const timestamp = new Date().getTime();
+    const options = {
+      appName: 'testApp',
+      outputPath: 'C:/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const expectedDestination = path.join('C:/output', '.', 'temp', 'testApp', String(timestamp));
+
+    expect(copySyncStub.calledOnce).to.be.true;
+    expect(copySyncStub.calledWith('C:/source/manifest', expectedDestination)).to.be.true;
+  });
+
+  it('should handle relative manifest path correctly', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    const copySyncStub = sinon.stub(fsExtra, 'copySync');
+    sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const timestamp = new Date().getTime();
+    const options = {
+      appName: 'testApp',
+      outputPath: 'C:/output',
+      manifestPath: 'relative/manifest/path',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const expectedSource = path.join('.', 'relative/manifest/path');
+    const expectedDestination = path.join('C:/output', '.', 'temp', 'testApp', String(timestamp));
+
+    expect(copySyncStub.calledOnce).to.be.true;
+    expect(copySyncStub.calledWith(expectedSource, expectedDestination)).to.be.true;
+  });
+
+  it('should handle relative output path correctly', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    const copySyncStub = sinon.stub(fsExtra, 'copySync');
+    sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const timestamp = new Date().getTime();
+    const options = {
+      appName: 'testApp',
+      outputPath: 'relative/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const expectedDestination = path.join(
+      '.',
+      'relative/output',
+      '.',
+      'temp',
+      'testApp',
+      String(timestamp)
+    );
+
+    expect(copySyncStub.calledOnce).to.be.true;
+    expect(copySyncStub.calledWith('C:/source/manifest', expectedDestination)).to.be.true;
+  });
+
+  it('should create package with correct name and paths', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    sinon.stub(fsExtra, 'copySync');
+    const createPackageStub = sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const timestamp = new Date().getTime();
+    const options = {
+      appName: 'myApp',
+      outputPath: 'C:/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const expectedManifestPath = path.join('C:/output', '.', 'temp', 'myApp', String(timestamp));
+    const expectedPackagePath = path.join('C:/output', `myApp.${timestamp}.manifest.zip`);
+
+    expect(createPackageStub.calledOnce).to.be.true;
+    expect(createPackageStub.calledWith(expectedManifestPath, expectedPackagePath)).to.be.true;
+  });
+
+  it('should return a promise that resolves when package is created', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    sinon.stub(fsExtra, 'copySync');
+    sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const options = {
+      appName: 'myApp',
+      outputPath: 'C:/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    const result = await packageGenerate(options);
+
+    expect(result).to.be.null;
+  });
+
+  it('should handle both relative paths correctly', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    const copySyncStub = sinon.stub(fsExtra, 'copySync');
+    const createPackageStub = sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const timestamp = new Date().getTime();
+    const options = {
+      appName: 'relativeApp',
+      outputPath: 'dist/output',
+      manifestPath: 'src/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const expectedSource = path.join('.', 'src/manifest');
+    const expectedDestination = path.join(
+      '.',
+      'dist/output',
+      '.',
+      'temp',
+      'relativeApp',
+      String(timestamp)
+    );
+    const expectedPackagePath = path.join('dist/output', `relativeApp.${timestamp}.manifest.zip`);
+
+    expect(copySyncStub.calledWith(expectedSource, expectedDestination)).to.be.true;
+    expect(createPackageStub.calledWith(expectedDestination, expectedPackagePath)).to.be.true;
+  });
+
+  it('should use timestamp in manifest path and package name', async () => {
+    sinon.stub(fsExtra, 'emptyDirSync');
+    const copySyncStub = sinon.stub(fsExtra, 'copySync');
+    const createPackageStub = sinon.stub(updateUtils, 'createPackage').callsArg(2);
+
+    const expectedTimestamp = new Date().getTime();
+    const options = {
+      appName: 'timestampApp',
+      outputPath: 'C:/output',
+      manifestPath: 'C:/source/manifest',
+      manifestFileName: 'manifest.json',
+    };
+
+    await packageGenerate(options);
+
+    const copySyncDestination = copySyncStub.firstCall.args[1];
+    const createPackageSource = createPackageStub.firstCall.args[0];
+    const createPackageZip = createPackageStub.firstCall.args[1];
+
+    expect(copySyncDestination).to.include(String(expectedTimestamp));
+    expect(createPackageSource).to.include(String(expectedTimestamp));
+    expect(createPackageZip).to.include(`timestampApp.${expectedTimestamp}.manifest.zip`);
   });
 });

--- a/packages/sitecore-jss-dev-tools/src/package-generate.ts
+++ b/packages/sitecore-jss-dev-tools/src/package-generate.ts
@@ -18,9 +18,16 @@ export function packageGenerate(options: PackageGenerateOptions) {
   const datepath = `${new Date().getTime()}`;
 
   // manifest at temp path, need to save path for adding to metadata
-  const manifestRelativePath = path.join('.', 'temp', options.appName, datepath);
-  const packageManifestPath = path.join('.', options.outputPath, manifestRelativePath);
-  fsExtra.copySync(path.join('.', options.manifestPath), packageManifestPath);
+  const manifestTargetRelativePath = path.join('.', 'temp', options.appName, datepath);
+  const manifestTargetPath = path.isAbsolute(options.outputPath)
+    ? path.join(options.outputPath, manifestTargetRelativePath)
+    : path.join('.', options.outputPath, manifestTargetRelativePath);
+
+  const manifestSourcePath = path.isAbsolute(options.manifestPath)
+    ? options.manifestPath
+    : path.join('.', options.manifestPath);
+
+  fsExtra.copySync(manifestSourcePath, manifestTargetPath);
 
   // generate manifest package
   const updatePackage = path.join(
@@ -29,6 +36,6 @@ export function packageGenerate(options: PackageGenerateOptions) {
   );
 
   return new Promise((resolve) => {
-    createPackage(packageManifestPath, updatePackage, () => resolve(null));
+    createPackage(manifestTargetPath, updatePackage, () => resolve(null));
   });
 }

--- a/packages/sitecore-jss-dev-tools/src/update/index.ts
+++ b/packages/sitecore-jss-dev-tools/src/update/index.ts
@@ -24,7 +24,7 @@ const getEntries = (folder: string): FileEntry[] => {
   const files = walkSync(folder);
   const entries: { path: string; name: string }[] = [];
   files.forEach((entry) => {
-    const entryPath = path.join('.', entry);
+    const entryPath = path.isAbsolute(entry) ? entry : path.join('.', entry);
     // remove initial folder and convert to fwd slash
     let name = path.relative(folder, entryPath);
     if (entryPath.endsWith(path.sep)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The 'jss deploy component' command was failing tue to not resolving properly relative vs absolute paths when creating the deploy package.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
