### PR TITLE
[sitecore-jss-react] RichText builds a new dangerouslySetInnerHTML object every render, causing full DOM replacement and dropped internal-link listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Our versioning strategy is as follows:
 
 * `[create-sitecore-jss]` Fix Vue template build failure caused by `@vue/cli-plugin-eslint` being incompatible with ESLint 9; linting during `vue-cli-service build` is now disabled, use `npm run lint` instead ([#2208](https://github.com/Sitecore/jss/pull/2208))
 * `[create-sitecore-jss]` Pass `metadata` to navigation link fields to prevent 404 errors when hovering links in Pages ([#2206](https://github.com/Sitecore/jss/pull/2206))
+* `[sitecore-jss-react]` Stabilize `RichText` nested DOM across parent re-renders by memoizing `dangerouslySetInnerHTML`, preserving attached event listeners (e.g. Next.js internal-link click/prefetch handlers) ([#2215](https://github.com/Sitecore/jss/pull/2215))
 
 ### 🛠 Breaking Changes
 

--- a/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-nextjs/src/components/RichText.test.tsx
@@ -362,6 +362,55 @@ describe('RichText', () => {
     expect(router.prefetch).callCount(0);
   });
 
+  it('should keep internal link click handlers after parent re-render with unchanged HTML', () => {
+    const app = document.createElement('main');
+
+    document.body.appendChild(app);
+
+    const router = Router();
+
+    const props = {
+      field: {
+        value: '<p>Hello <a id="rt-link" href="/foo">home</a></p>',
+      },
+    };
+
+    const PageWithTick = ({ tick }: { tick: number }) => (
+      <Page value={router}>
+        <div data-tick={tick}>
+          <RichText {...props} />
+        </div>
+      </Page>
+    );
+
+    const { rerender } = render(<PageWithTick tick={0} />, { baseElement: app });
+
+    const link = document.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+
+    expect(link).to.not.equal(null);
+    link.__marker = true;
+
+    link.click();
+    expect(router.push).callCount(1);
+
+    // Unrelated parent re-render must not recreate anchors (listeners would be lost).
+    rerender(<PageWithTick tick={1} />);
+
+    const linkAfter = document.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+
+    expect(linkAfter).to.equal(link);
+    expect(linkAfter.__marker).to.equal(true);
+
+    linkAfter.click();
+    expect(router.push).callCount(2);
+
+    document.body.removeChild(app);
+  });
+
   it('should call prefetch when prefetchLinks is set to hover', () => {
     const router = Router();
 

--- a/packages/sitecore-jss-nextjs/test/setup.js
+++ b/packages/sitecore-jss-nextjs/test/setup.js
@@ -1,3 +1,21 @@
 require('ts-node/register/transpile-only');
 require('../src/tests/request.ts');
 require('../src/tests/jsdom-setup.ts');
+
+// With nmHoistingLimits: workspaces, each package has its own React copy. Force a single
+// React for tests so hooks inside @sitecore-jss/sitecore-jss-react share the same dispatcher
+// as this package's react-dom renderer.
+const Module = require('module');
+const reactExports = require('react');
+const reactDomExports = require('react-dom');
+const originalRequire = Module.prototype.require;
+
+Module.prototype.require = function (id) {
+  if (id === 'react') {
+    return reactExports;
+  }
+  if (id === 'react-dom') {
+    return reactDomExports;
+  }
+  return originalRequire.apply(this, arguments);
+};

--- a/packages/sitecore-jss-react/src/components/RichText.test.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.test.tsx
@@ -97,4 +97,29 @@ describe('<RichText />', () => {
     expect(rendered[0].outerHTML).to.contain('<h1 class="cssClass" id="lorem">');
     expect(rendered[0].outerHTML).to.contain('value');
   });
+
+  it('should preserve nested DOM nodes across re-renders when HTML is unchanged', () => {
+    const field = {
+      value: '<a id="rt-link" href="/foo">bar</a>',
+    };
+
+    const { container, rerender } = render(<RichText field={field} />);
+    const link = container.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+
+    expect(link).to.not.equal(null);
+    link.__marker = true;
+
+    // Parent-style re-render with the same field HTML must not recreate child DOM nodes
+    // (React compares dangerouslySetInnerHTML by object reference).
+    rerender(<RichText field={field} />);
+
+    const linkAfter = container.querySelector('#rt-link') as HTMLAnchorElement & {
+      __marker?: boolean;
+    };
+
+    expect(linkAfter).to.equal(link);
+    expect(linkAfter.__marker).to.equal(true);
+  });
 });

--- a/packages/sitecore-jss-react/src/components/RichText.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.tsx
@@ -27,7 +27,7 @@ export const RichText = forwardRef(
     // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
     const html = field?.editable && editable ? field.editable : field?.value;
     const dangerouslySetInnerHTML = useMemo(
-      () => (html != null && html !== '' ? { __html: html } : undefined),
+      () => (html !== undefined && html !== '' ? { __html: html } : undefined),
       [html]
     );
 

--- a/packages/sitecore-jss-react/src/components/RichText.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef, useMemo } from 'react';
 import { EditableFieldProps } from './sharedTypes';
 import { isFieldValueEmpty } from '@sitecore-jss/sitecore-jss/layout';
 
@@ -23,14 +23,20 @@ export const RichText = forwardRef(
     { field, tag = 'div', editable = true, ...otherProps }: RichTextProps,
     ref: ForwardedRef<HTMLElement>
   ) => {
-    if (!field || (!field.editable && isFieldValueEmpty(field))) {
+    // Stabilize the object reference so React DOM does not rewrite innerHTML on every
+    // parent re-render when the HTML string is unchanged (preserves DOM nodes / listeners).
+    const html = field?.editable && editable ? field.editable : field?.value;
+    const dangerouslySetInnerHTML = useMemo(
+      () => (html != null && html !== '' ? { __html: html } : undefined),
+      [html]
+    );
+
+    if (!field || (!field.editable && isFieldValueEmpty(field)) || !dangerouslySetInnerHTML) {
       return null;
     }
 
     const htmlProps = {
-      dangerouslySetInnerHTML: {
-        __html: field.editable && editable ? field.editable : field.value,
-      },
+      dangerouslySetInnerHTML,
       ref,
       ...otherProps,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Memoize `RichText` `dangerouslySetInnerHTML` (keyed on resolved HTML) so React DOM does not reset `innerHTML` on every parent re-render when content is unchanged.
- Prevents nested DOM recreation and preserves Next.js internal-link click/prefetch listeners.
- Non-breaking bug fix; public API unchanged. Same class of issue as Content SDK RichText.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
