### PR TITLE
[nextjs-sxa] Ensure sitemap schema URL has correct format in sample

### DIFF
--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/pages/api/sitemap.ts
@@ -67,7 +67,7 @@ const sitemapApi = async (
   res.setHeader('Content-Type', 'text/xml;charset=utf-8');
 
   return res.send(`<?xml version="1.0" encoding="UTF-8"?>
-  <sitemapindex xmlns="http://sitemaps.org/schemas/sitemap/0.9">${SitemapLinks}</sitemapindex>
+  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${SitemapLinks}</sitemapindex>
   `);
 };
 


### PR DESCRIPTION
Small chore change to SXA add-on, ensuring correct format in schema URL, for the sitemap page.
