### PR TITLE
[create-sitecore-jss] Next.js link prefetch functionality causes a lot of 404 errors in Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Our versioning strategy is as follows:
 * `[sitecore-jss-nextjs]` Skip malformed redirect regex rules instead of failing the entire redirect chain ([#2201](https://github.com/Sitecore/jss/pull/2201))
 * `[sitecore-jss]` Fix personalize hide component not working properly in edit mode for nested personalization ([#2202](https://github.com/Sitecore/jss/pull/2202))
 * `[create-sitecore-jss]` Sitemap index XML xmlns omits the 'www' prefix ([#2199](https://github.com/Sitecore/jss/pull/2199))
+* `[create-sitecore-jss]` Pass `metadata` to navigation link fields to prevent 404 errors when hovering links in Pages ([#2206](https://github.com/Sitecore/jss/pull/2206))
 
 ### Chores
 

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
@@ -48,6 +48,7 @@ export class NavigationItemComponent implements OnInit {
       title: this.getLinkTitle(navItemFields),
       querystring: navItemFields.Querystring,
     },
+    metadata: navItemFields.NavigationTitle?.metadata,
   });
 
   private getLinkTitle = (navItemFields: NavItemFields): string | undefined => {

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import { LinkField, JssModule } from '@sitecore-jss/sitecore-jss-angular';
 import { Field } from '@sitecore-jss/sitecore-jss-angular';
 
@@ -43,7 +42,7 @@ export class NavigationItemComponent implements OnInit {
     this.childLinkClickEvent.emit(event);
   }
 
-  private getLinkField = (navItemFields: NavItemFields): LinkField & FieldMetadata => ({
+  private getLinkField = (navItemFields: NavItemFields): LinkField => ({
     value: {
       href: navItemFields.Href,
       title: this.getLinkTitle(navItemFields),

--- a/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
+++ b/packages/create-sitecore-jss/src/templates/angular-xmcloud/src/app/components/navigation/navigation-item.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import { LinkField, JssModule } from '@sitecore-jss/sitecore-jss-angular';
 import { Field } from '@sitecore-jss/sitecore-jss-angular';
 
@@ -42,7 +43,7 @@ export class NavigationItemComponent implements OnInit {
     this.childLinkClickEvent.emit(event);
   }
 
-  private getLinkField = (navItemFields: NavItemFields): LinkField => ({
+  private getLinkField = (navItemFields: NavItemFields): LinkField & FieldMetadata => ({
     value: {
       href: navItemFields.Href,
       title: this.getLinkTitle(navItemFields),

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import { useState, JSX } from 'react';
-import type { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
+import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import {
   Link,
   LinkField,

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -39,12 +39,13 @@ const getNavigationText = function(props: NavigationProps): JSX.Element | string
   return text;
 };
 
-const getLinkField = (props: NavigationProps): LinkField => ({
+const getLinkField = (props: NavigationProps): LinkField & any => ({
   value: {
     href: props.fields.Href,
     title: getLinkTitle(props),
     querystring: props.fields.Querystring,
   },
+  metadata: props.fields.NavigationTitle?.metadata,
 });
 
 export const Default = (props: NavigationProps): JSX.Element => {

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -1,4 +1,5 @@
 import { useState, JSX } from 'react';
+import type { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import {
   Link,
   LinkField,
@@ -39,9 +40,7 @@ const getNavigationText = function(props: NavigationProps): JSX.Element | string
   return text;
 };
 
-type NavigationLinkField = LinkField & Pick<TextField, 'metadata'>;
-
-const getLinkField = (props: NavigationProps): NavigationLinkField => ({
+const getLinkField = (props: NavigationProps): LinkField & FieldMetadata => ({
   value: {
     href: props.fields.Href,
     title: getLinkTitle(props),

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { useState, JSX } from 'react';
 import {
   Link,
   LinkField,
-  Field,
+  FieldMetadata,
   Text,
   TextField,
   useSitecoreContext,
@@ -40,7 +40,7 @@ const getNavigationText = function(props: NavigationProps): JSX.Element | string
   return text;
 };
 
-const getLinkField = (props: NavigationProps): LinkField & Field => ({
+const getLinkField = (props: NavigationProps): LinkField & FieldMetadata => ({
   value: {
     href: props.fields.Href,
     title: getLinkTitle(props),

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -1,8 +1,8 @@
 import { useState, JSX } from 'react';
-import { FieldMetadata } from '@sitecore-jss/sitecore-jss/layout';
 import {
   Link,
   LinkField,
+  Field,
   Text,
   TextField,
   useSitecoreContext,
@@ -40,7 +40,7 @@ const getNavigationText = function(props: NavigationProps): JSX.Element | string
   return text;
 };
 
-const getLinkField = (props: NavigationProps): LinkField & FieldMetadata => ({
+const getLinkField = (props: NavigationProps): LinkField & Field => ({
   value: {
     href: props.fields.Href,
     title: getLinkTitle(props),

--- a/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
+++ b/packages/create-sitecore-jss/src/templates/nextjs-sxa/src/components/Navigation.tsx
@@ -39,7 +39,9 @@ const getNavigationText = function(props: NavigationProps): JSX.Element | string
   return text;
 };
 
-const getLinkField = (props: NavigationProps): LinkField & any => ({
+type NavigationLinkField = LinkField & Pick<TextField, 'metadata'>;
+
+const getLinkField = (props: NavigationProps): NavigationLinkField => ({
   value: {
     href: props.fields.Href,
     title: getLinkTitle(props),

--- a/packages/sitecore-jss-nextjs/src/index.ts
+++ b/packages/sitecore-jss-nextjs/src/index.ts
@@ -28,6 +28,7 @@ export {
   PlaceholdersData,
   RouteData,
   Field,
+  FieldMetadata,
   Item,
   HtmlElementRendering,
   getChildPlaceholder,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Hovering navigation links in Sitecore Pages causes 404 console errors. Navigation components build synthetic `LinkField` objects without `NavigationTitle.metadata`, so `sitecore-jss-nextjs` `Link `renders `NextLink` (with prefetch) instead of the React Link in edit mode.

This PR passes `NavigationTitle.metadata` into `getLinkField` in the `nextjs-sxa` and `angular-xmcloud` Navigation templates.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)
open Pages, hover nav links, confirm no 404s; verify links work in normal mode and titles remain editable in Pages

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
