### PR TITLE
[sitecore-jss] Personalize hide component not working properly in edit mode for nested personalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Skip malformed redirect regex rules instead of failing the entire redirect chain ([#2201](https://github.com/Sitecore/jss/pull/2201))
-* `[sitecore-jss]` Fix personalize hide component not working properly in edit mode for nested personalization
+* `[sitecore-jss]` Fix personalize hide component not working properly in edit mode for nested personalization ([#2202](https://github.com/Sitecore/jss/pull/2202))
 * `[create-sitecore-jss]` Sitemap index XML xmlns omits the 'www' prefix ([#2199](https://github.com/Sitecore/jss/pull/2199))
 
 ## 22.12.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Our versioning strategy is as follows:
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-nextjs]` Skip malformed redirect regex rules instead of failing the entire redirect chain ([#2201](https://github.com/Sitecore/jss/pull/2201))
+* `[sitecore-jss]` Fix personalize hide component not working properly in edit mode for nested personalization
+* `[create-sitecore-jss]` Sitemap index XML xmlns omits the 'www' prefix ([#2199](https://github.com/Sitecore/jss/pull/2199))
 
 ## 22.12.3
 

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.test.ts
@@ -147,6 +147,111 @@ describe('layout-personalizer', () => {
           },
         ]);
       });
+
+      it('should handle nested hidden components in edit mode', () => {
+        const nestedHiddenComponent = {
+          uid: 'nested-hidden-uid',
+          componentName: 'NestedComponent',
+          dataSource: 'nested-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'nested-hidden-uid',
+              componentName: null,
+              dataSource: null,
+            },
+          },
+        };
+
+        const rootComponent = {
+          uid: 'root-uid',
+          componentName: 'RootComponent',
+          dataSource: 'root-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'root-uid',
+              componentName: 'RootComponent',
+              dataSource: 'root-variant-datasource',
+              placeholders: {
+                main: [nestedHiddenComponent],
+              },
+            },
+          },
+        };
+
+        const variant = 'mountain_bike_audience';
+        const personalizedPlaceholderResult = personalizePlaceholder(
+          [rootComponent],
+          [variant],
+          true
+        );
+
+        expect(personalizedPlaceholderResult).to.deep.equal([
+          {
+            uid: 'root-uid',
+            componentName: 'RootComponent',
+            dataSource: 'root-variant-datasource',
+            placeholders: {
+              main: [
+                {
+                  uid: 'nested-hidden-uid',
+                  componentName: HIDDEN_RENDERING_NAME,
+                  dataSource: 'nested-datasource',
+                  experiences: {},
+                },
+              ],
+            },
+          },
+        ]);
+      });
+
+      it('should filter out hidden nested components when not in edit mode', () => {
+        const nestedHiddenComponent = {
+          uid: 'nested-hidden-uid',
+          componentName: 'NestedComponent',
+          dataSource: 'nested-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'nested-hidden-uid',
+              componentName: null,
+              dataSource: null,
+            },
+          },
+        };
+
+        const rootComponent = {
+          uid: 'root-uid',
+          componentName: 'RootComponent',
+          dataSource: 'root-default-datasource',
+          experiences: {
+            mountain_bike_audience: {
+              uid: 'root-uid',
+              componentName: 'RootComponent',
+              dataSource: 'root-variant-datasource',
+              placeholders: {
+                nested: [nestedHiddenComponent],
+              },
+            },
+          },
+        };
+
+        const variant = 'mountain_bike_audience';
+        const personalizedPlaceholderResult = personalizePlaceholder(
+          [rootComponent],
+          [variant],
+          false
+        );
+
+        expect(personalizedPlaceholderResult).to.deep.equal([
+          {
+            uid: 'root-uid',
+            componentName: 'RootComponent',
+            dataSource: 'root-variant-datasource',
+            placeholders: {
+              nested: [],
+            },
+          },
+        ]);
+      });
     });
 
     describe('with multiple variant Ids', () => {

--- a/packages/sitecore-jss/src/personalize/layout-personalizer.ts
+++ b/packages/sitecore-jss/src/personalize/layout-personalizer.ts
@@ -135,7 +135,8 @@ export function personalizeComponent(
     if (component.placeholders) {
       component.placeholders[placeholder] = personalizePlaceholder(
         component.placeholders[placeholder],
-        variantIds
+        variantIds,
+        metadataEditing
       );
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
If the immediate parent component contains broken links associated with a personalization variant, hide/unhide functionality does not behave correctly for child components added under that parent.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
