### PR TITLE
[sitecore-jss-react] Hydration failed because the server rendered HTML didn't match the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Our versioning strategy is as follows:
 
 ### 🐛 Bug Fixes
 
+* `[sitecore-jss-react]` Suppress hydration mismatch warnings in Experience Editor by adding `suppressHydrationWarning` to SDK chrome paths (ErrorBoundary, placeholders, field components)([#2218](https://github.com/Sitecore/jss/pull/2218))
 * `[create-sitecore-jss]` Fix Vue template build failure caused by `@vue/cli-plugin-eslint` being incompatible with ESLint 9; linting during `vue-cli-service build` is now disabled, use `npm run lint` instead ([#2208](https://github.com/Sitecore/jss/pull/2208))
 * `[create-sitecore-jss]` Pass `metadata` to navigation link fields to prevent 404 errors when hovering links in Pages ([#2206](https://github.com/Sitecore/jss/pull/2206))
 * `[sitecore-jss-react]` RichText rebuilds `dangerouslySetInnerHTML` on every render, causing full DOM replacement and dropped internal-link listeners ([#2204](https://github.com/Sitecore/jss/pull/2204))

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.test.tsx
@@ -78,6 +78,33 @@ describe('ErrorBoundary', () => {
       expect(ems[1].textContent).to.equal(errorMessage);
     });
 
+    it('Should wrap children in edit mode so Experience Editor chrome mutations can be suppressed', () => {
+      const setContext = spy();
+
+      const testComponentProps = {
+        context: {
+          pageEditing: true,
+          pageState: LayoutServicePageState.Edit,
+        },
+        setContext,
+      };
+
+      const rendered = render(
+        <SitecoreContextReactContext.Provider value={testComponentProps}>
+          <ErrorBoundary>
+            <span data-testid="child">Rendered child</span>
+          </ErrorBoundary>
+        </SitecoreContextReactContext.Provider>
+      );
+
+      const wrapper = rendered.container.firstElementChild as HTMLElement;
+      expect(wrapper?.tagName).to.equal('DIV');
+      expect(wrapper?.style.display).to.equal('contents');
+      expect(wrapper?.querySelector('[data-testid="child"]')?.textContent).to.equal(
+        'Rendered child'
+      );
+    });
+
     it('Should render errors message and errored component name when error is thrown in preview mode', () => {
       const setContext = spy();
 

--- a/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
+++ b/packages/sitecore-jss-react/src/components/ErrorBoundary.tsx
@@ -54,6 +54,13 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
     );
   }
 
+  isPageEditing(): boolean {
+    return (
+      !!this.props.sitecoreContext?.pageEditing ||
+      this.props.sitecoreContext?.pageState === LayoutServicePageState.Edit
+    );
+  }
+
   render() {
     if (this.state.error) {
       if (this.props.errorComponent) {
@@ -81,17 +88,32 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
     }
 
     // do not apply suspense when suspense is disabled or when on already dynamic components
+    let content: ReactNode;
     if ((this.props.disableSuspense ?? true) || this.props.isDynamic) {
-      return this.props.children;
+      content = this.props.children;
+    } else {
+      content = (
+        <Suspense
+          fallback={<h4>{this.props.componentLoadingMessage || this.defaultLoadingMessage}</h4>}
+        >
+          {this.props.children}
+        </Suspense>
+      );
     }
 
-    return (
-      <Suspense
-        fallback={<h4>{this.props.componentLoadingMessage || this.defaultLoadingMessage}</h4>}
-      >
-        {this.props.children}
-      </Suspense>
-    );
+    // Experience Editor tags the outermost DOM node of each rendering (sc-part-of,
+    // scEnabledChrome) after SSR. Own that node in the SDK during editing so hydration
+    // mismatches can be suppressed without requiring suppressHydrationWarning on every
+    // app component. `display: contents` keeps SXA/Bootstrap column layout intact.
+    if (this.isPageEditing()) {
+      return (
+        <div suppressHydrationWarning style={{ display: 'contents' }}>
+          {content}
+        </div>
+      );
+    }
+
+    return content;
   }
 }
 

--- a/packages/sitecore-jss-react/src/components/Image.tsx
+++ b/packages/sitecore-jss-react/src/components/Image.tsx
@@ -63,8 +63,10 @@ export interface ImageProps extends EditableFieldProps {
 const getEditableWrapper = (editableMarkup: string, ...otherProps: unknown[]) => (
   // create an inline wrapper and use dangerouslySetInnerHTML.
   // if we try to parse the EE value, the parser will strip invalid or disallowed attributes from html elements - and EE uses several
+  // Experience Editor rewrites this chrome markup client-side after SSR.
   <span
     className="sc-image-wrapper"
+    suppressHydrationWarning
     {...otherProps}
     dangerouslySetInnerHTML={{ __html: editableMarkup }}
   />

--- a/packages/sitecore-jss-react/src/components/Link.tsx
+++ b/packages/sitecore-jss-react/src/components/Link.tsx
@@ -56,6 +56,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 
       const htmlProps = {
         className: 'sc-link-wrapper',
+        // Experience Editor rewrites this chrome markup client-side after SSR.
+        suppressHydrationWarning: true,
         dangerouslySetInnerHTML: {
           __html: markup,
         },

--- a/packages/sitecore-jss-react/src/components/Placeholder.tsx
+++ b/packages/sitecore-jss-react/src/components/Placeholder.tsx
@@ -56,7 +56,12 @@ class PlaceholderComponent extends PlaceholderCommon<PlaceholderComponentProps> 
    * @returns react node
    */
   renderEmptyPlaceholder(node: React.ReactNode | React.ReactElement[]) {
-    return <div className="sc-jss-empty-placeholder">{node}</div>;
+    // Experience Editor may mutate empty-placeholder chrome between SSR and hydration.
+    return (
+      <div className="sc-jss-empty-placeholder" suppressHydrationWarning>
+        {node}
+      </div>
+    );
   }
 
   render() {

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -339,6 +339,10 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
       props.ref = this.addRef; // only need ref for placeholder containers, trying to add it to other components (e.g. stateless components) may result in a warning.
     }
 
+    // Editing middleware renames phkey→key in the HTML EE loads; EE may also mutate chrome
+    // attributes before React hydrates. Suppress the expected mismatch on these SDK nodes.
+    props.suppressHydrationWarning = true;
+
     return React.createElement(elem.name, props);
   }
 

--- a/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
+++ b/packages/sitecore-jss-react/src/components/PlaceholderCommon.tsx
@@ -337,11 +337,9 @@ export class PlaceholderCommon<T extends PlaceholderProps> extends React.Compone
     if (!Array.isArray(attributes) && attributes && attributes.chrometype === 'placeholder') {
       props.phkey = elem.attributes.key; // props that get rendered as dom attribute names need to be lowercase, otherwise React complains.
       props.ref = this.addRef; // only need ref for placeholder containers, trying to add it to other components (e.g. stateless components) may result in a warning.
+      // EE may mutate chrome
+      props.suppressHydrationWarning = true;
     }
-
-    // Editing middleware renames phkey→key in the HTML EE loads; EE may also mutate chrome
-    // attributes before React hydrates. Suppress the expected mismatch on these SDK nodes.
-    props.suppressHydrationWarning = true;
 
     return React.createElement(elem.name, props);
   }

--- a/packages/sitecore-jss-react/src/components/RichText.tsx
+++ b/packages/sitecore-jss-react/src/components/RichText.tsx
@@ -40,6 +40,8 @@ export const RichText = forwardRef(
     const htmlProps = {
       dangerouslySetInnerHTML,
       ref,
+      // Experience Editor rewrites editable chrome markup client-side after SSR.
+      ...(field.editable && editable ? { suppressHydrationWarning: true } : {}),
       ...otherProps,
     };
 

--- a/packages/sitecore-jss-react/src/components/Text.tsx
+++ b/packages/sitecore-jss-react/src/components/Text.tsx
@@ -80,11 +80,6 @@ export const Text: React.FC<TextProps> = ({
     htmlProps.dangerouslySetInnerHTML = {
       __html: output,
     };
-
-    // Experience Editor rewrites editable chrome markup client-side after SSR.
-    if (isEditable) {
-      htmlProps.suppressHydrationWarning = true;
-    }
   } else {
     children = output;
   }

--- a/packages/sitecore-jss-react/src/components/Text.tsx
+++ b/packages/sitecore-jss-react/src/components/Text.tsx
@@ -80,6 +80,11 @@ export const Text: React.FC<TextProps> = ({
     htmlProps.dangerouslySetInnerHTML = {
       __html: output,
     };
+
+    // Experience Editor rewrites editable chrome markup client-side after SSR.
+    if (isEditable) {
+      htmlProps.suppressHydrationWarning = true;
+    }
   } else {
     children = output;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [ ] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes Experience Editor hydration mismatch warnings caused by Sitecore chrome mutating the DOM after SSR (e.g. `sc-part-of`, `scEnabledChrome`, editable field chrome).
- Adds `suppressHydrationWarning` only in SDK components so apps do not need it on every rendering.
## Changes
- `ErrorBoundary`: in edit mode, wrap renderings with a `display: contents` node that has `suppressHydrationWarning` (central fix for rendering-root EE tags).
- `Placeholder` / `PlaceholderCommon`: suppress on empty-placeholder wrapper and EE raw chrome elements (`phkey` / `<code>`).
- Field components (`RichText`, `Text`, `Image`, `Link`): suppress on editable chrome markup paths only.
- `HiddenRendering`: suppress on root (not wrapped by ErrorBoundary).
- Tests updated for the ErrorBoundary edit-mode wrapper.

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [ ] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
