### PR TITLE
[sitecore-jss-react] Limit props passed by Placeholder component to rendered components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Our versioning strategy is as follows:
 
 * `[create-sitecore-jss]` Pass `metadata` to navigation link fields to prevent 404 errors when hovering links in Pages ([#2206](https://github.com/Sitecore/jss/pull/2206))
 
+### 🛠 Breaking Changes
+
+* `[sitecore-jss-react]` Internal props such as `api`, `componentFactory`, `modifyComponentProps`, `sitecoreContext`, and `updateSitecoreContext` are no longer passed to components via `Placeholder` ([#2207](https://github.com/Sitecore/jss/pull/2207))
+  * **Still passed:** `fields`, `params`, `rendering` (+ props from `modifyComponentProps`).
+  * **New prop:** `passThroughComponentProps` — use this to pass additional props to rendered components explicitly.
+
 ## 22.12.4
 
 ### 🐛 Bug Fixes

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -163,9 +163,8 @@ describe('<Placeholder />', () => {
 
         expect(renderedComponent.container.innerHTML).to.be.equal('');
       });
-    });
 
-    it('should render output based on the renderEmpty function in case of no renderings', () => {
+      it('should render output based on the renderEmpty function in case of no renderings', () => {
       const component = dataSet.data.sitecore.route as RouteData;
       const renderings = component.placeholders.main.filter(
         (c) => !(c as ComponentRendering).componentName
@@ -237,10 +236,11 @@ describe('<Placeholder />', () => {
     });
 
     it('should apply modifyComponentProps to the final props', () => {
-      const component = dataSet.data.sitecore.route as any;
-      const phKey = 'main';
-      const expectedMessage = (component.placeholders.main as any[]).find((c) => c.componentName)
-        .fields.message;
+      const component = (dataSet.data.sitecore.route.placeholders.main as (
+        | ComponentRendering
+        | RouteData
+      )[]).find((c) => (c as ComponentRendering).componentName);
+      const phKey = 'page-content';
 
       const modifyComponentProps = (props: ComponentProps) => {
         if (props.rendering?.componentName === 'DownloadCallout') {
@@ -263,12 +263,76 @@ describe('<Placeholder />', () => {
         </SitecoreContext>
       );
 
-      expect(
-        renderedComponent.container
-          .querySelector('.download-callout-mock')
-          ?.innerHTML.indexOf(expectedMessage.value) !== -1
-      ).to.be.true;
       expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
+    });
+
+    it('should not pass internal Placeholder props to rendered components', () => {
+      const receivedProps: string[] = [];
+      const PropCapture: React.FC<Record<string, unknown>> = (props) => {
+        receivedProps.push(...Object.keys(props));
+        return <div className="prop-capture" />;
+      };
+
+      const factory: ComponentFactory = (componentName: string) => {
+        if (componentName === 'DownloadCallout') return PropCapture;
+        return componentFactory(componentName);
+      };
+
+      const component = (dataSet.data.sitecore.route.placeholders.main as (
+        | ComponentRendering
+        | RouteData
+      )[]).find((c) => (c as ComponentRendering).componentName);
+      const phKey = 'page-content';
+
+      render(
+        <SitecoreContext componentFactory={factory}>
+          <Placeholder name={phKey} rendering={component} />
+        </SitecoreContext>
+      );
+
+      const unexpectedProps = [
+        'api',
+        'componentFactory',
+        'modifyComponentProps',
+        'sitecoreContext',
+        'updateSitecoreContext',
+        'errorComponent',
+        'componentLoadingMessage',
+        'disableSuspense',
+        'missingComponentComponent',
+        'hiddenRenderingComponent',
+        'passThroughComponentProps',
+        'name',
+      ];
+
+      unexpectedProps.forEach((prop) => {
+        expect(receivedProps, `rendered component should not receive "${prop}"`).to.not.include(
+          prop
+        );
+      });
+
+      expect(receivedProps).to.include('rendering');
+    });
+
+    it('should pass passThroughComponentProps to rendered components', () => {
+      const component = (dataSet.data.sitecore.route.placeholders.main as (
+        | ComponentRendering
+        | RouteData
+      )[]).find((c) => (c as ComponentRendering).componentName);
+      const phKey = 'page-content';
+
+      const renderedComponent = render(
+        <SitecoreContext componentFactory={componentFactory}>
+          <Placeholder
+            name={phKey}
+            rendering={component}
+            passThroughComponentProps={{ extraDiv: true }}
+          />
+        </SitecoreContext>
+      );
+
+      expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
+    });
     });
   });
 });

--- a/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.test.tsx
@@ -165,174 +165,174 @@ describe('<Placeholder />', () => {
       });
 
       it('should render output based on the renderEmpty function in case of no renderings', () => {
-      const component = dataSet.data.sitecore.route as RouteData;
-      const renderings = component.placeholders.main.filter(
-        (c) => !(c as ComponentRendering).componentName
-      );
-      const myComponent = {
-        ...component,
-        placeholders: {
-          ...component.placeholders,
-          main: [...renderings],
-        },
-      };
+        const component = dataSet.data.sitecore.route as RouteData;
+        const renderings = component.placeholders.main.filter(
+          (c) => !(c as ComponentRendering).componentName
+        );
+        const myComponent = {
+          ...component,
+          placeholders: {
+            ...component.placeholders,
+            main: [...renderings],
+          },
+        };
 
-      const phKey = 'main';
+        const phKey = 'main';
 
-      const renderedComponent = render(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder
-            name={phKey}
-            rendering={myComponent}
-            renderEmpty={(comp) => <div className="wrapper">{comp}</div>}
-          />
-        </SitecoreContext>
-      );
+        const renderedComponent = render(
+          <SitecoreContext componentFactory={componentFactory}>
+            <Placeholder
+              name={phKey}
+              rendering={myComponent}
+              renderEmpty={(comp) => <div className="wrapper">{comp}</div>}
+            />
+          </SitecoreContext>
+        );
 
-      expect(renderedComponent.container.querySelectorAll('.wrapper').length).to.equal(1);
-      expect(
-        renderedComponent.container.querySelectorAll('.download-callout-mock').length
-      ).to.equal(0);
-      expect(renderedComponent.container.querySelectorAll('.home-mock').length).to.equal(0);
-      expect(renderedComponent.container.querySelectorAll('.jumbotron-mock').length).to.equal(0);
-    });
+        expect(renderedComponent.container.querySelectorAll('.wrapper').length).to.equal(1);
+        expect(
+          renderedComponent.container.querySelectorAll('.download-callout-mock').length
+        ).to.equal(0);
+        expect(renderedComponent.container.querySelectorAll('.home-mock').length).to.equal(0);
+        expect(renderedComponent.container.querySelectorAll('.jumbotron-mock').length).to.equal(0);
+      });
 
-    it('should render output based on the renderEmpty function in case of empty placeholder', () => {
-      const route = emptyPlaceholderData.sitecore.route as RouteData;
-      const phKey = 'mainEmpty';
+      it('should render output based on the renderEmpty function in case of empty placeholder', () => {
+        const route = emptyPlaceholderData.sitecore.route as RouteData;
+        const phKey = 'mainEmpty';
 
-      const renderedComponent = render(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder
-            name={phKey}
-            rendering={route}
-            renderEmpty={() => <span>My name is empty placeholder</span>}
-          />
-        </SitecoreContext>
-      );
+        const renderedComponent = render(
+          <SitecoreContext componentFactory={componentFactory}>
+            <Placeholder
+              name={phKey}
+              rendering={route}
+              renderEmpty={() => <span>My name is empty placeholder</span>}
+            />
+          </SitecoreContext>
+        );
 
-      expect(renderedComponent.container.innerHTML).to.equal(
-        '<div class="sc-jss-empty-placeholder"><span>My name is empty placeholder</span></div>'
-      );
-    });
-
-    it('should pass properties to nested components', () => {
-      const component = dataSet.data.sitecore.route as any;
-      const phKey = 'main';
-      const expectedMessage = (component.placeholders.main as any[]).find((c) => c.componentName)
-        .fields.message;
-
-      const renderedComponent = render(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder name={phKey} rendering={component} />
-        </SitecoreContext>
-      );
-
-      expect(
-        renderedComponent.container
-          .querySelector('.download-callout-mock')
-          ?.innerHTML.indexOf(expectedMessage.value) !== -1
-      ).to.be.true;
-    });
-
-    it('should apply modifyComponentProps to the final props', () => {
-      const component = (dataSet.data.sitecore.route.placeholders.main as (
-        | ComponentRendering
-        | RouteData
-      )[]).find((c) => (c as ComponentRendering).componentName);
-      const phKey = 'page-content';
-
-      const modifyComponentProps = (props: ComponentProps) => {
-        if (props.rendering?.componentName === 'DownloadCallout') {
-          return {
-            ...props,
-            extraDiv: true,
-          };
-        }
-
-        return props;
-      };
-
-      const renderedComponent = render(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder
-            name={phKey}
-            rendering={component}
-            modifyComponentProps={modifyComponentProps}
-          />
-        </SitecoreContext>
-      );
-
-      expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
-    });
-
-    it('should not pass internal Placeholder props to rendered components', () => {
-      const receivedProps: string[] = [];
-      const PropCapture: React.FC<Record<string, unknown>> = (props) => {
-        receivedProps.push(...Object.keys(props));
-        return <div className="prop-capture" />;
-      };
-
-      const factory: ComponentFactory = (componentName: string) => {
-        if (componentName === 'DownloadCallout') return PropCapture;
-        return componentFactory(componentName);
-      };
-
-      const component = (dataSet.data.sitecore.route.placeholders.main as (
-        | ComponentRendering
-        | RouteData
-      )[]).find((c) => (c as ComponentRendering).componentName);
-      const phKey = 'page-content';
-
-      render(
-        <SitecoreContext componentFactory={factory}>
-          <Placeholder name={phKey} rendering={component} />
-        </SitecoreContext>
-      );
-
-      const unexpectedProps = [
-        'api',
-        'componentFactory',
-        'modifyComponentProps',
-        'sitecoreContext',
-        'updateSitecoreContext',
-        'errorComponent',
-        'componentLoadingMessage',
-        'disableSuspense',
-        'missingComponentComponent',
-        'hiddenRenderingComponent',
-        'passThroughComponentProps',
-        'name',
-      ];
-
-      unexpectedProps.forEach((prop) => {
-        expect(receivedProps, `rendered component should not receive "${prop}"`).to.not.include(
-          prop
+        expect(renderedComponent.container.innerHTML).to.equal(
+          '<div class="sc-jss-empty-placeholder"><span>My name is empty placeholder</span></div>'
         );
       });
 
-      expect(receivedProps).to.include('rendering');
-    });
+      it('should pass properties to nested components', () => {
+        const component = dataSet.data.sitecore.route as any;
+        const phKey = 'main';
+        const expectedMessage = (component.placeholders.main as any[]).find((c) => c.componentName)
+          .fields.message;
 
-    it('should pass passThroughComponentProps to rendered components', () => {
-      const component = (dataSet.data.sitecore.route.placeholders.main as (
-        | ComponentRendering
-        | RouteData
-      )[]).find((c) => (c as ComponentRendering).componentName);
-      const phKey = 'page-content';
+        const renderedComponent = render(
+          <SitecoreContext componentFactory={componentFactory}>
+            <Placeholder name={phKey} rendering={component} />
+          </SitecoreContext>
+        );
 
-      const renderedComponent = render(
-        <SitecoreContext componentFactory={componentFactory}>
-          <Placeholder
-            name={phKey}
-            rendering={component}
-            passThroughComponentProps={{ extraDiv: true }}
-          />
-        </SitecoreContext>
-      );
+        expect(
+          renderedComponent.container
+            .querySelector('.download-callout-mock')
+            ?.innerHTML.indexOf(expectedMessage.value) !== -1
+        ).to.be.true;
+      });
 
-      expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
-    });
+      it('should apply modifyComponentProps to the final props', () => {
+        const component = (dataSet.data.sitecore.route.placeholders.main as (
+          | ComponentRendering
+          | RouteData
+        )[]).find((c) => (c as ComponentRendering).componentName);
+        const phKey = 'page-content';
+
+        const modifyComponentProps = (props: ComponentProps) => {
+          if (props.rendering?.componentName === 'DownloadCallout') {
+            return {
+              ...props,
+              extraDiv: true,
+            };
+          }
+
+          return props;
+        };
+
+        const renderedComponent = render(
+          <SitecoreContext componentFactory={componentFactory}>
+            <Placeholder
+              name={phKey}
+              rendering={component}
+              modifyComponentProps={modifyComponentProps}
+            />
+          </SitecoreContext>
+        );
+
+        expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
+      });
+
+      it('should not pass internal Placeholder props to rendered components', () => {
+        const receivedProps: string[] = [];
+        const PropCapture: React.FC<Record<string, unknown>> = (props) => {
+          receivedProps.push(...Object.keys(props));
+          return <div className="prop-capture" />;
+        };
+
+        const factory: ComponentFactory = (componentName: string) => {
+          if (componentName === 'DownloadCallout') return PropCapture;
+          return componentFactory(componentName);
+        };
+
+        const component = (dataSet.data.sitecore.route.placeholders.main as (
+          | ComponentRendering
+          | RouteData
+        )[]).find((c) => (c as ComponentRendering).componentName);
+        const phKey = 'page-content';
+
+        render(
+          <SitecoreContext componentFactory={factory}>
+            <Placeholder name={phKey} rendering={component} />
+          </SitecoreContext>
+        );
+
+        const unexpectedProps = [
+          'api',
+          'componentFactory',
+          'modifyComponentProps',
+          'sitecoreContext',
+          'updateSitecoreContext',
+          'errorComponent',
+          'componentLoadingMessage',
+          'disableSuspense',
+          'missingComponentComponent',
+          'hiddenRenderingComponent',
+          'passThroughComponentProps',
+          'name',
+        ];
+
+        unexpectedProps.forEach((prop) => {
+          expect(receivedProps, `rendered component should not receive "${prop}"`).to.not.include(
+            prop
+          );
+        });
+
+        expect(receivedProps).to.include('rendering');
+      });
+
+      it('should pass passThroughComponentProps to rendered components', () => {
+        const component = (dataSet.data.sitecore.route.placeholders.main as (
+          | ComponentRendering
+          | RouteData
+        )[]).find((c) => (c as ComponentRendering).componentName);
+        const phKey = 'page-content';
+
+        const renderedComponent = render(
+          <SitecoreContext componentFactory={componentFactory}>
+            <Placeholder
+              name={phKey}
+              rendering={component}
+              passThroughComponentProps={{ extraDiv: true }}
+            />
+          </SitecoreContext>
+        );
+
+        expect(renderedComponent.container.querySelectorAll('div.extra').length).to.equal(1);
+      });
     });
   });
 });

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -267,9 +267,7 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           rendering: componentRendering,
         };
 
-        const modifiedProps = modifyComponentProps
-          ? modifyComponentProps(childProps)
-          : childProps;
+        const modifiedProps = modifyComponentProps ? modifyComponentProps(childProps) : childProps;
 
         const finalProps = {
           ...modifiedProps,

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -65,6 +65,13 @@ export interface PlaceholderProps {
    */
   modifyComponentProps?: (componentProps: ComponentProps) => ComponentProps;
   /**
+   * An alternative to `modifyComponentProps` that allows passing additional props to rendered
+   * components without forwarding Placeholder/SitecoreContext internal props.
+   */
+  passThroughComponentProps?: {
+    [key: string]: unknown;
+  };
+  /**
    * A component that is rendered in place of any components that are in this placeholder,
    * but do not have a definition in the componentFactory (i.e. don't have a React implementation)
    */
@@ -187,7 +194,11 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       params: placeholderParams,
       missingComponentComponent,
       hiddenRenderingComponent,
-      ...placeholderProps
+      passThroughComponentProps,
+      modifyComponentProps,
+      errorComponent,
+      componentLoadingMessage,
+      disableSuspense,
     } = this.props;
 
     const transformedComponents = placeholderData
@@ -241,9 +252,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           isEmpty = true;
         }
 
-        const finalProps = {
+        // Only pass rendering data props to child components.
+        // Internal Placeholder/SitecoreContext props are excluded.
+        const childProps: ComponentProps = {
           ...commonProps,
-          ...placeholderProps,
           ...((placeholderFields || componentRendering.fields) && {
             fields: { ...placeholderFields, ...componentRendering.fields },
           }),
@@ -258,9 +270,18 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           rendering: componentRendering,
         };
 
+        const modifiedProps = modifyComponentProps
+          ? modifyComponentProps(childProps)
+          : childProps;
+
+        const finalProps = {
+          ...modifiedProps,
+          ...passThroughComponentProps,
+        };
+
         let rendered = React.createElement<{ [attr: string]: unknown }>(
           component as React.ComponentType,
-          this.props.modifyComponentProps ? this.props.modifyComponentProps(finalProps) : finalProps
+          finalProps
         );
 
         if (!isEmpty) {
@@ -273,17 +294,18 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           // all dynamic elements will have a separate render prop
           const isDynamicComponent = !!(component as JssComponentType).render?.preload;
 
-          // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
-          // that's why we need to expose element's props here
+          // Pass only ErrorBoundary props here (aligned with Content SDK).
+          // Do not spread child props onto the boundary — that made ErrorBoundary look like the
+          // Sitecore component in React DevTools and leaked Placeholder internals as undefined.
           rendered = (
             <ErrorBoundary
-              key={rendered.type + '-' + index}
-              errorComponent={this.props.errorComponent}
-              componentLoadingMessage={this.props.componentLoadingMessage}
+              key={String(rendered.type) + '-' + index}
               type={type}
               isDynamic={isDynamicComponent || isByocWrapper}
-              disableSuspense={this.props.disableSuspense}
-              {...rendered.props}
+              rendering={componentRendering}
+              {...(errorComponent ? { errorComponent } : {})}
+              {...(componentLoadingMessage ? { componentLoadingMessage } : {})}
+              {...(disableSuspense !== undefined ? { disableSuspense } : {})}
             >
               {rendered}
             </ErrorBoundary>

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -196,9 +196,6 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       hiddenRenderingComponent,
       passThroughComponentProps,
       modifyComponentProps,
-      errorComponent,
-      componentLoadingMessage,
-      disableSuspense,
     } = this.props;
 
     const transformedComponents = placeholderData
@@ -294,18 +291,17 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
           // all dynamic elements will have a separate render prop
           const isDynamicComponent = !!(component as JssComponentType).render?.preload;
 
-          // Pass only ErrorBoundary props here (aligned with Content SDK).
-          // Do not spread child props onto the boundary — that made ErrorBoundary look like the
-          // Sitecore component in React DevTools and leaked Placeholder internals as undefined.
+          // wrapping with error boundary could cause problems in case where parent component uses withPlaceholder HOC and tries to access its children props
+          // that's why we need to expose element's props here
           rendered = (
             <ErrorBoundary
-              key={String(rendered.type) + '-' + index}
+              key={rendered.type + '-' + index}
+              errorComponent={this.props.errorComponent}
+              componentLoadingMessage={this.props.componentLoadingMessage}
               type={type}
               isDynamic={isDynamicComponent || isByocWrapper}
-              rendering={componentRendering}
-              {...(errorComponent ? { errorComponent } : {})}
-              {...(componentLoadingMessage ? { componentLoadingMessage } : {})}
-              {...(disableSuspense !== undefined ? { disableSuspense } : {})}
+              disableSuspense={this.props.disableSuspense}
+              {...rendered.props}
             >
               {rendered}
             </ErrorBoundary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Stop forwarding Placeholder/SitecoreContext internal props to rendered components
- Add `passThroughComponentProps `for explicit extras
- Keep `{...rendered.props}` on `ErrorBoundary` for `withPlaceholder` compatibility


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)
Confirm internal props are not passed to components; `passThroughComponentProps` / modifyComponentProps still work
`
`## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
