### PR TITLE
[sitecore-jss-react] Preserve form state and interactivity between rerenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 * `[create-sitecore-jss]` Fix nextjs-styleguide template build failure ([#2196](https://github.com/Sitecore/jss/pull/2196))
 * `[sitecore-jss-tools]` Fix `jss deploy component` command failing ([#2195](https://github.com/Sitecore/jss/pull/2195))
+* `[sitecore-jss-react]` Form component loses interactivity and state between rerenders ([#2197](https://github.com/Sitecore/jss/pull/2197))
 
 ### Chores
 

--- a/packages/sitecore-jss-react/src/components/Form.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Form.test.tsx
@@ -197,4 +197,55 @@ describe('Form', () => {
       );
     });
   });
+
+  it('initializes form DOM only once (prevents re-initialization on re-render)', async () => {
+    const loadFormSpy = sinon
+      .stub()
+      .resolves('<form id="test-form"><input type="text" name="field1" /></form>');
+    const subscribeSpy = sinon.spy();
+    const execSpy = sinon.spy();
+
+    mockFormModule({
+      loadForm: loadFormSpy,
+      subscribeToFormSubmitEvent: subscribeSpy,
+      executeScriptElements: execSpy,
+    });
+
+    const rendered = render(
+      <SitecoreContext api={context.api} layoutData={context.layoutData.normal}>
+        <Form rendering={rendering} params={rendering.params} />
+      </SitecoreContext>
+    );
+
+    // Wait for initial render
+    await waitFor(() => {
+      expect(execSpy.calledOnce).to.be.true;
+      expect(subscribeSpy.calledOnce).to.be.true;
+    });
+
+    // Simulate user entering data
+    const input = rendered.container.querySelector('input[name="field1"]') as HTMLInputElement;
+    if (input) {
+      input.value = 'user-entered-value';
+    }
+
+    // Force re-render with same props
+    rendered.rerender(
+      <SitecoreContext api={context.api} layoutData={context.layoutData.normal}>
+        <Form rendering={rendering} params={rendering.params} />
+      </SitecoreContext>
+    );
+
+    await waitFor(() => {
+      // Scripts and subscription should still only be called once
+      expect(execSpy.calledOnce).to.be.true;
+      expect(subscribeSpy.calledOnce).to.be.true;
+
+      // User input should be preserved
+      const inputAfterRerender = rendered.container.querySelector(
+        'input[name="field1"]'
+      ) as HTMLInputElement;
+      expect(inputAfterRerender?.value).to.equal('user-entered-value');
+    });
+  });
 });

--- a/packages/sitecore-jss-react/src/components/Form.tsx
+++ b/packages/sitecore-jss-react/src/components/Form.tsx
@@ -60,15 +60,20 @@ export const Form = ({ params, rendering }: FormProps) => {
           }
           setError(true);
         });
-    } else {
-      // If we are in editing mode, we don't want to send any events
-      if (!isEditing) {
-        subscribeToFormSubmitEvent(formRef.current, rendering.uid);
-      }
-
-      executeScriptElements(formRef.current);
     }
-  }, [content]);
+  }, [content, params.FormId, context.api?.edge?.contextId, context.api?.edge?.edgeUrl, isEditing]);
+
+  useEffect(() => {
+    if (!content || !formRef.current) return;
+
+    formRef.current.innerHTML = content;
+    executeScriptElements(formRef.current);
+
+    // If we are in editing mode, we don't want to send any events
+    if (!isEditing) {
+      subscribeToFormSubmitEvent(formRef.current, rendering.uid);
+    }
+  }, [content, isEditing, rendering.uid]);
 
   if (isEditing) {
     if (error) {
@@ -78,12 +83,5 @@ export const Form = ({ params, rendering }: FormProps) => {
     }
   }
 
-  return (
-    <div
-      ref={formRef}
-      dangerouslySetInnerHTML={{ __html: content }}
-      className={params.styles?.trimEnd()}
-      id={id ? id : undefined}
-    ></div>
-  );
+  return <div ref={formRef} className={params.styles?.trimEnd()} id={id ? id : undefined}></div>;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using dangerouslySetInnerHTML caused scripts to execute only on the initial render. Subsequent re-renders would update the HTML but would not re-trigger executeScripts, breaking form validation and interactive features.
Avoid this by replacing dangerouslySetInnerHTML with setting innerHtml  offormRef.
Decoupled logic into two distinct useEffects: one for fetching content and one for injecting HTML/executing scripts.
- Form scripts now run correctly on every re-render.
- Form state is now preserved across renders.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
