### PR TITLE
fix(sitecore-jss-vue): preserve query string in RichText internal links (#2191)

### DIFF
--- a/packages/sitecore-jss-vue/src/components/RichText.test.ts
+++ b/packages/sitecore-jss-vue/src/components/RichText.test.ts
@@ -141,7 +141,7 @@ describe('<RichText />', () => {
     const props = {
       field: {
         value:
-          '<div id="test"><h1>Hello!</h1><a href="/styleguide">1<span>nested</span></a><a href="/graphql#hash">2</a></div>',
+          '<div id="test"><h1>Hello!</h1><a href="/styleguide">1<span>nested</span></a><a href="/graphql#hash">2</a><a href="/styleguide?query=true">3</a><a href="/styleguide?query=true#hash">4</a></div>',
       },
     };
     const rendered = mount(RichText, {
@@ -155,6 +155,8 @@ describe('<RichText />', () => {
 
     expect(rendered.element.innerHTML).toContain('<a href="/styleguide">1<span>nested</span></a>');
     expect(rendered.element.innerHTML).toContain('<a href="/graphql#hash">2</a>');
+    expect(rendered.element.innerHTML).toContain('<a href="/styleguide?query=true">3</a>');
+    expect(rendered.element.innerHTML).toContain('<a href="/styleguide?query=true#hash">4</a>');
 
     // Make sure eventListener in not passed to wrong element
     await rendered.find('#test').trigger('click');
@@ -164,13 +166,19 @@ describe('<RichText />', () => {
     expect(mockRouter.push).toHaveBeenCalledTimes(1);
     expect(mockRouter.push).toHaveBeenCalledWith('/styleguide');
 
-    const [link1, link2] = rendered.findAll('a');
+    const [link1, link2, link3, link4] = rendered.findAll('a');
     link1 && (await link1.trigger('click'));
     expect(mockRouter.push).toHaveBeenCalledTimes(2);
     expect(mockRouter.push).toHaveBeenCalledWith('/styleguide');
     link2 && (await link2.trigger('click'));
     expect(mockRouter.push).toHaveBeenCalledTimes(3);
     expect(mockRouter.push).toHaveBeenCalledWith('/graphql#hash');
+    link3 && (await link3.trigger('click'));
+    expect(mockRouter.push).toHaveBeenCalledTimes(4);
+    expect(mockRouter.push).toHaveBeenCalledWith('/styleguide?query=true');
+    link4 && (await link4.trigger('click'));
+    expect(mockRouter.push).toHaveBeenCalledTimes(5);
+    expect(mockRouter.push).toHaveBeenCalledWith('/styleguide?query=true#hash');
   });
 
   it('should not initialize links when editable', async () => {

--- a/packages/sitecore-jss-vue/src/components/RichText.ts
+++ b/packages/sitecore-jss-vue/src/components/RichText.ts
@@ -53,7 +53,9 @@ export const RichText = defineComponent({
         target = target.closest('a') as HTMLAnchorElement;
       }
 
-      const destination = target.hash ? `${target.pathname}${target.hash}` : target.pathname;
+      const search = target.search || '';
+      const hash = target.hash || '';
+      const destination = `${target.pathname}${search}${hash}`;
 
       this.$router.push(destination);
     },


### PR DESCRIPTION
### Description
Fixes #2191
The `RichText` component's `routeHandler` method in `@sitecore-jss/sitecore-jss-vue` previously constructed the navigation destination using only `target.pathname` and `target.hash`, omitting `target.search`. Consequently, internal links with query parameters (e.g., `/my-page?type=foo&section=bar`) lost their query string during client-side SPA routing.
This PR updates `routeHandler` to include `target.search` alongside `target.pathname` and `target.hash`.

### Changes
- Updated `packages/sitecore-jss-vue/src/components/RichText.ts` to include `target.search` when building the destination URL.
- Added unit tests in `packages/sitecore-jss-vue/src/components/RichText.test.ts` to test links with query strings (both with and without hash fragments).

### Verification
- `yarn test` in `@sitecore-jss/sitecore-jss-vue` passes (10/10 suites, 97/97 tests).
- `yarn lint` passes.
- `yarn build` compiles CJS and ESM distributions cleanly.
- `yarn lint-packages` passes across all monorepo packages.