### PR TITLE
[sitecore-jss][sitecore-jss-react] Enhance withDatasourceCheck() to support dataSourceResolveFailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss]` `[sitecore-jss-react]` Treat Layout Service `dataSourceResolveFailed` as an invalid datasource in `withDatasourceCheck()`
+* `[sitecore-jss]` `[sitecore-jss-react]` Treat Layout Service `dataSourceResolveFailed` as an invalid datasource in `withDatasourceCheck()` ([#2219](https://github.com/Sitecore/jss/pull/2219))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Our versioning strategy is as follows:
 
 ### 🎉 New Features & Improvements
 
-* `[sitecore-jss]` `[sitecore-jss-react]` Treat Layout Service `dataSourceResolveFailed` as an invalid datasource in `withDatasourceCheck()` ([#2219](https://github.com/Sitecore/jss/pull/2219))
+* `[sitecore-jss]` `[sitecore-jss-react]` Treat Layout Service `isContentResolved` as datasource validity in `withDatasourceCheck()` ([#2219](https://github.com/Sitecore/jss/pull/2219))
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Our versioning strategy is as follows:
 
 > ⚠️ **JSS 23 supports Sitecore XP 10.5 only. Sitecore AI is not supported - use Sitecore Content SDK for that scenario.**
 
+### 🎉 New Features & Improvements
+
+* `[sitecore-jss]` `[sitecore-jss-react]` Treat Layout Service `dataSourceResolveFailed` as an invalid datasource in `withDatasourceCheck()`
+
 ### 🐛 Bug Fixes
 
 * `[sitecore-jss-react]` Suppress hydration mismatch warnings in Experience Editor by adding `suppressHydrationWarning` to SDK chrome paths (ErrorBoundary, placeholders, field components)([#2218](https://github.com/Sitecore/jss/pull/2218))

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
@@ -146,4 +146,217 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
   });
+
+  it('should return null if no datasource is configured on the rendering', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.be.empty;
+  });
+
+  it('should return wrapped component when dataSourceResolveFailed is false', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
+        dataSourceResolveFailed: false,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
+  });
+
+  it('should return wrapped component when dataSourceResolveFailed is false in editing mode', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
+        dataSourceResolveFailed: false,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(true)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.componentName);
+    expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
+  });
+
+  it('should return null when dataSourceResolveFailed is true in normal mode', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
+        dataSourceResolveFailed: true,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.be.empty;
+  });
+
+  it('should return default error component when dataSourceResolveFailed is true in editing mode', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
+        dataSourceResolveFailed: true,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(true)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.querySelectorAll('div.sc-jss-editing-error')).to.have.length(1);
+  });
+
+  it('should not render when the datasource item was deleted and dataSourceResolveFailed is true', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{DELETED-DATASOURCE-ID}',
+        dataSourceResolveFailed: true,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.be.empty;
+  });
+
+  it('should not render when the datasource item was archived and dataSourceResolveFailed is true', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{ARCHIVED-DATASOURCE-ID}',
+        dataSourceResolveFailed: true,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.be.empty;
+  });
+
+  it('should preserve existing missing-datasource behavior when dataSourceResolveFailed is false', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const props = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '',
+        dataSourceResolveFailed: false,
+      },
+    };
+
+    const wrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...props} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(wrapper.container.innerHTML).to.be.empty;
+  });
+
+  it('should preserve existing behavior when dataSourceResolveFailed is absent', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const propsWithDatasource = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
+      },
+    };
+    const propsWithoutDatasource = {
+      rendering: {
+        componentName: 'TestComponent',
+        dataSource: '',
+      },
+    };
+
+    const rendered = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...propsWithDatasource} />
+      </SitecoreContextReactContext.Provider>
+    );
+    const hidden = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck {...propsWithoutDatasource} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(rendered.container.innerHTML).to.contain(propsWithDatasource.rendering.componentName);
+    expect(hidden.container.innerHTML).to.be.empty;
+  });
+
+  it('should evaluate nested placeholder renderings independently', () => {
+    const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
+    const nestedChild = {
+      componentName: 'ChildComponent',
+      dataSource: '{CHILD-DATASOURCE-ID}',
+      dataSourceResolveFailed: true,
+    };
+    const parentRendering = {
+      componentName: 'ParentComponent',
+      dataSource: '{PARENT-DATASOURCE-ID}',
+      dataSourceResolveFailed: false,
+      placeholders: {
+        nested: [nestedChild],
+      },
+    };
+
+    const parentWrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck rendering={parentRendering} />
+      </SitecoreContextReactContext.Provider>
+    );
+    const childWrapper = render(
+      <SitecoreContextReactContext.Provider value={mockContext(false)}>
+        <TestComponentWithDatasourceCheck rendering={nestedChild} />
+      </SitecoreContextReactContext.Provider>
+    );
+
+    expect(parentWrapper.container.innerHTML).to.contain(parentRendering.componentName);
+    expect(childWrapper.container.innerHTML).to.be.empty;
+  });
 });

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.test.tsx
@@ -164,13 +164,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
-  it('should return wrapped component when dataSourceResolveFailed is false', () => {
+  it('should return wrapped component when isContentResolved is true', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
-        dataSourceResolveFailed: false,
+        isContentResolved: true,
       },
     };
 
@@ -184,13 +184,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
   });
 
-  it('should return wrapped component when dataSourceResolveFailed is false in editing mode', () => {
+  it('should return wrapped component when isContentResolved is true in editing mode', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
-        dataSourceResolveFailed: false,
+        isContentResolved: true,
       },
     };
 
@@ -204,13 +204,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.contain(props.rendering.dataSource);
   });
 
-  it('should return null when dataSourceResolveFailed is true in normal mode', () => {
+  it('should return null when isContentResolved is false in normal mode', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
-        dataSourceResolveFailed: true,
+        isContentResolved: false,
       },
     };
 
@@ -223,13 +223,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
-  it('should return default error component when dataSourceResolveFailed is true in editing mode', () => {
+  it('should return default error component when isContentResolved is false in editing mode', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{CACDB205-2386-4271-9F05-AE20AAC2A39E}',
-        dataSourceResolveFailed: true,
+        isContentResolved: false,
       },
     };
 
@@ -242,13 +242,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.querySelectorAll('div.sc-jss-editing-error')).to.have.length(1);
   });
 
-  it('should not render when the datasource item was deleted and dataSourceResolveFailed is true', () => {
+  it('should not render when the datasource item was deleted and isContentResolved is false', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{DELETED-DATASOURCE-ID}',
-        dataSourceResolveFailed: true,
+        isContentResolved: false,
       },
     };
 
@@ -261,13 +261,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
-  it('should not render when the datasource item was archived and dataSourceResolveFailed is true', () => {
+  it('should not render when the datasource item was archived and isContentResolved is false', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '{ARCHIVED-DATASOURCE-ID}',
-        dataSourceResolveFailed: true,
+        isContentResolved: false,
       },
     };
 
@@ -280,13 +280,13 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
-  it('should preserve existing missing-datasource behavior when dataSourceResolveFailed is false', () => {
+  it('should preserve existing missing-datasource behavior when isContentResolved is true', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const props = {
       rendering: {
         componentName: 'TestComponent',
         dataSource: '',
-        dataSourceResolveFailed: false,
+        isContentResolved: true,
       },
     };
 
@@ -299,7 +299,7 @@ describe('withDatasourceCheck', () => {
     expect(wrapper.container.innerHTML).to.be.empty;
   });
 
-  it('should preserve existing behavior when dataSourceResolveFailed is absent', () => {
+  it('should preserve existing behavior when isContentResolved is absent', () => {
     const TestComponentWithDatasourceCheck = withDatasourceCheck()(TestComponent);
     const propsWithDatasource = {
       rendering: {
@@ -334,12 +334,12 @@ describe('withDatasourceCheck', () => {
     const nestedChild = {
       componentName: 'ChildComponent',
       dataSource: '{CHILD-DATASOURCE-ID}',
-      dataSourceResolveFailed: true,
+      isContentResolved: false,
     };
     const parentRendering = {
       componentName: 'ParentComponent',
       dataSource: '{PARENT-DATASOURCE-ID}',
-      dataSourceResolveFailed: false,
+      isContentResolved: true,
       placeholders: {
         nested: [nestedChild],
       },

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
@@ -14,18 +14,40 @@ export interface WithDatasourceCheckProps {
 
 export interface WithDatasourceCheckOptions {
   /**
-   * A component that is rendered when a datasource is missing during editing.
+   * A component that is rendered when a datasource is missing or failed to resolve during editing.
    * If unspecified, a default component with message is displayed.
    */
   editingErrorComponent?: React.ComponentClass<unknown> | React.FC<unknown>;
 }
 
 /**
- * Checks whether a Sitecore datasource is present and renders appropriately depending on page mode (normal vs editing).
+ * Returns true when the rendering has a datasource and Layout Service did not report a resolve failure.
+ * @param {ComponentRendering} [rendering] rendering data from Layout Service
+ * @returns {boolean} whether the datasource is present and valid
+ */
+function hasValidDatasource(rendering?: ComponentRendering): boolean {
+  if (!rendering?.dataSource) {
+    return false;
+  }
+
+  return rendering.dataSourceResolveFailed !== true;
+}
+
+/**
+ * Checks whether a Sitecore datasource is present and valid, then renders appropriately depending on page mode (normal vs editing).
+ * `dataSourceResolveFailed: true` is treated the same as a missing datasource. If the property is omitted, the original presence check is used.
  * @param {WithDatasourceCheckOptions} [options]
  * @returns
- *  The wrapped component, if a datasource is present.
- *  A null component (in normal mode) or an error component (in editing mode), if a datasource is not present.
+ *  The wrapped component, if a datasource is present and valid.
+ *  A null component (in normal mode) or an error component (in editing mode), if a datasource is missing or failed to resolve.
+ * @example
+ * // Wrap once. Deleted/archived datasources (dataSourceResolveFailed: true) use the same
+ * // fallback as a missing datasource: hide in normal mode, show an editing error in editing mode.
+ * const ContentBlock = (props) => <div>{props.fields.heading}</div>;
+ * export default withDatasourceCheck()(ContentBlock);
+ *
+ * // Layout Service: { componentName: 'ContentBlock', dataSource: '{id}', dataSourceResolveFailed: true }
+ * // → ContentBlock is not rendered; no extra app-level check is required.
  */
 export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
   return function withDatasourceCheckHoc<ComponentProps extends WithDatasourceCheckProps>(
@@ -35,7 +57,7 @@ export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {
       const { sitecoreContext } = useSitecoreContext();
       const EditingError = options?.editingErrorComponent ?? DefaultEditingError;
 
-      return props.rendering?.dataSource ? (
+      return hasValidDatasource(props.rendering) ? (
         <Component {...props} />
       ) : sitecoreContext.pageEditing ? (
         <EditingError />

--- a/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
+++ b/packages/sitecore-jss-react/src/enhancers/withDatasourceCheck.tsx
@@ -21,7 +21,7 @@ export interface WithDatasourceCheckOptions {
 }
 
 /**
- * Returns true when the rendering has a datasource and Layout Service did not report a resolve failure.
+ * Returns true when the rendering has a datasource and Layout Service did not report unresolved content.
  * @param {ComponentRendering} [rendering] rendering data from Layout Service
  * @returns {boolean} whether the datasource is present and valid
  */
@@ -30,23 +30,23 @@ function hasValidDatasource(rendering?: ComponentRendering): boolean {
     return false;
   }
 
-  return rendering.dataSourceResolveFailed !== true;
+  return rendering.isContentResolved !== false;
 }
 
 /**
  * Checks whether a Sitecore datasource is present and valid, then renders appropriately depending on page mode (normal vs editing).
- * `dataSourceResolveFailed: true` is treated the same as a missing datasource. If the property is omitted, the original presence check is used.
+ * `isContentResolved: false` is treated the same as a missing datasource. If the property is omitted, the original presence check is used.
  * @param {WithDatasourceCheckOptions} [options]
  * @returns
  *  The wrapped component, if a datasource is present and valid.
  *  A null component (in normal mode) or an error component (in editing mode), if a datasource is missing or failed to resolve.
  * @example
- * // Wrap once. Deleted/archived datasources (dataSourceResolveFailed: true) use the same
+ * // Wrap once. Deleted/archived datasources (isContentResolved: false) use the same
  * // fallback as a missing datasource: hide in normal mode, show an editing error in editing mode.
  * const ContentBlock = (props) => <div>{props.fields.heading}</div>;
  * export default withDatasourceCheck()(ContentBlock);
  *
- * // Layout Service: { componentName: 'ContentBlock', dataSource: '{id}', dataSourceResolveFailed: true }
+ * // Layout Service: { componentName: 'ContentBlock', dataSource: '{id}', isContentResolved: false }
  * // → ContentBlock is not rendered; no extra app-level check is required.
  */
 export function withDatasourceCheck(options?: WithDatasourceCheckOptions) {

--- a/packages/sitecore-jss/src/layout/models.ts
+++ b/packages/sitecore-jss/src/layout/models.ts
@@ -85,6 +85,12 @@ export interface ComponentParams {
 export interface ComponentRendering<T = ComponentFields> {
   componentName: string;
   dataSource?: string;
+  /**
+   * `true` when Layout Service failed to resolve this rendering's datasource item
+   * (for example because the item was deleted or archived).
+   * Omitted by older Layout Service versions; absence preserves existing behavior.
+   */
+  dataSourceResolveFailed?: boolean;
   uid?: string;
   placeholders?: PlaceholdersData;
   fields?: T;

--- a/packages/sitecore-jss/src/layout/models.ts
+++ b/packages/sitecore-jss/src/layout/models.ts
@@ -86,11 +86,11 @@ export interface ComponentRendering<T = ComponentFields> {
   componentName: string;
   dataSource?: string;
   /**
-   * `true` when Layout Service failed to resolve this rendering's datasource item
-   * (for example because the item was deleted or archived).
+   * `true` when Layout Service resolved this rendering's datasource content.
+   * `false` when resolution failed (for example because the item was deleted or archived).
    * Omitted by older Layout Service versions; absence preserves existing behavior.
    */
-  dataSourceResolveFailed?: boolean;
+  isContentResolved?: boolean;
   uid?: string;
   placeholders?: PlaceholdersData;
   fields?: T;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- [ ] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [x] Changelog updated
- [x] Upgrade guide entry added

## Description / Motivation
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Add optional `dataSourceResolveFailed` to `ComponentRendering`.
- Treat `dataSourceResolveFailed: true` the same as a missing datasource in `withDatasourceCheck()` (hide in normal mode, editing error in editing mode).
- Preserve existing behavior when the property is `false` or omitted so older Layout Service versions keep working.
- Document the automatic handling in the `withDatasourceCheck()` JSDoc example.


## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Unit Test Added
- [x] Manual Test/Other (Please elaborate)
- Confirm `dataSourceResolveFailed: false` still renders the wrapped component.
- Confirm `dataSourceResolveFailed: true` hides the component in normal mode and shows the editing error in editing mode.
- Confirm omitted property (older Layout Service) still uses the original presence check.
- Confirm nested placeholder renderings are evaluated independently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
